### PR TITLE
feat: add @vue-lynx-example package support to galleries

### DIFF
--- a/example-rspress/scripts/prepare-examples.js
+++ b/example-rspress/scripts/prepare-examples.js
@@ -1,6 +1,10 @@
 /**
- * Fetches all @lynx-example/* packages from the npm registry and extracts
- * them into docs/public/lynx-examples/ with generated example-metadata.json files.
+ * Fetches all @lynx-example/* and @vue-lynx-example/* packages from the npm
+ * registry and extracts them into docs/public/lynx-examples/ with generated
+ * example-metadata.json files.
+ *
+ * Vue examples are placed under a `vue-` prefix so the UI can distinguish them
+ * (e.g. @vue-lynx-example/basic → vue-basic/).
  *
  * No node_modules or package.json dependencies needed — always pulls latest.
  *
@@ -21,27 +25,66 @@ const clean = process.argv.includes('--clean');
 const outputDir = path.join(rootDir, 'docs/public/lynx-examples');
 const lynxEntryFileName = '.lynx.bundle';
 const webEntryFileName = '.web.bundle';
-const exampleGitBaseUrl =
-  'https://github.com/lynx-family/lynx-examples/tree/main';
+
+/** Package scopes to fetch, with their directory prefix and git base URL. */
+const scopes = [
+  {
+    scope: '@lynx-example/',
+    prefix: '',
+    exampleGitBaseUrl:
+      'https://github.com/lynx-family/lynx-examples/tree/main',
+    frameworkVersionKey: 'reactLynxVersion',
+    frameworkDep: '@lynx-js/react',
+  },
+  {
+    scope: '@vue-lynx-example/',
+    prefix: 'vue-',
+    exampleGitBaseUrl:
+      'https://github.com/Huxpro/vue-lynx/tree/main',
+    frameworkVersionKey: 'vueLynxVersion',
+    frameworkDep: 'vue-lynx',
+    // npm search doesn't reliably index new scoped packages, so we maintain
+    // a known list as fallback. The search result is preferred when available.
+    knownPackages: [
+      '@vue-lynx-example/7guis',
+      '@vue-lynx-example/basic',
+      '@vue-lynx-example/gallery',
+      '@vue-lynx-example/hello-world',
+      '@vue-lynx-example/main-thread',
+      '@vue-lynx-example/option-api',
+      '@vue-lynx-example/pinia',
+      '@vue-lynx-example/suspense',
+      '@vue-lynx-example/swiper',
+      '@vue-lynx-example/tailwindcss',
+      '@vue-lynx-example/todomvc',
+      '@vue-lynx-example/transition',
+      '@vue-lynx-example/vue-router',
+    ],
+  },
+];
 
 const ignoreDirs = ['node_modules', '.git', '.turbo'];
 const ignoreFiles = ['.DS_Store', 'LICENSE'];
 
 // --- npm registry helpers ---
 
