### PR TITLE
fix: update CSS custom properties on preview panel resize

### DIFF
--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -107,10 +107,27 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       pixelWidth: Math.round(w * window.devicePixelRatio),
       pixelHeight: Math.round(h * window.devicePixelRatio),
     };
-    // @ts-ignore – update CSS custom properties for viewport-unit rewriting
-    lynxViewRef.current.injectStyleRules = [
-      `:host { --lynx-vh: ${h}px; --lynx-vw: ${w}px; }`,
-    ];
+
+    const rule = `:host { --lynx-vh: ${h}px; --lynx-vw: ${w}px; }`;
+
+    // Set injectStyleRules for initial template load
+    // @ts-ignore
+    lynxViewRef.current.injectStyleRules = [rule];
+
+    // Also update directly in the shadow DOM for live resize,
+    // since injectStyleRules only takes effect at template load time.
+    const shadow = (lynxViewRef.current as unknown as HTMLElement).shadowRoot;
+    if (shadow) {
+      let styleEl = shadow.getElementById(
+        '__lynx-viewport-vars',
+      ) as HTMLStyleElement | null;
+      if (!styleEl) {
+        styleEl = document.createElement('style');
+        styleEl.id = '__lynx-viewport-vars';
+        shadow.prepend(styleEl);
+      }
+      styleEl.textContent = rule;
+    }
   }, []);
 
   // Set URL only after runtime is ready AND element is mounted

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -110,24 +110,16 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
 
     const rule = `:host { --lynx-vh: ${h}px; --lynx-vw: ${w}px; }`;
 
-    // Set injectStyleRules for initial template load
+    // Set injectStyleRules for initial template load (before shadow DOM exists)
     // @ts-ignore
     lynxViewRef.current.injectStyleRules = [rule];
 
-    // Also update directly in the shadow DOM for live resize,
-    // since injectStyleRules only takes effect at template load time.
-    const shadow = (lynxViewRef.current as unknown as HTMLElement).shadowRoot;
-    if (shadow) {
-      let styleEl = shadow.getElementById(
-        '__lynx-viewport-vars',
-      ) as HTMLStyleElement | null;
-      if (!styleEl) {
-        styleEl = document.createElement('style');
-        styleEl.id = '__lynx-viewport-vars';
-        shadow.prepend(styleEl);
-      }
-      styleEl.textContent = rule;
-    }
+    // Also set CSS custom properties directly on the host element's inline
+    // style for live resize updates. Inline custom properties on the host
+    // are inherited by shadow DOM descendants immediately.
+    const el = lynxViewRef.current as unknown as HTMLElement;
+    el.style.setProperty('--lynx-vh', `${h}px`);
+    el.style.setProperty('--lynx-vw', `${w}px`);
   }, []);
 
   // Set URL only after runtime is ready AND element is mounted


### PR DESCRIPTION
The --lynx-vh and --lynx-vw custom properties inside <lynx-view> now dynamically update when the preview panel is resized. Previously, injectStyleRules only took effect at template load time, preventing viewport unit calculations from responding to dimension changes.

We now maintain a <style> element in the shadow DOM and update it directly on each resize event, ensuring vh/vw viewport units work correctly as the container is resized.