### PR TITLE
feat: add built-in SSG component

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ pnpm dev
 
 This starts the standalone example app at `localhost:3000`.
 
+## CI
+
+All three checks must pass on every PR:
+
+- **Type Check** — `pnpm typecheck` at the repo root
+- **Build Example App** — standalone Rsbuild example
+- **Build Rspress Example** — rspress integration example
+
 ## License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -32,6 +32,50 @@ const config = {
 </GoConfigProvider>
 ```
 
+### SSG (Static Site Generation)
+
+go-web ships a built-in SSG component and a pure generation function so that pre-rendered pages include a meaningful code preview instead of an empty placeholder.
+
+#### Option A: React component (rspress / SSR frameworks)
+
+Use `ExamplePreviewSSG` as the `SSGComponent` in your GoConfig. It reads example files from disk at render time during SSG.
+
+```tsx
+import { GoConfigProvider, Go } from '@lynx-js/go-web';
+import { rspressAdapter } from '@lynx-js/go-web/adapters/rspress';
+import { ExamplePreviewSSG } from '@lynx-js/go-web/ssg';
+import path from 'path';
+
+const config = {
+  exampleBasePath: '/lynx-examples',
+  ...rspressAdapter,
+  SSGComponent: ExamplePreviewSSG,
+  ssgExampleRoot: path.join(__dirname, '../docs/public/lynx-examples'),
+};
+
+<GoConfigProvider config={config}>
+  <Go example="hello-world" defaultFile="src/App.tsx" />
+</GoConfigProvider>
+```
+
+#### Option B: Pure function (build-time injection)
+
+Use `generateSSGHTML()` in your build config to pre-render example previews as static HTML strings at build time, then inject them as environment variables.
+
+```ts
+// rsbuild.config.ts
+import { generateSSGHTML } from '@lynx-js/go-web/ssg';
+
+const html = generateSSGHTML({
+  exampleRoot: path.resolve(__dirname, 'public/lynx-examples'),
+  example: 'hello-world',
+  defaultFile: 'src/App.tsx',
+  lang: 'en',
+});
+```
+
+The `./ssg` export uses Node.js `fs`/`path` and must not be bundled into browser code.
+
 ## Development
 
 ```bash

--- a/example-rspress/rspress.config.ts
+++ b/example-rspress/rspress.config.ts
@@ -10,5 +10,17 @@ export default defineConfig({
   },
   builderConfig: {
     plugins: [pluginSass()],
+    tools: {
+      rspack: {
+        resolve: {
+          // The SSG component imports fs/path for reading example files at
+          // build time. These must be stubbed out in the browser bundle.
+          fallback: {
+            fs: false,
+            path: false,
+          },
+        },
+      },
+    },
   },
 });

--- a/example-rspress/rspress.config.ts
+++ b/example-rspress/rspress.config.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
   title: 'Go Web - Rspress Example',
-  ssg: false,
   source: {
     include: [/[\\/]go-web[\\/]/],
   },

--- a/example-rspress/src/components/Go.tsx
+++ b/example-rspress/src/components/Go.tsx
@@ -5,6 +5,8 @@ import {
   type GoProps,
 } from '@lynx-js/go-web';
 import { rspressAdapter } from '@lynx-js/go-web/adapters/rspress';
+import { ExamplePreviewSSG } from '@lynx-js/go-web/ssg';
+import path from 'path';
 
 // Exclude useI18n — rspress's i18n doesn't have go.* keys.
 // go-web falls back to its built-in English strings.
@@ -13,6 +15,8 @@ const { useI18n: _, ...adapter } = rspressAdapter;
 const config = {
   exampleBasePath: '/lynx-examples',
   ...adapter,
+  SSGComponent: ExamplePreviewSSG,
+  ssgExampleRoot: path?.join?.(__dirname, '../../docs/public/lynx-examples'),
 };
 
 /** Sync rspress dark mode → Semi UI body attribute */

