### PR TITLE
fix: normalize font size on mobile Safari

### DIFF
--- a/src/example-preview/components/code.module.scss
+++ b/src/example-preview/components/code.module.scss
@@ -1,4 +1,7 @@
 .code {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+
   :global(.rp-codeblock) {
     margin: 0 0;
     border: none;


### PR DESCRIPTION
## Summary

Disable iOS Safari's automatic text size adjustment in code blocks. When rendering mixed content (bold keywords vs normal text), Safari auto-enlarges certain text, causing inconsistent font sizes within the code editor on mobile devices. Setting `text-size-adjust: 100%` preserves the intended font sizes.

## Changes

- Added `-webkit-text-size-adjust: 100%` and `text-size-adjust: 100%` to `.code` container in `code.module.scss`

Fixes variant font sizes appearing in the code editor on mobile Safari.