### PR TITLE
feat: make middle bar draggable vertically on mobile

### DIFF
--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -169,7 +169,7 @@
     }
     .code-wrap {
       flex: 1;
-      min-height: 0;
+      min-height: 120px;
     }
     .preview-wrap .qrcode {
       margin-top: 0;
@@ -211,7 +211,7 @@
     }
     .code-wrap {
       flex: 1;
-      min-height: 0;
+      min-height: 120px;
     }
     .preview-wrap .qrcode {
       margin-top: 0;

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -169,7 +169,7 @@
     }
     .code-wrap {
       flex: 1;
-      min-height: 120px;
+      min-height: 80px;
     }
     .preview-wrap .qrcode {
       margin-top: 0;
@@ -211,7 +211,7 @@
     }
     .code-wrap {
       flex: 1;
-      min-height: 120px;
+      min-height: 80px;
     }
     .preview-wrap .qrcode {
       margin-top: 0;

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -153,11 +153,7 @@
       flex-direction: column;
     }
     :global {
-      .semi-resizable-resizableHandler {
-        display: none;
-      }
       .semi-resizable-resizable {
-        height: 370px !important;
         width: 100% !important;
       }
       pre.shiki {
@@ -199,11 +195,7 @@
       flex-direction: column;
     }
     :global {
-      .semi-resizable-resizableHandler {
-        display: none;
-      }
       .semi-resizable-resizable {
-        height: 370px !important;
         width: 100% !important;
       }
       pre.shiki {

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -157,18 +157,18 @@
         width: 100% !important;
       }
       pre.shiki {
-        min-height: 371px !important;
+        min-height: 0 !important;
       }
     }
     .code-view-container-tab-show {
       :global {
         pre.shiki {
-          min-height: 324px !important;
+          min-height: 0 !important;
         }
       }
     }
     .code-wrap {
-      height: 100%;
+      flex: 1;
       min-height: 0;
     }
     .preview-wrap .qrcode {
@@ -199,18 +199,18 @@
         width: 100% !important;
       }
       pre.shiki {
-        min-height: 371px !important;
+        min-height: 0 !important;
       }
     }
     .code-view-container-tab-show {
       :global {
         pre.shiki {
-          min-height: 324px !important;
+          min-height: 0 !important;
         }
       }
     }
     .code-wrap {
-      height: 100%;
+      flex: 1;
       min-height: 0;
     }
     .preview-wrap .qrcode {

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -117,6 +117,20 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   const [showPreview, setShowPreview] = useState(true);
   const [showFileTree, setShowFileTree] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const [isVertical, setIsVertical] = useState(false);
+
+  useEffect(() => {
+    const el = boxRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setIsVertical(entry.contentRect.width <= 600);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
   const [previewType, setPreviewType] = useState(() => {
     if (defaultTab === 'preview' && previewImage) return PreviewType.Preview;
     if (defaultTab === 'qrcode') return PreviewType.QRCode;
@@ -163,7 +177,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
 
   const showCodeTab = entryData && entryData?.length > 1;
   return (
-    <div className={s.box}>
+    <div className={s.box} ref={boxRef}>
       <div className={s.container} ref={containerRef}>
         <div className={s.content}>
           <div className={s['code-wrap']}>
@@ -218,7 +232,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
             </div>
           </div>
 
-          <ResizableContainer show={hasPreview && showPreview}>
+          <ResizableContainer show={hasPreview && showPreview} vertical={isVertical}>
             <div className={s['preview-wrap']}>
               <div className={s['preview-wrap-content']}>
                 <RadioGroup

--- a/src/example-preview/components/resizable.tsx
+++ b/src/example-preview/components/resizable.tsx
@@ -5,10 +5,65 @@ import { Resizable } from '@douyinfe/semi-ui';
 export const ResizableContainer = ({
   show,
   children,
+  vertical = false,
 }: {
   show: boolean;
   children: React.ReactNode;
+  vertical?: boolean;
 }) => {
+  if (vertical) {
+    return (
+      <Resizable
+        style={{
+          display: show ? 'block' : 'none',
+        }}
+        enable={{
+          top: true,
+          right: false,
+          bottom: false,
+          left: false,
+          topLeft: false,
+          topRight: false,
+          bottomLeft: false,
+          bottomRight: false,
+        }}
+        defaultSize={{
+          height: 370,
+          width: '100%',
+        }}
+        minHeight={150}
+        maxHeight={500}
+        handleStyle={{
+          top: {
+            top: '-8px',
+            height: '8px',
+          },
+        }}
+        handleNode={{
+          top: (
+            <div
+              style={{
+                width: '100%',
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              <IconHandle
+                style={{
+                  fontSize: '12px',
+                  marginTop: '-2px',
+                  transform: 'rotate(90deg)',
+                }}
+              />
+            </div>
+          ),
+        }}
+      >
+        {children}
+      </Resizable>
+    );
+  }
+
   return (
     <Resizable
       style={{

--- a/src/example-preview/components/resizable.tsx
+++ b/src/example-preview/components/resizable.tsx
@@ -14,6 +14,7 @@ export const ResizableContainer = ({
   if (vertical) {
     return (
       <Resizable
+        key="vertical"
         style={{
           display: show ? 'block' : 'none',
         }}
@@ -66,6 +67,7 @@ export const ResizableContainer = ({
 
   return (
     <Resizable
+      key="horizontal"
       style={{
         display: show ? 'block' : 'none',
       }}

--- a/src/example-preview/components/resizable.tsx
+++ b/src/example-preview/components/resizable.tsx
@@ -28,11 +28,11 @@ export const ResizableContainer = ({
           bottomRight: false,
         }}
         defaultSize={{
-          height: 370,
+          height: '50%',
           width: '100%',
         }}
-        minHeight={150}
-        maxHeight={500}
+        minHeight={100}
+        maxHeight="70%"
         handleStyle={{
           top: {
             top: '-8px',

--- a/src/example-preview/components/resizable.tsx
+++ b/src/example-preview/components/resizable.tsx
@@ -33,7 +33,7 @@ export const ResizableContainer = ({
           width: '100%',
         }}
         minHeight={100}
-        maxHeight="70%"
+        maxHeight="80%"
         handleStyle={{
           top: {
             top: '-8px',


### PR DESCRIPTION
On mobile and narrow viewports (≤600px), the code and preview panels stack vertically. Previously, the draggable middle bar was hidden, forcing fixed heights. Now it's enabled for vertical dragging, allowing users to resize the preview panel height dynamically—matching the desktop experience of width-resizing.

Changes:
- ResizableContainer now accepts a vertical prop to switch from horizontal (left) to vertical (top) dragging
- Added ResizeObserver to detect when viewport width ≤ 600px and set vertical mode
- Updated SCSS to remove the handle hide and fixed height override on mobile
- Icon handle rotated 90° to indicate vertical dragging direction