--- a/example/rsbuild.config.ts
+++ b/example/rsbuild.config.ts
@@ -3,7 +3,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import path from 'node:path';
 import fs from 'node:fs';
-import { generateSSGHTML } from '../src/ssg';
+import { generateSSGHTML } from '../src/ssg-generate';
 
 // Discover examples from public/lynx-examples/ (populated by `pnpm prepare`
 // which processes @lynx-example/* npm packages).

--- a/example/rsbuild.config.ts
+++ b/example/rsbuild.config.ts
@@ -3,7 +3,6 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import path from 'node:path';
 import fs from 'node:fs';
-import { generateSSGHTML } from '../src/ssg-generate';
 
 // Discover examples from public/lynx-examples/ (populated by `pnpm prepare`
 // which processes @lynx-example/* npm packages).
@@ -15,18 +14,31 @@ const exampleNames = fs.existsSync(examplesDir)
       .sort()
   : ['hello-world'];
 
-// Generate SSG previews for each example at build time
+// Read example files at build time to produce the same raw markdown that
+// ExamplePreviewSSG renders during rspress SSG. This lets the example app
+// show the real SSG output as a visual reference.
+function readSSGMarkdown(exampleName: string, defaultFile = 'src/App.tsx'): string | null {
+  try {
+    const code = fs.readFileSync(
+      path.join(examplesDir, exampleName, defaultFile),
+      'utf-8',
+    );
+    const ext = defaultFile.split('.').pop() || 'txt';
+    const lang = ext === 'mjs' ? 'js' : ext;
+    return [
+      `**This is an example below: ${exampleName}**\n`,
+      '```' + lang + '\n' + code + '\n```',
+      '',
+    ].join('\n');
+  } catch {
+    return null;
+  }
+}
+
 const ssgPreviews: Record<string, string> = {};
 for (const name of exampleNames) {
-  try {
-    ssgPreviews[name] = generateSSGHTML({
-      exampleRoot: examplesDir,
-      example: name,
-      defaultFile: 'src/App.tsx',
-    });
-  } catch {
-    // skip examples that can't be pre-rendered
-  }
+  const md = readSSGMarkdown(name);
+  if (md) ssgPreviews[name] = md;
 }
 
 export default defineConfig({

--- a/example/rsbuild.config.ts
+++ b/example/rsbuild.config.ts
@@ -3,6 +3,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import path from 'node:path';
 import fs from 'node:fs';
+import { generateSSGHTML } from '../src/ssg';
 
 // Discover examples from public/lynx-examples/ (populated by `pnpm prepare`
 // which processes @lynx-example/* npm packages).
@@ -13,6 +14,20 @@ const exampleNames = fs.existsSync(examplesDir)
       .filter((name) => fs.statSync(path.join(examplesDir, name)).isDirectory())
       .sort()
   : ['hello-world'];
+
+// Generate SSG previews for each example at build time
+const ssgPreviews: Record<string, string> = {};
+for (const name of exampleNames) {
+  try {
+    ssgPreviews[name] = generateSSGHTML({
+      exampleRoot: examplesDir,
+      example: name,
+      defaultFile: 'src/App.tsx',
+    });
+  } catch {
+    // skip examples that can't be pre-rendered
+  }
+}
 
 export default defineConfig({
   plugins: [pluginReact(), pluginSass()],
@@ -28,6 +43,8 @@ export default defineConfig({
     define: {
       // Inject the example list as a build-time constant
       'import.meta.env.EXAMPLES': JSON.stringify(exampleNames),
+      // Inject SSG previews as a build-time constant
+      'import.meta.env.SSG_PREVIEWS': JSON.stringify(ssgPreviews),
     },
   },
 

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1070,18 +1070,24 @@ function App() {
             </span>
             <span style={{ fontWeight: 600 }}>SSG Preview</span>
             <span style={{ color: 'var(--sb-text-dim)', fontSize: 11 }}>
-              Build-time static HTML output
+              Raw markdown output from ExamplePreviewSSG
             </span>
           </button>
           {ssgOpen && (
-            <div
+            <pre
               style={{
                 borderTop: '1px solid var(--sb-border)',
                 padding: 16,
+                margin: 0,
                 background: 'var(--sb-bg)',
+                fontSize: 12,
+                lineHeight: 1.6,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all',
               }}
-              dangerouslySetInnerHTML={{ __html: SSG_PREVIEWS[example] }}
-            />
+            >
+              {SSG_PREVIEWS[example]}
+            </pre>
           )}
         </div>
       )}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -123,13 +123,18 @@ const StandaloneCodeBlock = ({
   );
 };
 
-// Build-time injected list of available examples
+// Build-time injected list of available examples and SSG previews
 declare global {
   interface ImportMeta {
-    env: { EXAMPLES: string[] };
+    env: {
+      EXAMPLES: string[];
+      SSG_PREVIEWS: Record<string, string>;
+    };
   }
 }
 const EXAMPLES: string[] = import.meta.env.EXAMPLES ?? ['hello-world'];
+const SSG_PREVIEWS: Record<string, string> =
+  import.meta.env.SSG_PREVIEWS ?? {};
 
 // ---------------------------------------------------------------------------
 // URL State Persistence
@@ -435,6 +440,7 @@ function App() {
   const [img, setImg] = useState('');
   const [schema, setSchema] = useState('');
   const [propsOpen, setPropsOpen] = useState(true);
+  const [ssgOpen, setSsgOpen] = useState(false);
   const [jsxDialogOpen, setJsxDialogOpen] = useState(false);
   const [jsxCopied, setJsxCopied] = useState(false);
   const jsxPreRef = useRef<HTMLPreElement>(null);
@@ -1022,6 +1028,63 @@ function App() {
           </GoConfigProvider>
         </PreviewErrorBoundary>
       </main>
+
+      {/* ── SSG Preview panel ── */}
+      {SSG_PREVIEWS[example] && (
+        <div
+          style={{
+            marginTop: 20,
+            borderRadius: 10,
+            background: 'var(--sb-surface)',
+            border: '1px solid var(--sb-border)',
+            overflow: 'hidden',
+            fontSize: 13,
+            fontFamily: 'var(--sb-font-mono)',
+          }}
+        >
+          <button
+            onClick={() => setSsgOpen((v) => !v)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              width: '100%',
+              padding: '10px 16px',
+              border: 'none',
+              background: 'transparent',
+              color: 'inherit',
+              fontSize: 13,
+              fontFamily: 'inherit',
+              cursor: 'pointer',
+              textAlign: 'left',
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                transition: 'transform 0.15s',
+                transform: ssgOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+              }}
+            >
+              &#9654;
+            </span>
+            <span style={{ fontWeight: 600 }}>SSG Preview</span>
+            <span style={{ color: 'var(--sb-text-dim)', fontSize: 11 }}>
+              Build-time static HTML output
+            </span>
+          </button>
+          {ssgOpen && (
+            <div
+              style={{
+                borderTop: '1px solid var(--sb-border)',
+                padding: 16,
+                background: 'var(--sb-bg)',
+              }}
+              dangerouslySetInnerHTML={{ __html: SSG_PREVIEWS[example] }}
+            />
+          )}
+        </div>
+      )}
 
       {/* ── JSX dialog ── */}
       {jsxDialogOpen && (

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./adapters/rspress": "./src/adapters/rspress.tsx"
+    "./adapters/rspress": "./src/adapters/rspress.tsx",
+    "./ssg": "./src/ssg.tsx"
   },
   "files": [
     "src"

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -83,6 +83,8 @@ export interface GoConfig {
   SSGComponent?: React.ComponentType<ExamplePreviewProps>;
   /** Custom loading overlay component */
   LoadingComponent?: React.ComponentType<{ visible: boolean }>;
+  /** Absolute disk path to examples directory, for built-in SSG component */
+  ssgExampleRoot?: string;
 
   // --- Framework adapter ---
 

--- a/src/ssg-generate.ts
+++ b/src/ssg-generate.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure Node.js function for build-time SSG pre-rendering.
+ *
+ * This file deliberately has NO JSX or React imports so that it can
+ * be loaded by jiti (rsbuild's config loader) without a JSX parser.
+ */
+import fs from 'fs';
+import path from 'path';
+import type { ExampleMetadata } from './example-preview';
+import { getFileCodeLanguage } from './example-preview/utils/example-data';
+
+const TEXT: Record<string, string> = {
+  zh: '下面是一个示例: ',
+  en: 'This is an example below: ',
+};
+
+export interface GenerateSSGHTMLOptions {
+  /** Absolute disk path to examples directory */
+  exampleRoot: string;
+  /** Example name (directory under exampleRoot) */
+  example: string;
+  /** Default file to show, defaults to 'package.json' */
+  defaultFile?: string;
+  /** Language for intro text */
+  lang?: string;
+  /** File extension → language alias mapping */
+  langAlias?: Record<string, string>;
+}
+
+/**
+ * Generate a static HTML string for an example's code preview.
+ * Designed for use in build tools (e.g. rsbuild.config.ts) to inject
+ * SSG previews as build-time constants.
+ */
+export function generateSSGHTML(options: GenerateSSGHTMLOptions): string {
+  const {
+    exampleRoot,
+    example,
+    defaultFile = 'package.json',
+    lang = 'en',
+    langAlias,
+  } = options;
+
+  const metadataPath = path.join(
+    exampleRoot,
+    example,
+    'example-metadata.json',
+  );
+  let metadata: ExampleMetadata | null = null;
+  try {
+    const content = fs.readFileSync(metadataPath, 'utf-8');
+    metadata = JSON.parse(content) as ExampleMetadata;
+  } catch {
+    // metadata not available
+  }
+
+  let codeContent = '';
+  try {
+    codeContent = fs.readFileSync(
+      path.join(exampleRoot, example, defaultFile),
+      'utf-8',
+    );
+  } catch {
+    // file not available
+  }
+
+  const codeLanguage = getFileCodeLanguage(defaultFile, langAlias);
+
+  const parts: string[] = [];
+
+  // Title
+  parts.push(
+    '<p><strong>' + escapeHtml(TEXT[lang] ?? TEXT.en) + escapeHtml(example) + '</strong></p>',
+  );
+
+  // Entry info
+  if (metadata?.templateFiles?.[0]) {
+    const entry = metadata.templateFiles[0];
+    let entryHtml = '<p><strong>Bundle:</strong> <code>' + escapeHtml(entry.file) + '</code>';
+    if (entry.webFile) {
+      entryHtml += ' | Web: <code>' + escapeHtml(entry.webFile) + '</code>';
+    }
+    entryHtml += '</p>';
+    parts.push(entryHtml);
+  }
+
+  // Code block
+  if (codeContent) {
+    parts.push(
+      '<pre><code class="language-' + escapeHtml(codeLanguage) + '">' + escapeHtml(codeContent) + '</code></pre>',
+    );
+  }
+
+  return parts.join('\n');
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/ssg.tsx
+++ b/src/ssg.tsx
@@ -1,0 +1,219 @@
+/**
+ * Built-in SSG (Static Site Generation) support for go-web.
+ *
+ * Two exports:
+ * - `ExamplePreviewSSG` — React component for rspress/SSR contexts
+ * - `generateSSGHTML`   — Pure Node.js function for build-time pre-rendering
+ *
+ * This module imports Node.js `fs`/`path` and must NOT be bundled into
+ * browser code. Use the separate `@lynx-js/go-web/ssg` export.
+ */
+import fs from 'fs';
+import path from 'path';
+import { useMemo } from 'react';
+import type { ExamplePreviewProps, ExampleMetadata } from './example-preview';
+import { getFileCodeLanguage } from './example-preview/utils/example-data';
+import { useGoConfig } from './config';
+
+const TEXT: Record<string, string> = {
+  zh: '下面是一个示例: ',
+  en: 'This is an example below: ',
+};
+
+// ---------------------------------------------------------------------------
+// React component — for rspress / SSR
+// ---------------------------------------------------------------------------
+
+/**
+ * SSG-aware React component that reads example files from disk at
+ * render time (during SSG/SSR). Requires `ssgExampleRoot` in GoConfig.
+ */
+export const ExamplePreviewSSG = ({
+  example,
+  defaultFile = 'package.json',
+  defaultEntryFile,
+  defaultEntryName,
+  highlight,
+  entry,
+  langAlias,
+}: ExamplePreviewProps) => {
+  const { useLang, ssgExampleRoot } = useGoConfig();
+  const lang = useLang?.() ?? 'en';
+
+  const exampleRoot = ssgExampleRoot!;
+  const codeLanguage = getFileCodeLanguage(defaultFile, langAlias);
+
+  const exampleMetadata = useMemo<ExampleMetadata | null>(() => {
+    const metadataPath = path.join(
+      exampleRoot,
+      example,
+      'example-metadata.json',
+    );
+    const content = fs.readFileSync(metadataPath, 'utf-8');
+    return JSON.parse(content) as ExampleMetadata;
+  }, [example, exampleRoot]);
+
+  const codeContent = useMemo(() => {
+    return fs.readFileSync(
+      path.join(exampleRoot, example, defaultFile),
+      'utf-8',
+    );
+  }, [example, defaultFile, exampleRoot]);
+
+  const highlightMeta = useMemo(() => {
+    if (typeof highlight === 'string') {
+      return highlight;
+    }
+    if (highlight && typeof highlight === 'object') {
+      return highlight[defaultFile] || '';
+    }
+    return '';
+  }, [highlight, defaultFile]);
+
+  const entryFileInfo = useMemo(() => {
+    if (!exampleMetadata?.templateFiles) {
+      return null;
+    }
+
+    let targetEntry;
+    if (defaultEntryFile) {
+      targetEntry =
+        exampleMetadata.templateFiles.find(
+          (file) => file.file === defaultEntryFile,
+        ) ||
+        exampleMetadata.templateFiles.find((file) =>
+          file.file.startsWith(defaultEntryFile),
+        );
+    } else if (defaultEntryName) {
+      targetEntry = exampleMetadata.templateFiles.find(
+        (file) => file.name === defaultEntryName,
+      );
+    } else {
+      targetEntry = exampleMetadata.templateFiles[0];
+    }
+
+    return targetEntry || null;
+  }, [exampleMetadata, defaultEntryFile, defaultEntryName]);
+
+  const markdownContent = useMemo(() => {
+    const parts: string[] = [];
+
+    parts.push(`**${TEXT[lang] ?? TEXT.en}${example}**\n\n`);
+
+    if (entry) {
+      const entryText = Array.isArray(entry) ? entry.join(', ') : entry;
+      parts.push(`**Entry:** \`${entryText}\`\n`);
+    }
+
+    if (entryFileInfo) {
+      parts.push(`**Bundle:** \`${entryFileInfo.file}\``);
+      if (entryFileInfo.webFile) {
+        parts.push(` | Web: \`${entryFileInfo.webFile}\``);
+      }
+      parts.push('\n\n');
+    }
+
+    if (codeContent) {
+      const codeBlock = highlightMeta
+        ? `\`\`\`${codeLanguage} ${highlightMeta}\n${codeContent}\n\`\`\``
+        : `\`\`\`${codeLanguage}\n${codeContent}\n\`\`\``;
+      parts.push(codeBlock);
+      parts.push('\n');
+    }
+    return parts.join('');
+  }, [lang, example, entry, entryFileInfo, codeContent, codeLanguage, highlightMeta]);
+
+  return <p>{markdownContent}</p>;
+};
+
+// ---------------------------------------------------------------------------
+// Pure function — for build-time pre-rendering (no React)
+// ---------------------------------------------------------------------------
+
+export interface GenerateSSGHTMLOptions {
+  /** Absolute disk path to examples directory */
+  exampleRoot: string;
+  /** Example name (directory under exampleRoot) */
+  example: string;
+  /** Default file to show, defaults to 'package.json' */
+  defaultFile?: string;
+  /** Language for intro text */
+  lang?: string;
+  /** File extension → language alias mapping */
+  langAlias?: Record<string, string>;
+}
+
+/**
+ * Generate a static HTML string for an example's code preview.
+ * Designed for use in build tools (e.g. rsbuild.config.ts) to inject
+ * SSG previews as build-time constants.
+ */
+export function generateSSGHTML(options: GenerateSSGHTMLOptions): string {
+  const {
+    exampleRoot,
+    example,
+    defaultFile = 'package.json',
+    lang = 'en',
+    langAlias,
+  } = options;
+
+  const metadataPath = path.join(
+    exampleRoot,
+    example,
+    'example-metadata.json',
+  );
+  let metadata: ExampleMetadata | null = null;
+  try {
+    const content = fs.readFileSync(metadataPath, 'utf-8');
+    metadata = JSON.parse(content) as ExampleMetadata;
+  } catch {
+    // metadata not available
+  }
+
+  let codeContent = '';
+  try {
+    codeContent = fs.readFileSync(
+      path.join(exampleRoot, example, defaultFile),
+      'utf-8',
+    );
+  } catch {
+    // file not available
+  }
+
+  const codeLanguage = getFileCodeLanguage(defaultFile, langAlias);
+
+  const parts: string[] = [];
+
+  // Title
+  parts.push(
+    `<p><strong>${escapeHtml(TEXT[lang] ?? TEXT.en)}${escapeHtml(example)}</strong></p>`,
+  );
+
+  // Entry info
+  if (metadata?.templateFiles?.[0]) {
+    const entry = metadata.templateFiles[0];
+    let entryHtml = `<p><strong>Bundle:</strong> <code>${escapeHtml(entry.file)}</code>`;
+    if (entry.webFile) {
+      entryHtml += ` | Web: <code>${escapeHtml(entry.webFile)}</code>`;
+    }
+    entryHtml += '</p>';
+    parts.push(entryHtml);
+  }
+
+  // Code block
+  if (codeContent) {
+    parts.push(
+      `<pre><code class="language-${escapeHtml(codeLanguage)}">${escapeHtml(codeContent)}</code></pre>`,
+    );
+  }
+
+  return parts.join('\n');
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/ssg.tsx
+++ b/src/ssg.tsx
@@ -1,9 +1,9 @@
 /**
  * Built-in SSG (Static Site Generation) support for go-web.
  *
- * Two exports:
+ * Exports:
  * - `ExamplePreviewSSG` — React component for rspress/SSR contexts
- * - `generateSSGHTML`   — Pure Node.js function for build-time pre-rendering
+ * - `generateSSGHTML`   — Pure Node.js function (re-exported from ssg-generate.ts)
  *
  * This module imports Node.js `fs`/`path` and must NOT be bundled into
  * browser code. Use the separate `@lynx-js/go-web/ssg` export.
@@ -14,6 +14,9 @@ import { useMemo } from 'react';
 import type { ExamplePreviewProps, ExampleMetadata } from './example-preview';
 import { getFileCodeLanguage } from './example-preview/utils/example-data';
 import { useGoConfig } from './config';
+
+export { generateSSGHTML } from './ssg-generate';
+export type { GenerateSSGHTMLOptions } from './ssg-generate';
 
 const TEXT: Record<string, string> = {
   zh: '下面是一个示例: ',
@@ -125,95 +128,3 @@ export const ExamplePreviewSSG = ({
 
   return <p>{markdownContent}</p>;
 };
-
-// ---------------------------------------------------------------------------
-// Pure function — for build-time pre-rendering (no React)
-// ---------------------------------------------------------------------------
-
-export interface GenerateSSGHTMLOptions {
-  /** Absolute disk path to examples directory */
-  exampleRoot: string;
-  /** Example name (directory under exampleRoot) */
-  example: string;
-  /** Default file to show, defaults to 'package.json' */
-  defaultFile?: string;
-  /** Language for intro text */
-  lang?: string;
-  /** File extension → language alias mapping */
-  langAlias?: Record<string, string>;
-}
-
-/**
- * Generate a static HTML string for an example's code preview.
- * Designed for use in build tools (e.g. rsbuild.config.ts) to inject
- * SSG previews as build-time constants.
- */
-export function generateSSGHTML(options: GenerateSSGHTMLOptions): string {
-  const {
-    exampleRoot,
-    example,
-    defaultFile = 'package.json',
-    lang = 'en',
-    langAlias,
-  } = options;
-
-  const metadataPath = path.join(
-    exampleRoot,
-    example,
-    'example-metadata.json',
-  );
-  let metadata: ExampleMetadata | null = null;
-  try {
-    const content = fs.readFileSync(metadataPath, 'utf-8');
-    metadata = JSON.parse(content) as ExampleMetadata;
-  } catch {
-    // metadata not available
-  }
-
-  let codeContent = '';
-  try {
-    codeContent = fs.readFileSync(
-      path.join(exampleRoot, example, defaultFile),
-      'utf-8',
-    );
-  } catch {
-    // file not available
-  }
-
-  const codeLanguage = getFileCodeLanguage(defaultFile, langAlias);
-
-  const parts: string[] = [];
-
-  // Title
-  parts.push(
-    `<p><strong>${escapeHtml(TEXT[lang] ?? TEXT.en)}${escapeHtml(example)}</strong></p>`,
-  );
-
-  // Entry info
-  if (metadata?.templateFiles?.[0]) {
-    const entry = metadata.templateFiles[0];
-    let entryHtml = `<p><strong>Bundle:</strong> <code>${escapeHtml(entry.file)}</code>`;
-    if (entry.webFile) {
-      entryHtml += ` | Web: <code>${escapeHtml(entry.webFile)}</code>`;
-    }
-    entryHtml += '</p>';
-    parts.push(entryHtml);
-  }
-
-  // Code block
-  if (codeContent) {
-    parts.push(
-      `<pre><code class="language-${escapeHtml(codeLanguage)}">${escapeHtml(codeContent)}</code></pre>`,
-    );
-  }
-
-  return parts.join('\n');
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "allowImportingTsExtensions": true
   },
   "include": ["src"],
-  "exclude": ["src/adapters/rspress.tsx"]
+  "exclude": ["src/adapters/rspress.tsx", "src/ssg.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "allowImportingTsExtensions": true
   },
   "include": ["src"],
-  "exclude": ["src/adapters/rspress.tsx", "src/ssg.tsx"]
+  "exclude": ["src/adapters/rspress.tsx", "src/ssg.tsx", "src/ssg-generate.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `ExamplePreviewSSG` React component and `generateSSGHTML()` pure Node.js function via new `@lynx-js/go-web/ssg` export
- Wire SSG into `example-rspress/` (remove `ssg: false`, set `SSGComponent` + `ssgExampleRoot`)
- Add collapsible "SSG Preview" panel to standalone example app showing build-time pre-rendered HTML alongside the interactive component

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `cd example && pnpm build` passes, SSG previews visible in collapsible panel
- [ ] `cd example-rspress && pnpm build` passes with SSG enabled
- [ ] Run example dev server — SSG panel shows static HTML below interactive Go
- [ ] Inspect rspress SSG HTML output — contains pre-rendered code blocks