### PR TITLE
fix: move text-size-adjust to stable .code-wrap container

### DIFF
--- a/example-rspress/pnpm-lock.yaml
+++ b/example-rspress/pnpm-lock.yaml
@@ -8,18 +8,15 @@ importers:
 
   .:
     dependencies:
-      '@aspect-build/go-web':
-        specifier: file:..
-        version: file:..(@douyinfe/semi-icons@2.92.2(react@18.3.1))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1)))(@lynx-js/web-elements@0.11.3(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@douyinfe/semi-icons':
         specifier: ^2.74.0
         version: 2.92.2(react@18.3.1)
       '@douyinfe/semi-ui':
         specifier: ^2.75.0
         version: 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/hello-world':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
+      '@lynx-js/go-web':
+        specifier: file:..
+        version: file:..(@douyinfe/semi-icons@2.92.2(react@18.3.1))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1)))(@lynx-js/web-elements@0.11.3(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/web-core':
         specifier: npm:@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5
         version: '@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1))'
@@ -68,25 +65,6 @@ importers:
         version: 5.9.3
 
 packages:
-
-  '@aspect-build/go-web@file:..':
-    resolution: {directory: .., type: directory}
-    peerDependencies:
-      '@douyinfe/semi-icons': '>=2.74.0'
-      '@douyinfe/semi-ui': '>=2.75.0'
-      '@lynx-js/web-core': '*'
-      '@lynx-js/web-elements': '*'
-      '@rspress/core': '*'
-      '@shikijs/transformers': '>=3.0.0'
-      qrcode.react: '>=4.0.0'
-      react: '>=18.0.0'
-      react-copy-to-clipboard: '>=5.0.0'
-      react-dom: '>=18.0.0'
-      swr: '>=2.0.0'
-      vscode-icons-js: '>=11.0.0'
-    peerDependenciesMeta:
-      '@rspress/core':
-        optional: true
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -169,27 +147,30 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hongzhiyuan/preact@10.24.0-00213bad':
-    resolution: {integrity: sha512-bHWp4ZDK5ZimcY+bTWw3S3xGiB8eROpZj0RK3FClNIaTOajb0b11CsT3K+pdeakgPgq1jWN3T2e2rfrPm40JsQ==}
-
-  '@lynx-example/hello-world@0.6.7':
-    resolution: {integrity: sha512-6uUI4/x24QFtzlOv6yLS9yHhMN1iMFijpsaSPBgC1OaUES03XM/xWwbiXKMqoosRDM93TNuPczOyCiAgBrwswA==}
-    engines: {node: '>=18'}
+  '@lynx-js/go-web@file:..':
+    resolution: {directory: .., type: directory}
+    peerDependencies:
+      '@douyinfe/semi-icons': '>=2.74.0'
+      '@douyinfe/semi-ui': '>=2.75.0'
+      '@lynx-js/web-core': '*'
+      '@lynx-js/web-elements': '*'
+      '@rspress/core': '*'
+      '@shikijs/transformers': '>=3.0.0'
+      qrcode.react: '>=4.0.0'
+      react: '>=18.0.0'
+      react-copy-to-clipboard: '>=5.0.0'
+      react-dom: '>=18.0.0'
+      swr: '>=2.0.0'
+      vscode-icons-js: '>=11.0.0'
+    peerDependenciesMeta:
+      '@rspress/core':
+        optional: true
 
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
 
   '@lynx-js/offscreen-document-canary@0.1.4':
     resolution: {integrity: sha512-yqJmCBjKGq4Eil7IgBk5LKIbxN/KSn61KKxmPyrrz1MAiBmfyHLhHrd3V8XXKvI4JpmOG5q67BQY9VEuX5u0ZA==}
-
-  '@lynx-js/react@0.115.1':
-    resolution: {integrity: sha512-htZXSUmKI/7NI5hPMBcv2zN8CRJ+Yq8TaHX2nk3oJyZzQdIzo+L9IbtVx1GwRRMsC3PmkdKX9Wiqgtjle0MolQ==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
 
   '@lynx-js/web-constants-canary@0.19.7-canary-20260126-5e7e43c5':
     resolution: {integrity: sha512-zIg6NtG6MuNvePUF39JRLRFGtYiiyrwO/aig1Ais4XMLFhQCuPlFu99DJUtewHA2FdFtE6TcFllkDcpVUU8dVw==}
@@ -1905,22 +1886,6 @@ packages:
 
 snapshots:
 
-  '@aspect-build/go-web@file:..(@douyinfe/semi-icons@2.92.2(react@18.3.1))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1)))(@lynx-js/web-elements@0.11.3(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
-    dependencies:
-      '@douyinfe/semi-icons': 2.92.2(react@18.3.1)
-      '@douyinfe/semi-ui': 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/web-core': '@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1))'
-      '@lynx-js/web-elements': 0.11.3(tslib@2.8.1)
-      '@shikijs/transformers': 3.23.0
-      qrcode.react: 4.2.0(react@18.3.1)
-      react: 18.3.1
-      react-copy-to-clipboard: 5.1.1(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      swr: 2.4.1(react@18.3.1)
-      vscode-icons-js: 11.6.1
-    optionalDependencies:
-      '@rspress/core': 2.0.5(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2)
-
   '@babel/runtime@7.28.6': {}
 
   '@bufbuild/protobuf@2.11.0': {}
@@ -2073,23 +2038,25 @@ snapshots:
   '@floating-ui/utils@0.2.11':
     optional: true
 
-  '@hongzhiyuan/preact@10.24.0-00213bad': {}
-
-  '@lynx-example/hello-world@0.6.7(@types/react@18.3.28)':
+  '@lynx-js/go-web@file:..(@douyinfe/semi-icons@2.92.2(react@18.3.1))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1)))(@lynx-js/web-elements@0.11.3(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
+      '@douyinfe/semi-icons': 2.92.2(react@18.3.1)
+      '@douyinfe/semi-ui': 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/web-core': '@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1))'
+      '@lynx-js/web-elements': 0.11.3(tslib@2.8.1)
+      '@shikijs/transformers': 3.23.0
+      qrcode.react: 4.2.0(react@18.3.1)
+      react: 18.3.1
+      react-copy-to-clipboard: 5.1.1(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      swr: 2.4.1(react@18.3.1)
+      vscode-icons-js: 11.6.1
+    optionalDependencies:
+      '@rspress/core': 2.0.5(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@lynx-js/lynx-core@0.1.3': {}
 
   '@lynx-js/offscreen-document-canary@0.1.4': {}
-
-  '@lynx-js/react@0.115.1(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
 
   '@lynx-js/web-constants-canary@0.19.7-canary-20260126-5e7e43c5':
     dependencies:

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -14,129 +14,6 @@ importers:
       '@douyinfe/semi-ui':
         specifier: ^2.75.0
         version: 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/accessibility':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/action-sheet':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/animation':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/bankcards':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/composing-elements':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/css':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/css-api':
-        specifier: 0.7.1
-        version: 0.7.1(@types/react@18.3.28)
-      '@lynx-example/design-guide':
-        specifier: 0.4.2
-        version: 0.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/element-manipulation':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/event':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/fetch':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/frame':
-        specifier: 0.1.2
-        version: 0.1.2(@types/react@18.3.28)
-      '@lynx-example/gallery':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/hello-world':
-        specifier: 0.6.8
-        version: 0.6.8(@types/react@18.3.28)
-      '@lynx-example/i18n':
-        specifier: 0.5.5
-        version: 0.5.5(@types/react@18.3.28)
-      '@lynx-example/ifr':
-        specifier: 0.5.5
-        version: 0.5.5(@types/react@18.3.28)
-      '@lynx-example/image':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/input':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/layout':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/lazy-bundle':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/list':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/local-storage':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/lynx-api':
-        specifier: 0.1.7
-        version: 0.1.7(@types/react@18.3.28)
-      '@lynx-example/main-thread':
-        specifier: 0.4.7
-        version: 0.4.7(@types/react@18.3.28)
-      '@lynx-example/native-element':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/networking':
-        specifier: 0.4.7
-        version: 0.4.7(@types/react@18.3.28)(react@18.3.1)
-      '@lynx-example/overlay':
-        specifier: latest
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/page':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/performance-api':
-        specifier: 0.7.0
-        version: 0.7.0(@types/react@18.3.28)
-      '@lynx-example/react-lifecycle':
-        specifier: 0.5.6
-        version: 0.5.6(@types/react@18.3.28)
-      '@lynx-example/refresh':
-        specifier: latest
-        version: 0.6.9(@types/react@18.3.28)
-      '@lynx-example/scroll-view':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/svg':
-        specifier: latest
-        version: 0.6.8(@types/react@18.3.28)
-      '@lynx-example/swiper':
-        specifier: 0.5.6
-        version: 0.5.6(@types/react@18.3.28)
-      '@lynx-example/tailwindcss':
-        specifier: 0.4.3
-        version: 0.4.3(@types/react@18.3.28)
-      '@lynx-example/tanstack-router':
-        specifier: 0.6.8
-        version: 0.6.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/text':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/textarea':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/title-bar-view':
-        specifier: latest
-        version: 0.6.11(@types/react@18.3.28)
-      '@lynx-example/view':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/zustand':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
       '@lynx-js/web-core':
         specifier: npm:@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5
         version: '@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1))'
@@ -273,196 +150,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hongzhiyuan/preact@10.24.0-00213bad':
-    resolution: {integrity: sha512-bHWp4ZDK5ZimcY+bTWw3S3xGiB8eROpZj0RK3FClNIaTOajb0b11CsT3K+pdeakgPgq1jWN3T2e2rfrPm40JsQ==}
-
-  '@hongzhiyuan/preact@10.28.0-fc4af453':
-    resolution: {integrity: sha512-TrM2g079OZN1poroDnU2kQd1gNUB1DMfVoKyz23AE3hZvl9ypRgG2MdgxAJtwT5u3BmYvI4Z0EbdpJTdf428IQ==}
-
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@lynx-example/accessibility@0.6.5':
-    resolution: {integrity: sha512-q5T5VjB/EdcOb3Ek1AXTBFPaIhOaSSkym9dAVemy7B95xQxkRn+CE2WcP99cT9rI4UZ9hWeuz6HY47pyMmUevA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/action-sheet@0.6.5':
-    resolution: {integrity: sha512-sTBh2BdkepFvZ85ClIAlLjgQ5kQGwnVOAQp8gzKminr2TKbYPcri6rUk6K10mhZScTIhguISIr/US4CzngmmIA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/animation@0.6.7':
-    resolution: {integrity: sha512-U4HjIj72uS7PAScyP1z5vMNZsvSzn/9dZYjP1229h8Lic/OUH3FOG0xIsBq/TsP7bMRm7fw8W1DOSpdD2eF6qw==}
-
-  '@lynx-example/bankcards@0.6.5':
-    resolution: {integrity: sha512-Vc3ooEb+s7TXlcGNtStdO9pJVkNte3quiiXbtrUkDcXi7uDKJxcElNP7g4EyArlTbmA6d3T0dHMXEScYGYP4Uw==}
-
-  '@lynx-example/composing-elements@0.6.5':
-    resolution: {integrity: sha512-McxesZ9cBeCDE9wkfW/55UGB7Bh5Gwceq/WZ1aKONk8LmQqdtrfLF/5jwfMOu5NYUl+2g20yPmvudFW1bluT2A==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/css-api@0.7.1':
-    resolution: {integrity: sha512-HVhnUjr+LDlRaxMpUh51laYgR2U3k8IsbSfkitVFHLsEC2sF+6/RqTCGoIRhYGozjqasgWtNtVoNqCXXWxGpwQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/css@0.6.5':
-    resolution: {integrity: sha512-+x3e1ni+jAJ96tdB1mzTHamSO3vKcbO2nl3hAny39qU6e6Q452z6P1k/Wr9Z6gJtD1tgSgdZYnRaNruFHEl9eg==}
-
-  '@lynx-example/design-guide@0.4.2':
-    resolution: {integrity: sha512-VV7ufIpazK2Gg4NwT23W404SSfieHyegjgryEARv0H5PaoPXH7UGRDXXcPr5baI8zbwdR29C7xTOwXBE9f3xgA==}
-
-  '@lynx-example/element-manipulation@0.6.6':
-    resolution: {integrity: sha512-KP62Zsg0FfOQD3g05uHxv/bzT73DC8pru5TBxAZBx71MtKVgQQTmyPsfSTkb1Ox86b3GgjfxfouwP5Bb3+sHFQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/event@0.6.6':
-    resolution: {integrity: sha512-bNmTw4UAmuU0voB8VfpaERSsJ7BsFivUm4NCkbx3fJtqsYDSthMn/FZyL/W8Im3GPBbDhjmaGbBeyq9wZLZFmA==}
-
-  '@lynx-example/fetch@0.6.5':
-    resolution: {integrity: sha512-UTPAbEQd8INicwnQfRUTy5lKiW8axbZpRqy5Dr7vgOAXHbN3VPldeVo91EFMGZZf5tz+S83R/ivtnsebEyztIg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/frame@0.1.2':
-    resolution: {integrity: sha512-O2n1JnMUJMvM+0xzfQLBiXm39OyCR6SgIN8uo2THWmWoyAbCts/PDgmURWTX1tKDfBKypnl4Z0/yY4PZR1X0dg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/gallery@0.6.7':
-    resolution: {integrity: sha512-erXkDalISkUTToHf8eooYm9QdGY1uNQeRhaJNzmu5eUQ1mJRtPfaaAm8YmQusP5qfEN2ajmPRZ81vo4AUW/4Xg==}
-
-  '@lynx-example/hello-world@0.6.8':
-    resolution: {integrity: sha512-MgsovxJHgxCr91sOJPD0KKV0NM8aRk4IUWRsz2tA5ZP3FhgB5lj+N6NouVVDYUPbvciSOzDJDJ3gGbpu97AeSQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/i18n@0.5.5':
-    resolution: {integrity: sha512-DTs/YEVEZOWmda3U1z8kN7lHg1tRWsmWJlh33mprpZ27h0xzawEvEVUHAiARQVoZ8SgQFfJkBShiOHNBpdzj0g==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/ifr@0.5.5':
-    resolution: {integrity: sha512-RqJy4XR33yyYDFWtI6PhWkqpMjMbrlZseXQrm1H1GK8aFS5VTBA09QkzteSvmOXn+cHXZj/HQk5RIlULcNfJfw==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/image@0.6.5':
-    resolution: {integrity: sha512-Ai6l06izU4nOQeNO5ZedcCXZ4Sy8qo9NhoqncEqcU1HHALaGJeDavW6f9kWsTtixS2NTvyf92ltUxXOFKWFHaA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/input@0.6.6':
-    resolution: {integrity: sha512-iqkkWexD+9uzWlP2W/2cbGPXw+0bjiU6bOjg0Lp0EVcTq2aoxTRns9OZ3EBVtW8WqpGxxgp7OgA9lZqeQEfr5A==}
-
-  '@lynx-example/layout@0.6.5':
-    resolution: {integrity: sha512-wcyRxwhYlCOGzxU+wSSj2ONQ0G6v1PI32tj7sH33Ws1RriNaKrFvufYgn0tz2aT+Rk+FWMFFc1IECENyLO8j3Q==}
-
-  '@lynx-example/lazy-bundle@0.6.5':
-    resolution: {integrity: sha512-tROVE5g6CE6Ep1GsZQAJNq5sABQNRa7eBAOlS/KrScx6cbfc/xSse4NxE2z9PtQeqwQh/BXpRstdMJsnywfS0Q==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/list@0.6.5':
-    resolution: {integrity: sha512-SayPu4/FKHdZoa53Q3ZLC/VtyIdW+49fOR4QjHP1s3yH0d8fH9wyN+4miyCG/wpLz520HEHvSS3pKf1f1ql6Dg==}
-
-  '@lynx-example/local-storage@0.6.6':
-    resolution: {integrity: sha512-V56IpWk7iS6qPorKZ485JNyOzdsC4zcl/aPdEcEQl3PFrStiBr/CcSLNnln1XbCVp3dsmewMgMmBP/39Ie5Ocg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/lynx-api@0.1.7':
-    resolution: {integrity: sha512-WMLcWgWBn/DminNaWD0UV6Ro58odW/rqIwlsH8netqUgg3ZL6p6Gq+s2f8UJxXk4WacFu2DYYlSMpbNDFEOcyg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/main-thread@0.4.7':
-    resolution: {integrity: sha512-7PMUhNlfX7lIM1SNeJF4PJBg7uyOs76iY7qWGsv/8gRiHuB4tu7UBtqb5X69Oy5kBKpZfZkcAor0F/ECsNQBSw==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/native-element@0.6.7':
-    resolution: {integrity: sha512-hLIzo9Sdb/4ZeDZOQoiPLj8YQS9N6CLIg766LkfiYFw6qbQjnnuK7MYmb65Fl/Sc/IDb5tG1Xv5WEMBacVg0iQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/networking@0.4.7':
-    resolution: {integrity: sha512-aRThfbd3h0Ph+mtv/yqZP9bXEP0AsWLdFNaIaFXbGNton9oTd8R+VKo5g4E5IrL0FzC4iWdVz/k+yxDoXNMZPg==}
-
-  '@lynx-example/overlay@0.6.7':
-    resolution: {integrity: sha512-HMKZc+mp0m1m95O+CRLsJ2831mqZ/j8S5NN1NUr+RHBJdT+XqHlOzrQaZI75Q1eeqI8btKNlF4nuaaZtFLrIIQ==}
-
-  '@lynx-example/page@0.6.5':
-    resolution: {integrity: sha512-qiBGaofERbCsaifh9UR1VrEI1GrOfzKtniW4GkjQFjCnZKUaaL4e4v7HzKa1gMMsenkTprigAJvqD08px52HmQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/performance-api@0.7.0':
-    resolution: {integrity: sha512-xpdzvFc3pukN1+N6p6pVsFzgDA+73+eFYyWV3TrKmXqeeQ6wRoxczrL7/rkjjCvtBZbTEX5h0fklu/GrdvOrQQ==}
-
-  '@lynx-example/react-lifecycle@0.5.6':
-    resolution: {integrity: sha512-woLhBDufmldCQ4xn9FaeknHTuJmmpLGy9m56HWN5QO+qu6gbEE84WDaR88I0Y67fZ/gIu9xkq7fy+Ukl5z8RqA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/refresh@0.6.9':
-    resolution: {integrity: sha512-A7Vte9us1iJSTLVoiklyHpwtIs9UlrONePZqLH9VmvVSjXy6ZkRQnuh0cIXdXOm+k+cfon9aZ6gIPSKUtMFm9w==}
-
-  '@lynx-example/scroll-view@0.6.5':
-    resolution: {integrity: sha512-jcfK33ZRxVGi3FiCllEy0CUK97mOU/Xd9V70KYAD9Jmkhl/BiOdLDe/QZP02cs+UCvSSNrA1wJE10LnnoNIHfg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/svg@0.6.8':
-    resolution: {integrity: sha512-9CsQeY4yeDmGFH0Vc1A5H03EJB4bgMoYAbf/G5CTpgcLEBSA1BGTRQIglHN2aGbCBhd5zx6g0Tn6ciOeFUKQKg==}
-
-  '@lynx-example/swiper@0.5.6':
-    resolution: {integrity: sha512-VB+mo2KU5MKMKBH1GG0Bu9so9itCe7tAnFJHVZdo8HERTzJZ1jFLs/FxZy9VfKMzqqgtWCSPi67/8uotBL+m/A==}
-
-  '@lynx-example/tailwindcss@0.4.3':
-    resolution: {integrity: sha512-lbStOF7Etec/ARCmozvOYs57MdyCf8Lj3iU1NF8fH/O7KAcmKTaV4G3P5BkRIJg4KQr01XtSlaYkb/+c0hfA1w==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/tanstack-router@0.6.8':
-    resolution: {integrity: sha512-bw0f3LGsSxShYw9o0s0rN0YJV2ezIBdQzgzALmeRYKj8ftfYyzJHceqxfoWUsmB37Kv8nQQhuKUFWVx9Q+DdaA==}
-
-  '@lynx-example/text@0.6.6':
-    resolution: {integrity: sha512-Kb9f1S34+Wdfzv3SyTQaWtt2DtAE+ZrNFqO3fMA+ySHiLSMKKFG1QLRb/XpGko0/BxxnVBj08mUu1YskrzLdsg==}
-
-  '@lynx-example/textarea@0.6.7':
-    resolution: {integrity: sha512-sceHiWkljTlQFjSr2AMBVSqNrQzGItE0zcPDwdtX02m1AVtqijoOyTei7LxbwlY7uNkybyi2N1F1YEyLZ5pKxQ==}
-
-  '@lynx-example/title-bar-view@0.6.11':
-    resolution: {integrity: sha512-r6BqhLij0b1lOvcZP3bdo1K4FyyCB+i7KVneatQyRcrrHJ0Rf73cNQfdtoYXEJnOmz4maMp8VILtU+w4f8aINQ==}
-
-  '@lynx-example/view@0.6.5':
-    resolution: {integrity: sha512-dSs0FhogEiuemWhV9QTFfPIQoKu+LW9wQN+JKxWbKvi1/eYP6PgZXm4ohDlSqBKdSVhw2Ok0LNgpPWmwdLV9HA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/zustand@0.6.5':
-    resolution: {integrity: sha512-zypS4TpmlyEc7u2ATutSewH8jEnMhL75RwQgvt2OFXHqfyj0gMJdu1ygP6OEoerx8wdMQUjO27I2HYvmwbhOwQ==}
-
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
 
   '@lynx-js/offscreen-document-canary@0.1.4':
     resolution: {integrity: sha512-yqJmCBjKGq4Eil7IgBk5LKIbxN/KSn61KKxmPyrrz1MAiBmfyHLhHrd3V8XXKvI4JpmOG5q67BQY9VEuX5u0ZA==}
-
-  '@lynx-js/react-use@0.1.3':
-    resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
-    peerDependencies:
-      '@lynx-js/react': '>=0.105.1'
-
-  '@lynx-js/react@0.115.1':
-    resolution: {integrity: sha512-htZXSUmKI/7NI5hPMBcv2zN8CRJ+Yq8TaHX2nk3oJyZzQdIzo+L9IbtVx1GwRRMsC3PmkdKX9Wiqgtjle0MolQ==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
-
-  '@lynx-js/react@0.115.3':
-    resolution: {integrity: sha512-EXoQ01ctzilFZfSfWAZ14DKrYla9AIxZItRuKkAIRwlh8y6207xQ9NmicdSCtQyPZ0JBCQ9KtTzXPvTPZzFwsA==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
-
-  '@lynx-js/react@0.116.4':
-    resolution: {integrity: sha512-U/4D/TtD1JLX+Wl0dyzAY/SFYnLln7BG6EacXnIGS0qHYDvdj+V1vmLmeYIJe6BxxVFMwMBjIAMRJNMxU+uoYA==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
 
   '@lynx-js/web-constants-canary@0.19.7-canary-20260126-5e7e43c5':
     resolution: {integrity: sha512-zIg6NtG6MuNvePUF39JRLRFGtYiiyrwO/aig1Ais4XMLFhQCuPlFu99DJUtewHA2FdFtE6TcFllkDcpVUU8dVw==}
@@ -729,38 +421,6 @@ packages:
   '@swc/helpers@0.5.19':
     resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
-  '@tanstack/history@1.139.0':
-    resolution: {integrity: sha512-l6wcxwDBeh/7Dhles23U1O8lp9kNJmAb2yNjekR6olZwCRNAVA8TCXlVCrueELyFlYZqvQkh0ofxnzG62A1Kkg==}
-    engines: {node: '>=12'}
-
-  '@tanstack/query-core@5.90.11':
-    resolution: {integrity: sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==}
-
-  '@tanstack/react-query@5.90.11':
-    resolution: {integrity: sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==}
-    peerDependencies:
-      react: ^18 || ^19
-
-  '@tanstack/react-router@1.139.14':
-    resolution: {integrity: sha512-eNQvFu2F+7tjCRLUiXWCHZv5OhNjn/0LP6k7o5IiOg5+JR1TOu2ztxhk1EqZfBHrebuenTFQHyFXfXVDi+3wkA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-
-  '@tanstack/react-store@0.8.1':
-    resolution: {integrity: sha512-XItJt+rG8c5Wn/2L/bnxys85rBpm0BfMbhb4zmPVLXAKY9POrp1xd6IbU4PKoOI+jSEGc3vntPRfLGSgXfE2Ig==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/router-core@1.139.14':
-    resolution: {integrity: sha512-OjNeTlAti75G+8djiAaQsfio4mpnn9HBFfION15nzIgmv+VX6wOS/OyOYKkaKf+QSecXcjajyV3HHc8YornH/A==}
-    engines: {node: '>=12'}
-
-  '@tanstack/store@0.8.1':
-    resolution: {integrity: sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw==}
-
   '@tiptap/core@3.20.1':
     resolution: {integrity: sha512-SwkPEWIfaDEZjC8SEIi4kZjqIYUbRgLUHUuQezo5GbphUNC8kM1pi3C3EtoOPtxXrEbY6e4pWEzW54Pcrd+rVA==}
     peerDependencies:
@@ -956,9 +616,6 @@ packages:
   '@types/jasmine@3.10.19':
     resolution: {integrity: sha512-Bz6P2XoeIN13AhvVe0nS7+m2RfxVllETDjFQ/s6lyEwEfIVpPCc1Q8vPdFopFAOU5mzrU1zypXJ1xGDl5EVU9Q==}
 
-  '@types/js-cookie@2.2.7':
-    resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
-
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
@@ -1002,9 +659,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
-  '@xobotyi/scrollbar-width@1.9.5':
-    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1073,9 +727,6 @@ packages:
   compute-scroll-into-view@1.0.20:
     resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
 
-  cookie-es@2.0.0:
-    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
-
   copy-text-to-clipboard@2.2.0:
     resolution: {integrity: sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ==}
     engines: {node: '>=6'}
@@ -1088,13 +739,6 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
-
-  css-in-js-utils@3.1.0:
-    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1187,18 +831,9 @@ packages:
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
-
-  fast-shallow-equal@1.0.0:
-    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-
-  fastest-stable-stringify@2.0.2:
-    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1225,20 +860,11 @@ packages:
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
-  i18next@23.16.8:
-    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
-
-  immer@10.1.1:
-    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
-
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  inline-style-prefixer@7.0.1:
-    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1264,22 +890,12 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  isbot@5.1.36:
-    resolution: {integrity: sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ==}
-    engines: {node: '>=18'}
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  jsbi@4.3.2:
-    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1370,9 +986,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -1488,20 +1101,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nano-css@5.6.2:
-    resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   node-addon-api@7.1.1:
@@ -1640,18 +1242,6 @@ packages:
       react: '>= 16.3'
       react-dom: '>= 16.3'
 
-  react-universal-interface@0.6.2:
-    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
-    peerDependencies:
-      react: '*'
-      tslib: '*'
-
-  react-use@17.6.0:
-    resolution: {integrity: sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
   react-window@1.8.11:
     resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
     engines: {node: '>8.0.0'}
@@ -1711,14 +1301,8 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
-
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
-
-  rtl-css-js@1.16.1:
-    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -1848,40 +1432,14 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  screenfull@5.2.0:
-    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
-    engines: {node: '>=0.10.0'}
-
   scroll-into-view-if-needed@2.2.31:
     resolution: {integrity: sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==}
-
-  seroval-plugins@1.5.1:
-    resolution: {integrity: sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
-  seroval@1.5.1:
-    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
-    engines: {node: '>=10'}
-
-  set-harmonic-interval@1.0.1:
-    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
-    engines: {node: '>=6.9'}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.5.6:
-    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -1891,17 +1449,8 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  stack-generator@2.0.10:
-    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
-
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  stacktrace-gps@3.1.2:
-    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
-
-  stacktrace-js@2.0.2:
-    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -1911,9 +1460,6 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
-
-  stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -1932,16 +1478,6 @@ packages:
     resolution: {integrity: sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==}
     engines: {node: '>=16.0.0'}
 
-  throttle-debounce@3.0.1:
-    resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
-    engines: {node: '>=10'}
-
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
-  tiny-warning@1.0.3:
-    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
-
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
@@ -1950,9 +1486,6 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
-  ts-easing@0.2.0:
-    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1985,9 +1518,6 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
-  url-search-params-polyfill@8.2.5:
-    resolution: {integrity: sha512-FOEojW4XReTmtZOB7xqSHmJZhrNTmClhBriwLTmle4iA7bwuCo6ldSfbtsFSb8bTf3E0a3XpfonAdaur9vqq8A==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -2173,338 +1703,9 @@ snapshots:
   '@floating-ui/utils@0.2.11':
     optional: true
 
-  '@hongzhiyuan/preact@10.24.0-00213bad': {}
-
-  '@hongzhiyuan/preact@10.28.0-fc4af453': {}
-
-  '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@lynx-example/accessibility@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/action-sheet@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/animation@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/bankcards@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/composing-elements@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/css-api@0.7.1(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/css@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/design-guide@0.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.115.3(@types/react@18.3.28))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-      - react
-      - react-dom
-
-  '@lynx-example/element-manipulation@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/event@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/fetch@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/frame@0.1.2(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/gallery@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/hello-world@0.6.8(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.116.4(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/i18n@0.5.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      i18next: 23.16.8
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/ifr@0.5.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      jsbi: 4.3.2
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/image@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/input@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/layout@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/lazy-bundle@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/list@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/local-storage@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/lynx-api@0.1.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/main-thread@0.4.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.116.4(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/native-element@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/networking@0.4.7(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      '@tanstack/react-query': 5.90.11(react@18.3.1)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-      - react
-
-  '@lynx-example/overlay@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/page@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/performance-api@0.7.0(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/react-lifecycle@0.5.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/refresh@0.6.9(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/scroll-view@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/svg@0.6.8(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/swiper@0.5.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/tailwindcss@0.4.3(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/tanstack-router@0.6.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      '@tanstack/react-router': 1.139.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      url-search-params-polyfill: 8.2.5
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-      - react
-      - react-dom
-
-  '@lynx-example/text@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/textarea@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/title-bar-view@0.6.11(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.116.4(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/view@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/zustand@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
   '@lynx-js/lynx-core@0.1.3': {}
 
   '@lynx-js/offscreen-document-canary@0.1.4': {}
-
-  '@lynx-js/react-use@0.1.3(@lynx-js/react@0.115.3(@types/react@18.3.28))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-      immer: 10.1.1
-      nanoid: 5.1.7
-      react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@lynx-js/react@0.115.1(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
-
-  '@lynx-js/react@0.115.3(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
-
-  '@lynx-js/react@0.116.4(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.28.0-fc4af453'
 
   '@lynx-js/web-constants-canary@0.19.7-canary-20260126-5e7e43c5':
     dependencies:
@@ -2795,45 +1996,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/history@1.139.0': {}
-
-  '@tanstack/query-core@5.90.11': {}
-
-  '@tanstack/react-query@5.90.11(react@18.3.1)':
-    dependencies:
-      '@tanstack/query-core': 5.90.11
-      react: 18.3.1
-
-  '@tanstack/react-router@1.139.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@tanstack/history': 1.139.0
-      '@tanstack/react-store': 0.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/router-core': 1.139.14
-      isbot: 5.1.36
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/react-store@0.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@tanstack/store': 0.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
-  '@tanstack/router-core@1.139.14':
-    dependencies:
-      '@tanstack/history': 1.139.0
-      '@tanstack/store': 0.8.1
-      cookie-es: 2.0.0
-      seroval: 1.5.1
-      seroval-plugins: 1.5.1(seroval@1.5.1)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/store@0.8.1': {}
-
   '@tiptap/core@3.20.1(@tiptap/pm@3.20.1)':
     dependencies:
       '@tiptap/pm': 3.20.1
@@ -3055,8 +2217,6 @@ snapshots:
 
   '@types/jasmine@3.10.19': {}
 
-  '@types/js-cookie@2.2.7': {}
-
   '@types/linkify-it@5.0.0': {}
 
   '@types/markdown-it@14.1.2':
@@ -3096,8 +2256,6 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@xobotyi/scrollbar-width@1.9.5': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -3144,8 +2302,6 @@ snapshots:
 
   compute-scroll-into-view@1.0.20: {}
 
-  cookie-es@2.0.0: {}
-
   copy-text-to-clipboard@2.2.0: {}
 
   copy-to-clipboard@3.3.3:
@@ -3155,15 +2311,6 @@ snapshots:
   core-js@3.47.0: {}
 
   crelt@1.0.6: {}
-
-  css-in-js-utils@3.1.0:
-    dependencies:
-      hyphenate-style-name: 1.1.0
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
 
   csstype@3.2.3: {}
 
@@ -3257,13 +2404,7 @@ snapshots:
 
   fast-copy@3.0.2: {}
 
-  fast-deep-equal@3.1.3: {}
-
   fast-equals@5.4.0: {}
-
-  fast-shallow-equal@1.0.0: {}
-
-  fastest-stable-stringify@2.0.2: {}
 
   has-flag@4.0.0: {}
 
@@ -3332,19 +2473,9 @@ snapshots:
 
   hyphenate-style-name@1.1.0: {}
 
-  i18next@23.16.8:
-    dependencies:
-      '@babel/runtime': 7.28.6
-
-  immer@10.1.1: {}
-
   immutable@5.1.5: {}
 
   inline-style-parser@0.2.7: {}
-
-  inline-style-prefixer@7.0.1:
-    dependencies:
-      css-in-js-utils: 3.1.0
 
   is-alphabetical@2.0.1: {}
 
@@ -3367,15 +2498,9 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  isbot@5.1.36: {}
-
   jiti@2.6.1: {}
 
-  js-cookie@2.2.1: {}
-
   js-tokens@4.0.0: {}
-
-  jsbi@4.3.2: {}
 
   json5@2.2.3: {}
 
@@ -3578,8 +2703,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-
-  mdn-data@2.0.14: {}
 
   mdurl@2.0.0: {}
 
@@ -3851,22 +2974,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nano-css@5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      css-tree: 1.1.3
-      csstype: 3.2.3
-      fastest-stable-stringify: 2.0.2
-      inline-style-prefixer: 7.0.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      rtl-css-js: 1.16.1
-      stacktrace-js: 2.0.2
-      stylis: 4.3.6
-
   nanoid@3.3.11: {}
-
-  nanoid@5.1.7: {}
 
   node-addon-api@7.1.1:
     optional: true
@@ -4053,30 +3161,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-universal-interface@0.6.2(react@18.3.1)(tslib@2.8.1):
-    dependencies:
-      react: 18.3.1
-      tslib: 2.8.1
-
-  react-use@17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@types/js-cookie': 2.2.7
-      '@xobotyi/scrollbar-width': 1.9.5
-      copy-to-clipboard: 3.3.3
-      fast-deep-equal: 3.1.3
-      fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
-      nano-css: 5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-universal-interface: 0.6.2(react@18.3.1)(tslib@2.8.1)
-      resize-observer-polyfill: 1.5.1
-      screenfull: 5.2.0
-      set-harmonic-interval: 1.0.1
-      throttle-debounce: 3.0.1
-      ts-easing: 0.2.0
-      tslib: 2.8.1
-
   react-window@1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -4181,13 +3265,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  resize-observer-polyfill@1.5.1: {}
-
   rope-sequence@1.3.4: {}
-
-  rtl-css-js@1.16.1:
-    dependencies:
-      '@babel/runtime': 7.28.6
 
   rxjs@7.8.2:
     dependencies:
@@ -4293,19 +3371,9 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  screenfull@5.2.0: {}
-
   scroll-into-view-if-needed@2.2.31:
     dependencies:
       compute-scroll-into-view: 1.0.20
-
-  seroval-plugins@1.5.1(seroval@1.5.1):
-    dependencies:
-      seroval: 1.5.1
-
-  seroval@1.5.1: {}
-
-  set-harmonic-interval@1.0.1: {}
 
   shiki@3.23.0:
     dependencies:
@@ -4320,30 +3388,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.5.6: {}
-
-  source-map@0.6.1: {}
-
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
-  stack-generator@2.0.10:
-    dependencies:
-      stackframe: 1.3.4
-
   stackframe@1.3.4: {}
-
-  stacktrace-gps@3.1.2:
-    dependencies:
-      source-map: 0.5.6
-      stackframe: 1.3.4
-
-  stacktrace-js@2.0.2:
-    dependencies:
-      error-stack-parser: 2.1.4
-      stack-generator: 2.0.10
-      stacktrace-gps: 3.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -4357,8 +3406,6 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
-
-  stylis@4.3.6: {}
 
   supports-color@8.1.1:
     dependencies:
@@ -4376,19 +3423,11 @@ snapshots:
 
   sync-message-port@1.2.0: {}
 
-  throttle-debounce@3.0.1: {}
-
-  tiny-invariant@1.3.3: {}
-
-  tiny-warning@1.0.3: {}
-
   toggle-selection@1.0.6: {}
 
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-easing@0.2.0: {}
 
   tslib@2.8.1: {}
 
@@ -4432,8 +3471,6 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
-
-  url-search-params-polyfill@8.2.5: {}
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -113,13 +113,26 @@ const StandaloneCodeBlock = ({
 
   if (!html) {
     return (
-      <pre style={{ padding: '16px', margin: 0, overflow: 'auto' }}>
-        <code>{code}</code>
-      </pre>
+      <div className="rp-codeblock">
+        <div className="rp-codeblock__content">
+          <div className="rp-codeblock__content__scroll-container">
+            <pre className="shiki" style={{ margin: 0 }}>
+              <code style={{ padding: '1rem 1.25rem' }}>{code}</code>
+            </pre>
+          </div>
+        </div>
+      </div>
     );
   }
   return (
-    <div className="rp-codeblock" dangerouslySetInnerHTML={{ __html: html }} />
+    <div className="rp-codeblock">
+      <div className="rp-codeblock__content">
+        <div
+          className="rp-codeblock__content__scroll-container"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/example/src/styles.css
+++ b/example/src/styles.css
@@ -38,10 +38,12 @@ html[style*='color-scheme: dark'] .shiki span {
 /* ------------------------------------------------------------------ */
 /* Shiki line numbers (CSS counter)                                    */
 /* ------------------------------------------------------------------ */
+.rp-codeblock__content--line-numbers code,
 .shiki.has-line-numbers code {
   counter-reset: line;
 }
 
+.rp-codeblock__content--line-numbers code .line::before,
 .shiki.has-line-numbers code .line::before {
   counter-increment: line;
   content: counter(line);
@@ -53,6 +55,7 @@ html[style*='color-scheme: dark'] .shiki span {
 }
 
 /* Shiki highlight (matched to rspress) */
+.rp-codeblock__content .shiki.has-highlighted .line.highlighted,
 .shiki.has-highlighted .line.highlighted {
   background-color: #3b82f61a;
   box-shadow: inset 2px 0 #3b82f6;
@@ -64,10 +67,22 @@ html[style*='color-scheme: dark'] .shiki span {
 /* ------------------------------------------------------------------ */
 /* Shiki base styles (matched to rspress code block)                   */
 /* ------------------------------------------------------------------ */
-.shiki {
+.rp-codeblock {
+  position: relative;
+  overflow-x: auto;
+}
+
+.rp-codeblock__content {
+  position: relative;
+}
+
+.rp-codeblock__content__scroll-container {
+  overflow-x: auto;
+}
+
+.rp-codeblock__content :where(pre) {
   padding: 0;
   margin: 0;
-  overflow: auto;
   border-radius: 0;
   text-align: left;
   white-space: pre;
@@ -76,9 +91,13 @@ html[style*='color-scheme: dark'] .shiki span {
   word-wrap: normal;
   tab-size: 4;
   hyphens: none;
+  z-index: 1;
+  background: none;
+  outline: none;
+  position: relative;
 }
 
-.shiki code {
+.rp-codeblock__content :where(code) {
   display: inline-block;
   width: fit-content;
   min-width: 100%;
@@ -88,7 +107,7 @@ html[style*='color-scheme: dark'] .shiki span {
   line-height: 1.7;
 }
 
-.shiki span.line {
+.rp-codeblock__content .shiki span.line {
   padding: 0 1.25rem;
   display: inline-block;
 }

--- a/example/src/styles.css
+++ b/example/src/styles.css
@@ -1,6 +1,20 @@
 /* ------------------------------------------------------------------ */
 /* Shiki dual-theme support                                            */
 /* ------------------------------------------------------------------ */
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+.rp-codeblock,
+.rp-codeblock *,
+.shiki,
+.shiki *,
+.shiki code {
+  -webkit-text-size-adjust: 100% !important;
+  text-size-adjust: 100% !important;
+}
+
 html[style*='color-scheme: light'] .shiki,
 html:not([style*='color-scheme: dark']) .shiki {
   background-color: var(--shiki-light-bg, #fff) !important;

--- a/src/example-preview/components/code.module.scss
+++ b/src/example-preview/components/code.module.scss
@@ -1,4 +1,7 @@
 .code {
+  -webkit-text-size-adjust: 100% !important;
+  text-size-adjust: 100% !important;
+
   :global(.rp-codeblock) {
     margin: 0 0;
     border: none;

--- a/src/example-preview/components/code.module.scss
+++ b/src/example-preview/components/code.module.scss
@@ -6,5 +6,18 @@
     margin: 0 0;
     border: none;
     border-radius: none;
+    -webkit-text-size-adjust: 100% !important;
+    text-size-adjust: 100% !important;
+  }
+
+  :global(pre),
+  :global(code),
+  :global(pre code),
+  :global(pre code span),
+  :global(pre.shiki),
+  :global(pre.shiki code),
+  :global(pre.shiki code span) {
+    -webkit-text-size-adjust: 100% !important;
+    text-size-adjust: 100% !important;
   }
 }

--- a/src/example-preview/components/code.module.scss
+++ b/src/example-preview/components/code.module.scss
@@ -1,23 +1,7 @@
 .code {
-  -webkit-text-size-adjust: 100% !important;
-  text-size-adjust: 100% !important;
-
   :global(.rp-codeblock) {
     margin: 0 0;
     border: none;
-    border-radius: none;
-    -webkit-text-size-adjust: 100% !important;
-    text-size-adjust: 100% !important;
-  }
-
-  :global(pre),
-  :global(code),
-  :global(pre code),
-  :global(pre code span),
-  :global(pre.shiki),
-  :global(pre.shiki code),
-  :global(pre.shiki code span) {
-    -webkit-text-size-adjust: 100% !important;
-    text-size-adjust: 100% !important;
+    border-radius: 0;
   }
 }

--- a/src/example-preview/components/code.module.scss
+++ b/src/example-preview/components/code.module.scss
@@ -1,7 +1,4 @@
 .code {
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
-
   :global(.rp-codeblock) {
     margin: 0 0;
     border: none;

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -34,6 +34,8 @@
     width: 100%;
     min-width: 0;
     overflow: hidden;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
     background: var(--shiki-dark-bg, var(--rp-code-block-bg, var(--semi-color-bg-1)));
     :global {
       div[class^='language-'] {

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -35,6 +35,8 @@
     min-width: 0;
     overflow: hidden;
     background: var(--shiki-dark-bg, var(--rp-code-block-bg, var(--semi-color-bg-1)));
+    -webkit-text-size-adjust: 100% !important;
+    text-size-adjust: 100% !important;
     :global {
       div[class^='language-'] {
         margin: 0;
@@ -59,12 +61,21 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
+    -webkit-text-size-adjust: 100% !important;
+    text-size-adjust: 100% !important;
     .code-view-container {
       width: 100%;
       height: 100%;
       overflow: auto;
       min-height: 0;
       background: var(--shiki-dark-bg, var(--rp-code-block-bg, var(--semi-color-bg-1)));
+      -webkit-text-size-adjust: 100% !important;
+      text-size-adjust: 100% !important;
+
+      * {
+        -webkit-text-size-adjust: 100% !important;
+        text-size-adjust: 100% !important;
+      }
     }
     .code-tab {
       width: 100%;

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -42,8 +42,8 @@
       }
       pre.shiki {
         min-height: 567px;
-        -webkit-text-size-adjust: 100%;
-        text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100% !important;
+        text-size-adjust: 100% !important;
       }
     }
     .code-view-container-tab-show {

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -34,8 +34,6 @@
     width: 100%;
     min-width: 0;
     overflow: hidden;
-    -webkit-text-size-adjust: 100%;
-    text-size-adjust: 100%;
     background: var(--shiki-dark-bg, var(--rp-code-block-bg, var(--semi-color-bg-1)));
     :global {
       div[class^='language-'] {
@@ -44,6 +42,8 @@
       }
       pre.shiki {
         min-height: 567px;
+        -webkit-text-size-adjust: 100%;
+        text-size-adjust: 100%;
       }
     }
     .code-view-container-tab-show {

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -35,8 +35,6 @@
     min-width: 0;
     overflow: hidden;
     background: var(--shiki-dark-bg, var(--rp-code-block-bg, var(--semi-color-bg-1)));
-    -webkit-text-size-adjust: 100% !important;
-    text-size-adjust: 100% !important;
     :global {
       div[class^='language-'] {
         margin: 0;
@@ -44,8 +42,13 @@
       }
       pre.shiki {
         min-height: 567px;
-        -webkit-text-size-adjust: 100% !important;
-        text-size-adjust: 100% !important;
+        // Prevent iOS Safari text autosizing (font inflation).
+        // WebKit triggers autosizing when a block's layout width > visibleWidth.
+        // With white-space:pre and no overflow constraint, the pre's content
+        // width can exceed the viewport, triggering per-cluster font boosting.
+        // overflow-x:auto constrains the pre's layout width to its container,
+        // so WebKit sees width ≤ visibleWidth and skips autosizing entirely.
+        overflow-x: auto;
       }
     }
     .code-view-container-tab-show {
@@ -61,21 +64,13 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
-    -webkit-text-size-adjust: 100% !important;
-    text-size-adjust: 100% !important;
     .code-view-container {
       width: 100%;
       height: 100%;
-      overflow: auto;
+      overflow-y: auto;
+      overflow-x: hidden;
       min-height: 0;
       background: var(--shiki-dark-bg, var(--rp-code-block-bg, var(--semi-color-bg-1)));
-      -webkit-text-size-adjust: 100% !important;
-      text-size-adjust: 100% !important;
-
-      * {
-        -webkit-text-size-adjust: 100% !important;
-        text-size-adjust: 100% !important;
-      }
     }
     .code-tab {
       width: 100%;


### PR DESCRIPTION
## Summary

Follow-up to #13. The `text-size-adjust: 100%` fix was applied on `.code` in `code.module.scss`, which re-mounts when switching examples — causing the font size inconsistency to reappear.

This PR moves the property to `.code-wrap` in `index.module.scss`, which persists across example switches and keeps iOS Safari's automatic font size adjustment disabled at all times.

## Changes

- Removed `-webkit-text-size-adjust` / `text-size-adjust` from `.code` (`code.module.scss`)
- Added them to `.code-wrap` (`index.module.scss`)