-async function fetchAllExamplePackages() {
-  const url =
-    'https://registry.npmjs.org/-/v1/search?text=%40lynx-example&size=250';
+async function fetchPackagesForScope(scopeConfig) {
+  const { scope, knownPackages } = scopeConfig;
+  const encoded = encodeURIComponent(scope.slice(0, -1)); // drop trailing /
+  const url = `https://registry.npmjs.org/-/v1/search?text=${encoded}&size=250`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Registry search failed: HTTP ${res.status}`);
   const data = await res.json();
-  return data.objects
+  const found = data.objects
     .map((obj) => obj.package.name)
-    .filter((name) => name.startsWith('@lynx-example/'))
-    .sort();
+    .filter((name) => name.startsWith(scope));
+
+  // npm search may not index new scoped packages; merge with known list
+  const merged = [...new Set([...found, ...(knownPackages ?? [])])].sort();
+  return merged;
 }
 
-async function fetchPackageMeta(pkgName) {
+async function fetchPackageMeta(pkgName, scopeConfig) {
   const res = await fetch(`https://registry.npmjs.org/${pkgName}/latest`);
   if (!res.ok)
     throw new Error(`Failed to fetch ${pkgName}: HTTP ${res.status}`);
@@ -49,7 +92,8 @@ async function fetchPackageMeta(pkgName) {
   return {
     tarball: meta.dist.tarball,
     version: meta.version,
-    reactLynxVersion: meta.dependencies?.['@lynx-js/react'] ?? null,
+    frameworkVersion:
+      meta.dependencies?.[scopeConfig.frameworkDep] ?? null,
   };
 }
 
@@ -111,69 +155,82 @@ async function main() {
     return;
   }
 
-  console.log('Fetching @lynx-example packages from npm registry…');
-  const packages = await fetchAllExamplePackages();
-  if (packages.length === 0) {
-    console.log('No @lynx-example packages found on npm, skipping.');
-    process.exit(0);
-  }
-  console.log(`Found ${packages.length} packages.`);
-
   // Clean and recreate output
   if (fs.existsSync(outputDir)) {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
   fs.mkdirSync(outputDir, { recursive: true });
 
-  for (const pkgName of packages) {
-    const shortName = pkgName.replace('@lynx-example/', '');
-    const destDir = path.join(outputDir, shortName);
+  let totalCount = 0;
 
-    let registryMeta;
+  for (const scopeConfig of scopes) {
+    console.log(`Fetching ${scopeConfig.scope}* packages from npm registry…`);
+    let packages;
     try {
-      registryMeta = await fetchPackageMeta(pkgName);
-      console.log(`  ${shortName}@${registryMeta.version}`);
-      downloadAndExtract(registryMeta.tarball, destDir);
+      packages = await fetchPackagesForScope(scopeConfig);
     } catch (err) {
-      console.warn(`  ⚠ skipping ${shortName}: ${err.message}`);
+      console.warn(`  ⚠ failed to fetch ${scopeConfig.scope}*: ${err.message}`);
       continue;
     }
+    if (packages.length === 0) {
+      console.log(`  No ${scopeConfig.scope}* packages found, skipping.`);
+      continue;
+    }
+    console.log(`  Found ${packages.length} packages.`);
 
-    // Generate metadata
-    const allFiles = getAllFiles(destDir, []);
-    const files = allFiles.map((f) => path.relative(destDir, f));
-    const previewImageRe = /^preview-image\.(png|jpg|jpeg|webp|gif)$/;
-    const filtered = files.filter(
-      (f) => !previewImageRe.test(f) && f !== 'example-metadata.json',
-    );
-    const sorted = sortFiles(filtered);
-    const previewImage = files.find((f) => previewImageRe.test(f));
-    const templateFiles = getTemplateFiles(filtered);
+    for (const pkgName of packages) {
+      const shortName = pkgName.replace(scopeConfig.scope, '');
+      const dirName = `${scopeConfig.prefix}${shortName}`;
+      const destDir = path.join(outputDir, dirName);
 
-    const pkgJsonPath = path.join(destDir, 'package.json');
-    const pkg = fs.existsSync(pkgJsonPath)
-      ? JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
-      : {};
+      let registryMeta;
+      try {
+        registryMeta = await fetchPackageMeta(pkgName, scopeConfig);
+        console.log(`  ${dirName}@${registryMeta.version}`);
+        downloadAndExtract(registryMeta.tarball, destDir);
+      } catch (err) {
+        console.warn(`  ⚠ skipping ${dirName}: ${err.message}`);
+        continue;
+      }
 
-    fs.writeFileSync(
-      path.join(destDir, 'example-metadata.json'),
-      JSON.stringify(
-        {
-          name: pkg.repository?.directory || shortName,
-          version: registryMeta.version,
-          reactLynxVersion: registryMeta.reactLynxVersion,
-          files: sorted,
-          previewImage,
-          templateFiles,
-          exampleGitBaseUrl,
-        },
-        null,
-        2,
-      ),
-    );
+      // Generate metadata
+      const allFiles = getAllFiles(destDir, []);
+      const files = allFiles.map((f) => path.relative(destDir, f));
+      const previewImageRe = /^preview-image\.(png|jpg|jpeg|webp|gif)$/;
+      const filtered = files.filter(
+        (f) => !previewImageRe.test(f) && f !== 'example-metadata.json',
+      );
+      const sorted = sortFiles(filtered);
+      const previewImage = files.find((f) => previewImageRe.test(f));
+      const templateFiles = getTemplateFiles(filtered);
+
+      const pkgJsonPath = path.join(destDir, 'package.json');
+      const pkg = fs.existsSync(pkgJsonPath)
+        ? JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
+        : {};
+
+      fs.writeFileSync(
+        path.join(destDir, 'example-metadata.json'),
+        JSON.stringify(
+          {
+            name: pkg.repository?.directory || shortName,
+            version: registryMeta.version,
+            [scopeConfig.frameworkVersionKey]: registryMeta.frameworkVersion,
+            files: sorted,
+            previewImage,
+            templateFiles,
+            exampleGitBaseUrl: scopeConfig.exampleGitBaseUrl,
+          },
+          null,
+          2,
+        ),
+      );
+
+      totalCount++;
+    }
   }
 
-  console.log(`\nPrepared ${packages.length} examples in docs/public/lynx-examples/`);
+  console.log(`\nPrepared ${totalCount} examples in docs/public/lynx-examples/`);
 }
 
 main().catch((err) => {

--- a/example/rsbuild.config.ts
+++ b/example/rsbuild.config.ts
@@ -37,7 +37,8 @@ function readSSGMarkdown(exampleName: string, defaultFile = 'src/App.tsx'): stri
 
 const ssgPreviews: Record<string, string> = {};
 for (const name of exampleNames) {
-  const md = readSSGMarkdown(name);
+  const defaultFile = name.startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx';
+  const md = readSSGMarkdown(name, defaultFile);
   if (md) ssgPreviews[name] = md;
 }
 

--- a/example/scripts/prepare-examples.js
+++ b/example/scripts/prepare-examples.js
@@ -1,6 +1,10 @@
 /**
- * Fetches all @lynx-example/* packages from the npm registry and extracts
- * them into public/lynx-examples/ with generated example-metadata.json files.
+ * Fetches all @lynx-example/* and @vue-lynx-example/* packages from the npm
+ * registry and extracts them into public/lynx-examples/ with generated
+ * example-metadata.json files.
+ *
+ * Vue examples are placed under a `vue-` prefix so the UI can distinguish them
+ * (e.g. @vue-lynx-example/basic → vue-basic/).
  *
  * No node_modules or package.json dependencies needed — always pulls latest.
  *
@@ -21,27 +25,66 @@ const clean = process.argv.includes('--clean');
 const outputDir = path.join(rootDir, 'public/lynx-examples');
 const lynxEntryFileName = '.lynx.bundle';
 const webEntryFileName = '.web.bundle';
-const exampleGitBaseUrl =
-  'https://github.com/lynx-family/lynx-examples/tree/main';
+
+/** Package scopes to fetch, with their directory prefix and git base URL. */
+const scopes = [
+  {
+    scope: '@lynx-example/',
+    prefix: '',
+    exampleGitBaseUrl:
+      'https://github.com/lynx-family/lynx-examples/tree/main',
+    frameworkVersionKey: 'reactLynxVersion',
+    frameworkDep: '@lynx-js/react',
+  },
+  {
+    scope: '@vue-lynx-example/',
+    prefix: 'vue-',
+    exampleGitBaseUrl:
+      'https://github.com/Huxpro/vue-lynx/tree/main',
+    frameworkVersionKey: 'vueLynxVersion',
+    frameworkDep: 'vue-lynx',
+    // npm search doesn't reliably index new scoped packages, so we maintain
+    // a known list as fallback. The search result is preferred when available.
+    knownPackages: [
+      '@vue-lynx-example/7guis',
+      '@vue-lynx-example/basic',
+      '@vue-lynx-example/gallery',
+      '@vue-lynx-example/hello-world',
+      '@vue-lynx-example/main-thread',
+      '@vue-lynx-example/option-api',
+      '@vue-lynx-example/pinia',
+      '@vue-lynx-example/suspense',
+      '@vue-lynx-example/swiper',
+      '@vue-lynx-example/tailwindcss',
+      '@vue-lynx-example/todomvc',
+      '@vue-lynx-example/transition',
+      '@vue-lynx-example/vue-router',
+    ],
+  },
+];
 
 const ignoreDirs = ['node_modules', '.git', '.turbo'];
 const ignoreFiles = ['.DS_Store', 'LICENSE'];
 
 // --- npm registry helpers ---
 
-async function fetchAllExamplePackages() {
-  const url =
-    'https://registry.npmjs.org/-/v1/search?text=%40lynx-example&size=250';
+async function fetchPackagesForScope(scopeConfig) {
+  const { scope, knownPackages } = scopeConfig;
+  const encoded = encodeURIComponent(scope.slice(0, -1)); // drop trailing /
+  const url = `https://registry.npmjs.org/-/v1/search?text=${encoded}&size=250`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Registry search failed: HTTP ${res.status}`);
   const data = await res.json();
-  return data.objects
+  const found = data.objects
     .map((obj) => obj.package.name)
-    .filter((name) => name.startsWith('@lynx-example/'))
-    .sort();
+    .filter((name) => name.startsWith(scope));
+
+  // npm search may not index new scoped packages; merge with known list
+  const merged = [...new Set([...found, ...(knownPackages ?? [])])].sort();
+  return merged;
 }
 
-async function fetchPackageMeta(pkgName) {
+async function fetchPackageMeta(pkgName, scopeConfig) {
   const res = await fetch(`https://registry.npmjs.org/${pkgName}/latest`);
   if (!res.ok)
     throw new Error(`Failed to fetch ${pkgName}: HTTP ${res.status}`);
@@ -49,7 +92,8 @@ async function fetchPackageMeta(pkgName) {
   return {
     tarball: meta.dist.tarball,
     version: meta.version,
-    reactLynxVersion: meta.dependencies?.['@lynx-js/react'] ?? null,
+    frameworkVersion:
+      meta.dependencies?.[scopeConfig.frameworkDep] ?? null,
   };
 }
 
@@ -111,69 +155,82 @@ async function main() {
     return;
   }
 
-  console.log('Fetching @lynx-example packages from npm registry…');
-  const packages = await fetchAllExamplePackages();
-  if (packages.length === 0) {
-    console.log('No @lynx-example packages found on npm, skipping.');
-    process.exit(0);
-  }
-  console.log(`Found ${packages.length} packages.`);
-
   // Clean and recreate output
   if (fs.existsSync(outputDir)) {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
   fs.mkdirSync(outputDir, { recursive: true });
 
-  for (const pkgName of packages) {
-    const shortName = pkgName.replace('@lynx-example/', '');
-    const destDir = path.join(outputDir, shortName);
+  let totalCount = 0;
 
-    let registryMeta;
+  for (const scopeConfig of scopes) {
+    console.log(`Fetching ${scopeConfig.scope}* packages from npm registry…`);
+    let packages;
     try {
-      registryMeta = await fetchPackageMeta(pkgName);
-      console.log(`  ${shortName}@${registryMeta.version}`);
-      downloadAndExtract(registryMeta.tarball, destDir);
+      packages = await fetchPackagesForScope(scopeConfig);
     } catch (err) {
-      console.warn(`  ⚠ skipping ${shortName}: ${err.message}`);
+      console.warn(`  ⚠ failed to fetch ${scopeConfig.scope}*: ${err.message}`);
       continue;
     }
+    if (packages.length === 0) {
+      console.log(`  No ${scopeConfig.scope}* packages found, skipping.`);
+      continue;
+    }
+    console.log(`  Found ${packages.length} packages.`);
 
-    // Generate metadata
-    const allFiles = getAllFiles(destDir, []);
-    const files = allFiles.map((f) => path.relative(destDir, f));
-    const previewImageRe = /^preview-image\.(png|jpg|jpeg|webp|gif)$/;
-    const filtered = files.filter(
-      (f) => !previewImageRe.test(f) && f !== 'example-metadata.json',
-    );
-    const sorted = sortFiles(filtered);
-    const previewImage = files.find((f) => previewImageRe.test(f));
-    const templateFiles = getTemplateFiles(filtered);
+    for (const pkgName of packages) {
+      const shortName = pkgName.replace(scopeConfig.scope, '');
+      const dirName = `${scopeConfig.prefix}${shortName}`;
+      const destDir = path.join(outputDir, dirName);
 
-    const pkgJsonPath = path.join(destDir, 'package.json');
-    const pkg = fs.existsSync(pkgJsonPath)
-      ? JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
-      : {};
+      let registryMeta;
+      try {
+        registryMeta = await fetchPackageMeta(pkgName, scopeConfig);
+        console.log(`  ${dirName}@${registryMeta.version}`);
+        downloadAndExtract(registryMeta.tarball, destDir);
+      } catch (err) {
+        console.warn(`  ⚠ skipping ${dirName}: ${err.message}`);
+        continue;
+      }
 
-    fs.writeFileSync(
-      path.join(destDir, 'example-metadata.json'),
-      JSON.stringify(
-        {
-          name: pkg.repository?.directory || shortName,
-          version: registryMeta.version,
-          reactLynxVersion: registryMeta.reactLynxVersion,
-          files: sorted,
-          previewImage,
-          templateFiles,
-          exampleGitBaseUrl,
-        },
-        null,
-        2,
-      ),
-    );
+      // Generate metadata
+      const allFiles = getAllFiles(destDir, []);
+      const files = allFiles.map((f) => path.relative(destDir, f));
+      const previewImageRe = /^preview-image\.(png|jpg|jpeg|webp|gif)$/;
+      const filtered = files.filter(
+        (f) => !previewImageRe.test(f) && f !== 'example-metadata.json',
+      );
+      const sorted = sortFiles(filtered);
+      const previewImage = files.find((f) => previewImageRe.test(f));
+      const templateFiles = getTemplateFiles(filtered);
+
+      const pkgJsonPath = path.join(destDir, 'package.json');
+      const pkg = fs.existsSync(pkgJsonPath)
+        ? JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
+        : {};
+
+      fs.writeFileSync(
+        path.join(destDir, 'example-metadata.json'),
+        JSON.stringify(
+          {
+            name: pkg.repository?.directory || shortName,
+            version: registryMeta.version,
+            [scopeConfig.frameworkVersionKey]: registryMeta.frameworkVersion,
+            files: sorted,
+            previewImage,
+            templateFiles,
+            exampleGitBaseUrl: scopeConfig.exampleGitBaseUrl,
+          },
+          null,
+          2,
+        ),
+      );
+
+      totalCount++;
+    }
   }
 
-  console.log(`\nPrepared ${packages.length} examples in public/lynx-examples/`);
+  console.log(`\nPrepared ${totalCount} examples in public/lynx-examples/`);
 }
 
 main().catch((err) => {

--- a/example/src/embed-entry.tsx
+++ b/example/src/embed-entry.tsx
@@ -163,7 +163,7 @@ function EmbedApp() {
         <Go
           key={`${options.exampleBasePath}/${options.example}`}
           example={options.example}
-          defaultFile={options.defaultFile ?? 'src/App.tsx'}
+          defaultFile={options.defaultFile ?? (options.example.startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx')}
           defaultTab={options.defaultTab}
           img={options.img}
           defaultEntryFile={options.defaultEntryFile}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -469,27 +469,25 @@ function getJsonHighlighter() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Convert PascalCase / camelCase to kebab-case. */
-function toKebab(s: string) {
-  return s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
-}
-
 /**
  * Given an entry name (from bundle filename, e.g. "gallery-autoscroll") and the
- * full file list, find the actual source directory and index file.  Rspeedy may
- * kebab-case PascalCase directory names in the output bundle, so we can't just
- * use `src/${entryName}/` directly.
+ * full file list, find the actual source directory and index file.
+ *
+ * Entry keys in lynx.config.ts may differ in casing/hyphenation from source
+ * directory names (e.g. entry "gallery-autoscroll" → dir "GalleryAutoScroll"),
+ * so we normalize both sides by stripping hyphens and comparing lowercase.
  */
 function findEntrySourceDir(
   entryName: string,
   files: string[],
 ): { srcDir: string; indexFile: string | undefined } | undefined {
-  // Collect src/*/index.* candidates
+  const normalize = (s: string) => s.replace(/-/g, '').toLowerCase();
+  const target = normalize(entryName);
   for (const f of files) {
     const m = f.match(/^src\/([^/]+)\/index\.\w+$/);
     if (m) {
       const dirName = m[1];
-      if (dirName === entryName || toKebab(dirName) === entryName) {
+      if (normalize(dirName) === target) {
         return { srcDir: `src/${dirName}`, indexFile: f };
       }
     }

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -466,6 +466,38 @@ function getJsonHighlighter() {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert PascalCase / camelCase to kebab-case. */
+function toKebab(s: string) {
+  return s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
+ * Given an entry name (from bundle filename, e.g. "gallery-autoscroll") and the
+ * full file list, find the actual source directory and index file.  Rspeedy may
+ * kebab-case PascalCase directory names in the output bundle, so we can't just
+ * use `src/${entryName}/` directly.
+ */
+function findEntrySourceDir(
+  entryName: string,
+  files: string[],
+): { srcDir: string; indexFile: string | undefined } | undefined {
+  // Collect src/*/index.* candidates
+  for (const f of files) {
+    const m = f.match(/^src\/([^/]+)\/index\.\w+$/);
+    if (m) {
+      const dirName = m[1];
+      if (dirName === entryName || toKebab(dirName) === entryName) {
+        return { srcDir: `src/${dirName}`, indexFile: f };
+      }
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
 // App
 // ---------------------------------------------------------------------------
 
@@ -481,7 +513,9 @@ function App() {
     initial.tab ?? 'web',
   );
   const [example, setExample] = useState(initial.example ?? 'hello-world');
-  const [defaultFile, setDefaultFile] = useState(initial.file ?? 'src/App.tsx');
+  const [defaultFile, setDefaultFile] = useState(
+    initial.file ?? ((initial.example ?? 'hello-world').startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx'),
+  );
   const [copied, setCopied] = useState(false);
   const [exampleSearch, setExampleSearch] = useState('');
   const [entrySearch, setEntrySearch] = useState('');
@@ -614,8 +648,9 @@ function App() {
           setSelectedEntry(first.name);
           setDefaultEntryFile(first.file);
           if (data.templateFiles.length > 1) {
-            setDefaultFile(`src/${first.name}/index.tsx`);
-            setEntryFilter(`src/${first.name}`);
+            const found = findEntrySourceDir(first.name, data.files ?? []);
+            setDefaultFile(found?.indexFile ?? `src/${first.name}/index.tsx`);
+            setEntryFilter(found?.srcDir ?? `src/${first.name}`);
           } else {
             setEntryFilter('');
           }
@@ -654,8 +689,9 @@ function App() {
       if (entry) {
         setDefaultEntryFile(entry.file);
         if (metadata!.templateFiles.length > 1) {
-          setDefaultFile(`src/${entryName}/index.tsx`);
-          setEntryFilter(`src/${entryName}`);
+          const found = findEntrySourceDir(entryName, metadata!.files ?? []);
+          setDefaultFile(found?.indexFile ?? `src/${entryName}/index.tsx`);
+          setEntryFilter(found?.srcDir ?? `src/${entryName}`);
         }
       }
     },

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1106,6 +1106,11 @@ function App() {
                     react {metadata.reactLynxVersion}
                   </span>
                 )}
+                {metadata?.vueLynxVersion && (
+                  <span className="example-tag example-tag-vue">
+                    vue-lynx {metadata.vueLynxVersion}
+                  </span>
+                )}
                 {metadata?.templateFiles?.length > 0 && (
                   <span
                     className={`example-tag ${

--- a/example/src/styles.css
+++ b/example/src/styles.css
@@ -266,6 +266,11 @@ html[style*='color-scheme: dark'] .shiki span {
   color: #c026d3;
 }
 
+.example-tag-vue {
+  background: #42b88320;
+  color: #42b883;
+}
+
 .example-tag-web {
   background: #10b98120;
   color: #059669;


### PR DESCRIPTION
Extends the example auto-discovery system to fetch and display @vue-lynx-example packages from npm alongside @lynx-example packages. Vue examples are prefixed with 'vue-' for UI distinction and tracked with their own vueLynxVersion metadata field.

Changes include: refactored prepare-examples scripts to support multiple scopes with configurable prefixes and framework dependencies, added Vue-specific file detection in SSG preview generation, and added vueLynxVersion tag display with Vue brand color styling (#42b883).

The implementation mirrors the existing React example pattern and uses a knownPackages fallback list to handle npm search API limitations with new scoped packages.