### PR TITLE
fix: poll for shadow root before attaching click coord fix

### DIFF
--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -160,26 +160,16 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
 
       lynxViewRef.current.url = src;
 
-      // Detect when lynx-view has rendered content via MutationObserver
-      // on its shadow root
-      const el = lynxViewRef.current as unknown as HTMLElement;
-      const shadow = el.shadowRoot;
-      let mo: MutationObserver | undefined;
-      if (shadow) {
-        mo = new MutationObserver(() => {
-          if (shadow.childElementCount > 0) {
-            setRendered(true);
-            mo?.disconnect();
-          }
-        });
-        mo.observe(shadow, { childList: true, subtree: true });
-      }
-
       // Workaround: web-core reads MouseEvent.x/.y (viewport-relative) for
       // tap event detail.x/.y. When the <lynx-view> is embedded at a non-zero
       // offset, coordinates are wrong. Override the coordinate getters on the
       // original event in a capture-phase listener (before web-core reads
       // them on the element's bubbling handler).
+      const el = lynxViewRef.current as unknown as HTMLElement;
+      let disposed = false;
+      let mo: MutationObserver | undefined;
+      let removeClickFix: (() => void) | undefined;
+
       const adjustClickCoords = (e: Event) => {
         const me = e as MouseEvent;
         const rect = el.getBoundingClientRect();
@@ -194,14 +184,41 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
           pageY: { get: () => adjustedY },
         });
       };
-      shadow?.addEventListener('click', adjustClickCoords, true);
+
+      // The shadow root is created asynchronously by web-core after url is
+      // set, so we poll until it becomes available before attaching observers.
+      const setupShadow = (shadow: ShadowRoot) => {
+        mo = new MutationObserver(() => {
+          if (shadow.childElementCount > 0) {
+            setRendered(true);
+            mo!.disconnect();
+          }
+        });
+        mo.observe(shadow, { childList: true, subtree: true });
+
+        shadow.addEventListener('click', adjustClickCoords, true);
+        removeClickFix = () =>
+          shadow.removeEventListener('click', adjustClickCoords, true);
+      };
+
+      const pollShadow = () => {
+        if (disposed) return;
+        const shadow = el.shadowRoot;
+        if (shadow) {
+          setupShadow(shadow);
+        } else {
+          requestAnimationFrame(pollShadow);
+        }
+      };
+      pollShadow();
 
       // Fallback: hide loading after timeout
       const timer = setTimeout(() => setRendered(true), 5000);
       return () => {
+        disposed = true;
         clearTimeout(timer);
         mo?.disconnect();
-        shadow?.removeEventListener('click', adjustClickCoords, true);
+        removeClickFix?.();
       };
     }
   }, [ready, show, src, updateDimensions]);


### PR DESCRIPTION
## Problem

`el.shadowRoot` is accessed immediately after setting `lynxViewRef.current.url`, but web-core creates the shadow root **asynchronously**. This means `el.shadowRoot` returns `null`, and both:

1. The `MutationObserver` for rendered-state detection
2. The capture-phase `click` listener that rewrites viewport-relative coordinates to container-relative ones (`adjustClickCoords`)

...are silently skipped via optional chaining (`shadow?.addEventListener`).

This causes tap coordinates inside `<lynx-view>` to be viewport-relative instead of container-relative, breaking any Lynx app that uses `@tap` event coordinates (e.g. the 7GUIs Circle Drawer example).

## Fix

Restore the `requestAnimationFrame` polling pattern to wait for the shadow root before attaching observers and listeners. This was the original approach used in the vue-lynx website before the go-web extraction.

## Test plan

- Open any page with a `<Go>` web preview that uses `@tap` coordinates
- Verify circles appear at the correct click position in Circle Drawer
- Verify the loading overlay disappears after content renders (MutationObserver fix)