### PR TITLE
feat: add iframe embed API for go-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,48 @@ const html = generateSSGHTML({
 
 The `./ssg` export uses Node.js `fs`/`path` and must not be bundled into browser code.
 
+### Iframe Embed (no React required)
+
+For non-React sites (Hugo, Jekyll, plain HTML, etc.), use the iframe embed API. The host page only loads a tiny JS file — React runs inside the iframe.
+
+```html
+<div id="demo" style="height: 500px;"></div>
+<script type="module">
+  import { mount } from 'https://go.lynxjs.org/embed.js';
+
+  const embed = mount('#demo', {
+    example: 'hello-world',
+    defaultFile: 'src/App.tsx',
+  });
+
+  // Switch example dynamically:
+  // embed.update({ example: 'css' });
+
+  // Clean up:
+  // embed.destroy();
+</script>
+```
+
+Options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `example` | `string` | **Required.** Example folder name |
+| `defaultFile` | `string` | Initial file to display (default: `'src/App.tsx'`) |
+| `defaultTab` | `'preview' \| 'web' \| 'qrcode'` | Default preview tab |
+| `exampleBasePath` | `string` | Base path or full URL for example data |
+| `img` | `string` | Static preview image URL |
+| `defaultEntryFile` | `string` | Default entry file for web preview |
+| `highlight` | `string` | Line highlight spec, e.g. `'{1,3-5}'` |
+| `entry` | `string \| string[]` | Filter entry files in tree |
+
 ## Development
 
 ```bash
 pnpm dev
 ```
 
-This starts the standalone example app at `localhost:3000`.
+This starts the standalone example app at `localhost:5969`.
 
 ### Lynx examples
 

--- a/example-iframe-embed/index.html
+++ b/example-iframe-embed/index.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Go Web — Iframe Embed Test</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+        background: #f0f0f0;
+        color: #333;
+        padding: 40px;
+      }
+
+      h1 {
+        font-size: 24px;
+        margin-bottom: 8px;
+      }
+
+      p {
+        color: #666;
+        margin-bottom: 24px;
+        line-height: 1.5;
+      }
+
+      .demo-container {
+        height: 500px;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 4px 24px rgba(0,0,0,0.12);
+        margin-bottom: 32px;
+      }
+
+      .controls {
+        margin-bottom: 24px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        padding: 8px 16px;
+        border-radius: 6px;
+        border: 1px solid #ccc;
+        background: #fff;
+        cursor: pointer;
+        font-size: 14px;
+      }
+
+      button:hover { background: #f5f5f5; }
+      button.active { background: #0071e3; color: #fff; border-color: #0071e3; }
+
+      code {
+        background: #e8e8e8;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 13px;
+      }
+
+      .code-block {
+        background: #1e1e1e;
+        color: #d4d4d4;
+        padding: 16px 20px;
+        border-radius: 8px;
+        font-family: 'SF Mono', 'Fira Code', Menlo, monospace;
+        font-size: 13px;
+        line-height: 1.6;
+        overflow-x: auto;
+        margin-bottom: 32px;
+        white-space: pre;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 12px;
+      }
+
+      .info {
+        background: #e3f2fd;
+        border: 1px solid #90caf9;
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin-bottom: 24px;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+    </style>
+  </head>
+  <body>
+    <h1>Iframe Embed API Test</h1>
+    <p>
+      This page demonstrates the <code>@lynx-js/go-web</code> iframe embed API.
+      It loads the Go component inside an iframe via a pure JS <code>mount()</code> call —
+      no React dependency needed on the host page.
+    </p>
+
+    <div class="info">
+      <strong>How to test:</strong><br/>
+      1. Start dev server: <code>cd example && pnpm dev</code> (serves on <strong>localhost:5969</strong>)<br/>
+      2. Open this file in a browser (or <code>npx serve example-iframe-embed</code>)<br/>
+      Example data is proxied from <strong>go.lynxjs.org</strong> via <code>/proxy-lynx-examples</code>.
+    </div>
+
+    <h2>Usage</h2>
+    <div class="code-block">&lt;div id="demo" style="height: 500px"&gt;&lt;/div&gt;
+&lt;script type="module"&gt;
+  import { mount } from 'https://go.lynxjs.org/embed.js';
+  mount('#demo', {
+    example: 'hello-world',
+    defaultFile: 'src/App.tsx',
+    exampleBasePath: 'https://go.lynxjs.org/lynx-examples',
+  });
+&lt;/script&gt;</div>
+
+    <h2>Live Demo</h2>
+
+    <div class="controls" id="controls"></div>
+
+    <div class="demo-container" id="demo"></div>
+
+    <script type="module">
+      // ---------------------------------------------------------------------------
+      // Config
+      // ---------------------------------------------------------------------------
+
+      // The embed React app runs on localhost (cd example && pnpm dev).
+      // Example data is proxied through the dev server to avoid CORS issues.
+      // The proxy rewrites /proxy-lynx-examples/* → go.lynxjs.org/lynx-examples/*
+      const EMBED_BASE = 'http://localhost:5969';
+      const EXAMPLE_BASE_PATH = '/proxy-lynx-examples';
+
+      // ---------------------------------------------------------------------------
+      // Inline mount() — mimics src/embed.ts for local testing
+      // In production you'd: import { mount } from 'https://go.lynxjs.org/embed.js'
+      // ---------------------------------------------------------------------------
+
+      function mount(container, options) {
+        const el = typeof container === 'string'
+          ? document.querySelector(container)
+          : container;
+
+        if (!el) throw new Error('Container not found: ' + container);
+
+        const embedUrl = new URL(EMBED_BASE + '/embed');
+
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl.href;
+        iframe.style.cssText = 'width: 100%; height: 100%; border: none;';
+
+        let currentOptions = { ...options };
+
+        function handleMessage(event) {
+          if (event.source !== iframe.contentWindow) return;
+          if (event.data?.type === 'go-embed:ready') {
+            iframe.contentWindow.postMessage({
+              type: 'go-embed:init',
+              options: currentOptions,
+            }, '*');
+          }
+        }
+
+        window.addEventListener('message', handleMessage);
+        el.innerHTML = '';
+        el.appendChild(iframe);
+
+        return {
+          iframe,
+          update(newOptions) {
+            currentOptions = { ...currentOptions, ...newOptions };
+            iframe.contentWindow.postMessage({
+              type: 'go-embed:update',
+              options: newOptions,
+            }, '*');
+          },
+          destroy() {
+            window.removeEventListener('message', handleMessage);
+            el.innerHTML = '';
+          },
+        };
+      }
+
+      // ---------------------------------------------------------------------------
+      // Fetch available examples from production
+      // ---------------------------------------------------------------------------
+
+      async function fetchExampleList() {
+        // Try a few known examples; the production site doesn't expose a directory listing.
+        // Requests go through the dev server proxy to avoid CORS.
+        const knownExamples = [
+          'hello-world', 'text', 'view', 'image', 'css',
+          'scroll-view', 'list', 'navigator',
+        ];
+
+        const available = [];
+        await Promise.all(
+          knownExamples.map(async (name) => {
+            try {
+              const res = await fetch(`${EMBED_BASE}${EXAMPLE_BASE_PATH}/${name}/example-metadata.json`, { method: 'HEAD' });
+              if (res.ok) available.push(name);
+            } catch { /* skip */ }
+          }),
+        );
+
+        // Preserve original order
+        return knownExamples.filter((n) => available.includes(n));
+      }
+
+      // ---------------------------------------------------------------------------
+      // Mount demos
+      // ---------------------------------------------------------------------------
+
+      const examples = await fetchExampleList();
+      if (examples.length === 0) {
+        examples.push('hello-world'); // fallback
+      }
+
+      const EXAMPLES = examples.map((name) => ({
+        name,
+        file: 'src/App.tsx',
+      }));
+
+      // Mount main demo
+      let embed = mount('#demo', {
+        example: EXAMPLES[0].name,
+        defaultFile: EXAMPLES[0].file,
+        defaultTab: 'web',
+        exampleBasePath: EXAMPLE_BASE_PATH,
+      });
+
+      // Create example switcher buttons
+      const controls = document.getElementById('controls');
+      EXAMPLES.forEach((ex, i) => {
+        const btn = document.createElement('button');
+        btn.textContent = ex.name;
+        if (i === 0) btn.classList.add('active');
+        btn.addEventListener('click', () => {
+          controls.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          embed.destroy();
+          embed = mount('#demo', {
+            example: ex.name,
+            defaultFile: ex.file,
+            defaultTab: 'web',
+            exampleBasePath: EXAMPLE_BASE_PATH,
+          });
+        });
+        controls.appendChild(btn);
+      });
+
+    </script>
+  </body>
+</html>

--- a/example/embed.html
+++ b/example/embed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Go Web Embed</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+      }
+      #embed-root {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="embed-root"></div>
+    <script type="module" src="./src/embed-entry.tsx"></script>
+  </body>
+</html>

--- a/example/rsbuild.config.ts
+++ b/example/rsbuild.config.ts
@@ -44,13 +44,28 @@ for (const name of exampleNames) {
 export default defineConfig({
   plugins: [pluginReact(), pluginSass()],
 
+  server: {
+    port: 5969,
+    proxy: {
+      // Proxy requests to production examples when local examples are not available.
+      // This avoids CORS issues when testing the embed with go.lynxjs.org data.
+      '/proxy-lynx-examples': {
+        target: 'https://go.lynxjs.org',
+        pathRewrite: { '^/proxy-lynx-examples': '/lynx-examples' },
+        changeOrigin: true,
+      },
+    },
+  },
+
   html: {
-    template: './index.html',
+    template: ({ entryName }) =>
+      entryName === 'embed' ? './embed.html' : './index.html',
   },
 
   source: {
     entry: {
       index: './src/main.tsx',
+      embed: './src/embed-entry.tsx',
     },
     define: {
       // Inject the example list as a build-time constant

--- a/example/src/embed-entry.tsx
+++ b/example/src/embed-entry.tsx
@@ -1,0 +1,184 @@
+/**
+ * Embed entry point — renders inside the iframe created by src/embed.ts.
+ *
+ * Listens for postMessage from the parent to receive example configuration,
+ * then renders a Go component with GoConfigProvider.
+ */
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import '@douyinfe/semi-ui/dist/css/semi.min.css';
+import { GoConfigProvider, Go } from '../../src/index';
+import type { GoConfig } from '../../src/config';
+import type { ShikiTransformer, BundledLanguage } from 'shiki';
+import './styles.css';
+
+// ---------------------------------------------------------------------------
+// Shiki CodeBlock (reused from main.tsx)
+// ---------------------------------------------------------------------------
+
+let _codeHighlighterP: ReturnType<typeof import('shiki').then> | null = null;
+function getCodeHighlighter() {
+  if (!_codeHighlighterP) {
+    _codeHighlighterP = import('shiki').then((mod) =>
+      mod.createHighlighter({
+        themes: ['github-light', 'github-dark'],
+        langs: [],
+      }),
+    );
+  }
+  return _codeHighlighterP;
+}
+
+const StandaloneCodeBlock = ({
+  lang,
+  code,
+  onRendered,
+  shikiOptions,
+}: {
+  lang: string;
+  code: string;
+  onRendered?: () => void;
+  shikiOptions?: { transformers?: ShikiTransformer[] };
+}) => {
+  const [html, setHtml] = useState('');
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+    getCodeHighlighter().then(async (highlighter) => {
+      if (cancelled) return;
+      const loaded = highlighter.getLoadedLanguages();
+      if (!loaded.includes(lang as BundledLanguage)) {
+        try {
+          await highlighter.loadLanguage(lang as BundledLanguage);
+        } catch {
+          // fall back to plaintext
+        }
+      }
+      const effective = highlighter
+        .getLoadedLanguages()
+        .includes(lang as BundledLanguage)
+        ? lang
+        : 'text';
+      const result = highlighter.codeToHtml(code, {
+        lang: effective,
+        themes: { light: 'github-light', dark: 'github-dark' },
+        defaultColor: false,
+        transformers: shikiOptions?.transformers ?? [],
+      });
+      if (!cancelled) setHtml(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, lang, shikiOptions?.transformers]);
+
+  useEffect(() => {
+    if (html && onRendered) requestAnimationFrame(() => onRendered());
+  }, [html, onRendered]);
+
+  if (!html) {
+    return (
+      <pre style={{ padding: '16px', margin: 0, overflow: 'auto' }}>
+        <code>{code}</code>
+      </pre>
+    );
+  }
+  return (
+    <div className="rp-codeblock" dangerouslySetInnerHTML={{ __html: html }} />
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Embed options type (mirrors src/embed.ts)
+// ---------------------------------------------------------------------------
+
+type EmbedOptions = {
+  example: string;
+  defaultFile?: string;
+  defaultTab?: 'preview' | 'web' | 'qrcode';
+  img?: string;
+  defaultEntryFile?: string;
+  highlight?: string;
+  entry?: string | string[];
+  seamless?: boolean;
+  exampleBasePath?: string;
+};
+
+// ---------------------------------------------------------------------------
+// EmbedApp
+// ---------------------------------------------------------------------------
+
+function EmbedApp() {
+  const [options, setOptions] = useState<EmbedOptions | null>(null);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data as { type?: string; options?: EmbedOptions };
+
+      if (data?.type === 'go-embed:init' && data.options) {
+        setOptions(data.options);
+      }
+
+      if (data?.type === 'go-embed:update' && data.options) {
+        setOptions((prev) => (prev ? { ...prev, ...data.options } : null));
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    // Signal to parent that we're ready to receive options
+    if (window.parent !== window) {
+      window.parent.postMessage({ type: 'go-embed:ready' }, '*');
+    }
+
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  if (!options) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          color: '#999',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        Loading...
+      </div>
+    );
+  }
+
+  const goConfig: GoConfig = {
+    exampleBasePath: options.exampleBasePath || '/lynx-examples',
+    CodeBlock: StandaloneCodeBlock,
+  };
+
+  return (
+    <GoConfigProvider config={goConfig}>
+      <div style={{ height: '100%', overflow: 'hidden' }}>
+        <Go
+          key={`${options.exampleBasePath}/${options.example}`}
+          example={options.example}
+          defaultFile={options.defaultFile ?? 'src/App.tsx'}
+          defaultTab={options.defaultTab}
+          img={options.img}
+          defaultEntryFile={options.defaultEntryFile}
+          highlight={options.highlight}
+          entry={options.entry}
+        />
+      </div>
+    </GoConfigProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mount
+// ---------------------------------------------------------------------------
+
+const container = document.getElementById('embed-root')!;
+const root = createRoot(container);
+root.render(<EmbedApp />);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./adapters/rspress": "./src/adapters/rspress.tsx",
-    "./ssg": "./src/ssg.tsx"
+    "./ssg": "./src/ssg.tsx",
+    "./embed": "./src/embed.ts"
   },
   "files": [
     "src"

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,0 +1,147 @@
+/**
+ * @lynx-js/go-web Iframe Embed API
+ *
+ * Pure JS entry point — zero React dependency.
+ * Creates an iframe that loads the Go component, communicating via postMessage.
+ *
+ * Usage:
+ * ```html
+ * <div id="demo" style="height: 500px;"></div>
+ * <script type="module">
+ *   import { mount } from 'https://your-site.com/embed.js';
+ *   mount('#demo', {
+ *     example: 'hello-world',
+ *     defaultFile: 'src/App.tsx',
+ *   });
+ * </script>
+ * ```
+ */
+
+export type EmbedOptions = {
+  /** Example name (folder name under exampleBasePath) */
+  example: string;
+  /** Initial file to display */
+  defaultFile?: string;
+  /** Default preview tab */
+  defaultTab?: 'preview' | 'web' | 'qrcode';
+  /** Static preview image URL */
+  img?: string;
+  /** Default entry file for web preview */
+  defaultEntryFile?: string;
+  /** Code highlight spec, e.g. '{1,3-5}' */
+  highlight?: string;
+  /** Filter entry files in tree */
+  entry?: string | string[];
+  /** Hide the header bar for minimal embeds */
+  seamless?: boolean;
+  /**
+   * Base path (or full URL) for example assets.
+   * Defaults to '/lynx-examples'. Use a full URL for cross-origin data,
+   * e.g. 'https://go.lynxjs.org/lynx-examples'.
+   */
+  exampleBasePath?: string;
+};
+
+export type EmbedControl = {
+  iframe: HTMLIFrameElement;
+  /** Update the displayed example */
+  update: (options: Partial<EmbedOptions>) => void;
+  /** Remove the embed and clean up listeners */
+  destroy: () => void;
+};
+
+type EmbedReadyMessage = {
+  type: 'go-embed:ready';
+};
+
+type EmbedInitMessage = {
+  type: 'go-embed:init';
+  options: EmbedOptions;
+};
+
+type EmbedUpdateMessage = {
+  type: 'go-embed:update';
+  options: Partial<EmbedOptions>;
+};
+
+function isEmbedReadyMessage(data: unknown): data is EmbedReadyMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { type?: string }).type === 'go-embed:ready'
+  );
+}
+
+/**
+ * Resolve the embed.html URL relative to this script's location.
+ * Works because embed.js and embed.html are co-located in the build output.
+ */
+function getEmbedUrl(): string {
+  return new URL('embed.html', import.meta.url).href;
+}
+
+/**
+ * Mount a Go interactive example embed into a container element.
+ *
+ * @param container - CSS selector or DOM element
+ * @param options - Example configuration
+ * @returns Control object to update or destroy the embed
+ */
+export function mount(
+  container: string | HTMLElement,
+  options: EmbedOptions,
+): EmbedControl {
+  const el =
+    typeof container === 'string'
+      ? document.querySelector<HTMLElement>(container)
+      : container;
+
+  if (!el) {
+    throw new Error(`@lynx-js/go-web embed: container not found: ${container}`);
+  }
+
+  const embedUrl = new URL(getEmbedUrl());
+  if (options.seamless) {
+    embedUrl.searchParams.set('seamless', '1');
+  }
+
+  const iframe = document.createElement('iframe');
+  iframe.src = embedUrl.href;
+  iframe.style.cssText =
+    'width: 100%; height: 100%; border: none; border-radius: 8px;';
+
+  let currentOptions = { ...options };
+
+  const handleMessage = (event: MessageEvent<unknown>): void => {
+    if (event.source !== iframe.contentWindow) return;
+
+    if (isEmbedReadyMessage(event.data)) {
+      const initMessage: EmbedInitMessage = {
+        type: 'go-embed:init',
+        options: currentOptions,
+      };
+      iframe.contentWindow?.postMessage(initMessage, '*');
+    }
+  };
+
+  window.addEventListener('message', handleMessage);
+
+  el.innerHTML = '';
+  el.appendChild(iframe);
+
+  return {
+    iframe,
+    update(newOptions: Partial<EmbedOptions>): void {
+      currentOptions = { ...currentOptions, ...newOptions };
+      const updateMessage: EmbedUpdateMessage = {
+        type: 'go-embed:update',
+        options: newOptions,
+      };
+      iframe.contentWindow?.postMessage(updateMessage, '*');
+    },
+    destroy(): void {
+      window.removeEventListener('message', handleMessage);
+      el.innerHTML = '';
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implemented a pure-JS iframe embed API following RSCExplorer's pattern, enabling non-React sites to embed go-web components without React dependency.

- **src/embed.ts**: Public `mount()` function (pure JS, zero dependencies) that creates iframe + postMessage communication
- **example/embed.html + embed-entry.tsx**: iframe React app receiving options via postMessage
- **example-iframe-embed/**: Test page demonstrating embed with dynamic example switching
- **Dev improvements**: rsbuild multi-entry build, CORS proxy for testing against go.lynxjs.org

## Key Features

- Zero React dependency on host page — users only import `embed.js`
- Configurable `exampleBasePath` supports cross-origin data sources
- Dev server proxy avoids CORS issues during testing
- Dynamic example switching via `update()` API
- Export via `"./embed"` entry point in package.json

## Test Plan

1. Run `cd example && pnpm dev` (starts on localhost:5969)
2. Open `example-iframe-embed/index.html` in browser
3. Verify example switcher buttons work and data loads from production via proxy