### PR TITLE
feat: runtime npm registry fetching for lynx-example versions

### DIFF
--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -14,129 +14,6 @@ importers:
       '@douyinfe/semi-ui':
         specifier: ^2.75.0
         version: 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/accessibility':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/action-sheet':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/animation':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/bankcards':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/composing-elements':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/css':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/css-api':
-        specifier: 0.7.1
-        version: 0.7.1(@types/react@18.3.28)
-      '@lynx-example/design-guide':
-        specifier: 0.4.2
-        version: 0.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/element-manipulation':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/event':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/fetch':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/frame':
-        specifier: 0.1.2
-        version: 0.1.2(@types/react@18.3.28)
-      '@lynx-example/gallery':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/hello-world':
-        specifier: 0.6.8
-        version: 0.6.8(@types/react@18.3.28)
-      '@lynx-example/i18n':
-        specifier: 0.5.5
-        version: 0.5.5(@types/react@18.3.28)
-      '@lynx-example/ifr':
-        specifier: 0.5.5
-        version: 0.5.5(@types/react@18.3.28)
-      '@lynx-example/image':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/input':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/layout':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/lazy-bundle':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/list':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/local-storage':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/lynx-api':
-        specifier: 0.1.7
-        version: 0.1.7(@types/react@18.3.28)
-      '@lynx-example/main-thread':
-        specifier: 0.4.7
-        version: 0.4.7(@types/react@18.3.28)
-      '@lynx-example/native-element':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/networking':
-        specifier: 0.4.7
-        version: 0.4.7(@types/react@18.3.28)(react@18.3.1)
-      '@lynx-example/overlay':
-        specifier: latest
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/page':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/performance-api':
-        specifier: 0.7.0
-        version: 0.7.0(@types/react@18.3.28)
-      '@lynx-example/react-lifecycle':
-        specifier: 0.5.6
-        version: 0.5.6(@types/react@18.3.28)
-      '@lynx-example/refresh':
-        specifier: latest
-        version: 0.6.9(@types/react@18.3.28)
-      '@lynx-example/scroll-view':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/svg':
-        specifier: latest
-        version: 0.6.8(@types/react@18.3.28)
-      '@lynx-example/swiper':
-        specifier: 0.5.6
-        version: 0.5.6(@types/react@18.3.28)
-      '@lynx-example/tailwindcss':
-        specifier: 0.4.3
-        version: 0.4.3(@types/react@18.3.28)
-      '@lynx-example/tanstack-router':
-        specifier: 0.6.8
-        version: 0.6.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-example/text':
-        specifier: 0.6.6
-        version: 0.6.6(@types/react@18.3.28)
-      '@lynx-example/textarea':
-        specifier: 0.6.7
-        version: 0.6.7(@types/react@18.3.28)
-      '@lynx-example/title-bar-view':
-        specifier: latest
-        version: 0.6.11(@types/react@18.3.28)
-      '@lynx-example/view':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
-      '@lynx-example/zustand':
-        specifier: 0.6.5
-        version: 0.6.5(@types/react@18.3.28)
       '@lynx-js/web-core':
         specifier: npm:@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5
         version: '@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.3(tslib@2.8.1))'
@@ -273,196 +150,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hongzhiyuan/preact@10.24.0-00213bad':
-    resolution: {integrity: sha512-bHWp4ZDK5ZimcY+bTWw3S3xGiB8eROpZj0RK3FClNIaTOajb0b11CsT3K+pdeakgPgq1jWN3T2e2rfrPm40JsQ==}
-
-  '@hongzhiyuan/preact@10.28.0-fc4af453':
-    resolution: {integrity: sha512-TrM2g079OZN1poroDnU2kQd1gNUB1DMfVoKyz23AE3hZvl9ypRgG2MdgxAJtwT5u3BmYvI4Z0EbdpJTdf428IQ==}
-
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@lynx-example/accessibility@0.6.5':
-    resolution: {integrity: sha512-q5T5VjB/EdcOb3Ek1AXTBFPaIhOaSSkym9dAVemy7B95xQxkRn+CE2WcP99cT9rI4UZ9hWeuz6HY47pyMmUevA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/action-sheet@0.6.5':
-    resolution: {integrity: sha512-sTBh2BdkepFvZ85ClIAlLjgQ5kQGwnVOAQp8gzKminr2TKbYPcri6rUk6K10mhZScTIhguISIr/US4CzngmmIA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/animation@0.6.7':
-    resolution: {integrity: sha512-U4HjIj72uS7PAScyP1z5vMNZsvSzn/9dZYjP1229h8Lic/OUH3FOG0xIsBq/TsP7bMRm7fw8W1DOSpdD2eF6qw==}
-
-  '@lynx-example/bankcards@0.6.5':
-    resolution: {integrity: sha512-Vc3ooEb+s7TXlcGNtStdO9pJVkNte3quiiXbtrUkDcXi7uDKJxcElNP7g4EyArlTbmA6d3T0dHMXEScYGYP4Uw==}
-
-  '@lynx-example/composing-elements@0.6.5':
-    resolution: {integrity: sha512-McxesZ9cBeCDE9wkfW/55UGB7Bh5Gwceq/WZ1aKONk8LmQqdtrfLF/5jwfMOu5NYUl+2g20yPmvudFW1bluT2A==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/css-api@0.7.1':
-    resolution: {integrity: sha512-HVhnUjr+LDlRaxMpUh51laYgR2U3k8IsbSfkitVFHLsEC2sF+6/RqTCGoIRhYGozjqasgWtNtVoNqCXXWxGpwQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/css@0.6.5':
-    resolution: {integrity: sha512-+x3e1ni+jAJ96tdB1mzTHamSO3vKcbO2nl3hAny39qU6e6Q452z6P1k/Wr9Z6gJtD1tgSgdZYnRaNruFHEl9eg==}
-
-  '@lynx-example/design-guide@0.4.2':
-    resolution: {integrity: sha512-VV7ufIpazK2Gg4NwT23W404SSfieHyegjgryEARv0H5PaoPXH7UGRDXXcPr5baI8zbwdR29C7xTOwXBE9f3xgA==}
-
-  '@lynx-example/element-manipulation@0.6.6':
-    resolution: {integrity: sha512-KP62Zsg0FfOQD3g05uHxv/bzT73DC8pru5TBxAZBx71MtKVgQQTmyPsfSTkb1Ox86b3GgjfxfouwP5Bb3+sHFQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/event@0.6.6':
-    resolution: {integrity: sha512-bNmTw4UAmuU0voB8VfpaERSsJ7BsFivUm4NCkbx3fJtqsYDSthMn/FZyL/W8Im3GPBbDhjmaGbBeyq9wZLZFmA==}
-
-  '@lynx-example/fetch@0.6.5':
-    resolution: {integrity: sha512-UTPAbEQd8INicwnQfRUTy5lKiW8axbZpRqy5Dr7vgOAXHbN3VPldeVo91EFMGZZf5tz+S83R/ivtnsebEyztIg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/frame@0.1.2':
-    resolution: {integrity: sha512-O2n1JnMUJMvM+0xzfQLBiXm39OyCR6SgIN8uo2THWmWoyAbCts/PDgmURWTX1tKDfBKypnl4Z0/yY4PZR1X0dg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/gallery@0.6.7':
-    resolution: {integrity: sha512-erXkDalISkUTToHf8eooYm9QdGY1uNQeRhaJNzmu5eUQ1mJRtPfaaAm8YmQusP5qfEN2ajmPRZ81vo4AUW/4Xg==}
-
-  '@lynx-example/hello-world@0.6.8':
-    resolution: {integrity: sha512-MgsovxJHgxCr91sOJPD0KKV0NM8aRk4IUWRsz2tA5ZP3FhgB5lj+N6NouVVDYUPbvciSOzDJDJ3gGbpu97AeSQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/i18n@0.5.5':
-    resolution: {integrity: sha512-DTs/YEVEZOWmda3U1z8kN7lHg1tRWsmWJlh33mprpZ27h0xzawEvEVUHAiARQVoZ8SgQFfJkBShiOHNBpdzj0g==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/ifr@0.5.5':
-    resolution: {integrity: sha512-RqJy4XR33yyYDFWtI6PhWkqpMjMbrlZseXQrm1H1GK8aFS5VTBA09QkzteSvmOXn+cHXZj/HQk5RIlULcNfJfw==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/image@0.6.5':
-    resolution: {integrity: sha512-Ai6l06izU4nOQeNO5ZedcCXZ4Sy8qo9NhoqncEqcU1HHALaGJeDavW6f9kWsTtixS2NTvyf92ltUxXOFKWFHaA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/input@0.6.6':
-    resolution: {integrity: sha512-iqkkWexD+9uzWlP2W/2cbGPXw+0bjiU6bOjg0Lp0EVcTq2aoxTRns9OZ3EBVtW8WqpGxxgp7OgA9lZqeQEfr5A==}
-
-  '@lynx-example/layout@0.6.5':
-    resolution: {integrity: sha512-wcyRxwhYlCOGzxU+wSSj2ONQ0G6v1PI32tj7sH33Ws1RriNaKrFvufYgn0tz2aT+Rk+FWMFFc1IECENyLO8j3Q==}
-
-  '@lynx-example/lazy-bundle@0.6.5':
-    resolution: {integrity: sha512-tROVE5g6CE6Ep1GsZQAJNq5sABQNRa7eBAOlS/KrScx6cbfc/xSse4NxE2z9PtQeqwQh/BXpRstdMJsnywfS0Q==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/list@0.6.5':
-    resolution: {integrity: sha512-SayPu4/FKHdZoa53Q3ZLC/VtyIdW+49fOR4QjHP1s3yH0d8fH9wyN+4miyCG/wpLz520HEHvSS3pKf1f1ql6Dg==}
-
-  '@lynx-example/local-storage@0.6.6':
-    resolution: {integrity: sha512-V56IpWk7iS6qPorKZ485JNyOzdsC4zcl/aPdEcEQl3PFrStiBr/CcSLNnln1XbCVp3dsmewMgMmBP/39Ie5Ocg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/lynx-api@0.1.7':
-    resolution: {integrity: sha512-WMLcWgWBn/DminNaWD0UV6Ro58odW/rqIwlsH8netqUgg3ZL6p6Gq+s2f8UJxXk4WacFu2DYYlSMpbNDFEOcyg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/main-thread@0.4.7':
-    resolution: {integrity: sha512-7PMUhNlfX7lIM1SNeJF4PJBg7uyOs76iY7qWGsv/8gRiHuB4tu7UBtqb5X69Oy5kBKpZfZkcAor0F/ECsNQBSw==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/native-element@0.6.7':
-    resolution: {integrity: sha512-hLIzo9Sdb/4ZeDZOQoiPLj8YQS9N6CLIg766LkfiYFw6qbQjnnuK7MYmb65Fl/Sc/IDb5tG1Xv5WEMBacVg0iQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/networking@0.4.7':
-    resolution: {integrity: sha512-aRThfbd3h0Ph+mtv/yqZP9bXEP0AsWLdFNaIaFXbGNton9oTd8R+VKo5g4E5IrL0FzC4iWdVz/k+yxDoXNMZPg==}
-
-  '@lynx-example/overlay@0.6.7':
-    resolution: {integrity: sha512-HMKZc+mp0m1m95O+CRLsJ2831mqZ/j8S5NN1NUr+RHBJdT+XqHlOzrQaZI75Q1eeqI8btKNlF4nuaaZtFLrIIQ==}
-
-  '@lynx-example/page@0.6.5':
-    resolution: {integrity: sha512-qiBGaofERbCsaifh9UR1VrEI1GrOfzKtniW4GkjQFjCnZKUaaL4e4v7HzKa1gMMsenkTprigAJvqD08px52HmQ==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/performance-api@0.7.0':
-    resolution: {integrity: sha512-xpdzvFc3pukN1+N6p6pVsFzgDA+73+eFYyWV3TrKmXqeeQ6wRoxczrL7/rkjjCvtBZbTEX5h0fklu/GrdvOrQQ==}
-
-  '@lynx-example/react-lifecycle@0.5.6':
-    resolution: {integrity: sha512-woLhBDufmldCQ4xn9FaeknHTuJmmpLGy9m56HWN5QO+qu6gbEE84WDaR88I0Y67fZ/gIu9xkq7fy+Ukl5z8RqA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/refresh@0.6.9':
-    resolution: {integrity: sha512-A7Vte9us1iJSTLVoiklyHpwtIs9UlrONePZqLH9VmvVSjXy6ZkRQnuh0cIXdXOm+k+cfon9aZ6gIPSKUtMFm9w==}
-
-  '@lynx-example/scroll-view@0.6.5':
-    resolution: {integrity: sha512-jcfK33ZRxVGi3FiCllEy0CUK97mOU/Xd9V70KYAD9Jmkhl/BiOdLDe/QZP02cs+UCvSSNrA1wJE10LnnoNIHfg==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/svg@0.6.8':
-    resolution: {integrity: sha512-9CsQeY4yeDmGFH0Vc1A5H03EJB4bgMoYAbf/G5CTpgcLEBSA1BGTRQIglHN2aGbCBhd5zx6g0Tn6ciOeFUKQKg==}
-
-  '@lynx-example/swiper@0.5.6':
-    resolution: {integrity: sha512-VB+mo2KU5MKMKBH1GG0Bu9so9itCe7tAnFJHVZdo8HERTzJZ1jFLs/FxZy9VfKMzqqgtWCSPi67/8uotBL+m/A==}
-
-  '@lynx-example/tailwindcss@0.4.3':
-    resolution: {integrity: sha512-lbStOF7Etec/ARCmozvOYs57MdyCf8Lj3iU1NF8fH/O7KAcmKTaV4G3P5BkRIJg4KQr01XtSlaYkb/+c0hfA1w==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/tanstack-router@0.6.8':
-    resolution: {integrity: sha512-bw0f3LGsSxShYw9o0s0rN0YJV2ezIBdQzgzALmeRYKj8ftfYyzJHceqxfoWUsmB37Kv8nQQhuKUFWVx9Q+DdaA==}
-
-  '@lynx-example/text@0.6.6':
-    resolution: {integrity: sha512-Kb9f1S34+Wdfzv3SyTQaWtt2DtAE+ZrNFqO3fMA+ySHiLSMKKFG1QLRb/XpGko0/BxxnVBj08mUu1YskrzLdsg==}
-
-  '@lynx-example/textarea@0.6.7':
-    resolution: {integrity: sha512-sceHiWkljTlQFjSr2AMBVSqNrQzGItE0zcPDwdtX02m1AVtqijoOyTei7LxbwlY7uNkybyi2N1F1YEyLZ5pKxQ==}
-
-  '@lynx-example/title-bar-view@0.6.11':
-    resolution: {integrity: sha512-r6BqhLij0b1lOvcZP3bdo1K4FyyCB+i7KVneatQyRcrrHJ0Rf73cNQfdtoYXEJnOmz4maMp8VILtU+w4f8aINQ==}
-
-  '@lynx-example/view@0.6.5':
-    resolution: {integrity: sha512-dSs0FhogEiuemWhV9QTFfPIQoKu+LW9wQN+JKxWbKvi1/eYP6PgZXm4ohDlSqBKdSVhw2Ok0LNgpPWmwdLV9HA==}
-    engines: {node: '>=18'}
-
-  '@lynx-example/zustand@0.6.5':
-    resolution: {integrity: sha512-zypS4TpmlyEc7u2ATutSewH8jEnMhL75RwQgvt2OFXHqfyj0gMJdu1ygP6OEoerx8wdMQUjO27I2HYvmwbhOwQ==}
-
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
 
   '@lynx-js/offscreen-document-canary@0.1.4':
     resolution: {integrity: sha512-yqJmCBjKGq4Eil7IgBk5LKIbxN/KSn61KKxmPyrrz1MAiBmfyHLhHrd3V8XXKvI4JpmOG5q67BQY9VEuX5u0ZA==}
-
-  '@lynx-js/react-use@0.1.3':
-    resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
-    peerDependencies:
-      '@lynx-js/react': '>=0.105.1'
-
-  '@lynx-js/react@0.115.1':
-    resolution: {integrity: sha512-htZXSUmKI/7NI5hPMBcv2zN8CRJ+Yq8TaHX2nk3oJyZzQdIzo+L9IbtVx1GwRRMsC3PmkdKX9Wiqgtjle0MolQ==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
-
-  '@lynx-js/react@0.115.3':
-    resolution: {integrity: sha512-EXoQ01ctzilFZfSfWAZ14DKrYla9AIxZItRuKkAIRwlh8y6207xQ9NmicdSCtQyPZ0JBCQ9KtTzXPvTPZzFwsA==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
-
-  '@lynx-js/react@0.116.4':
-    resolution: {integrity: sha512-U/4D/TtD1JLX+Wl0dyzAY/SFYnLln7BG6EacXnIGS0qHYDvdj+V1vmLmeYIJe6BxxVFMwMBjIAMRJNMxU+uoYA==}
-    peerDependencies:
-      '@lynx-js/types': '*'
-      '@types/react': ^18
-    peerDependenciesMeta:
-      '@lynx-js/types':
-        optional: true
 
   '@lynx-js/web-constants-canary@0.19.7-canary-20260126-5e7e43c5':
     resolution: {integrity: sha512-zIg6NtG6MuNvePUF39JRLRFGtYiiyrwO/aig1Ais4XMLFhQCuPlFu99DJUtewHA2FdFtE6TcFllkDcpVUU8dVw==}
@@ -729,38 +421,6 @@ packages:
   '@swc/helpers@0.5.19':
     resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
-  '@tanstack/history@1.139.0':
-    resolution: {integrity: sha512-l6wcxwDBeh/7Dhles23U1O8lp9kNJmAb2yNjekR6olZwCRNAVA8TCXlVCrueELyFlYZqvQkh0ofxnzG62A1Kkg==}
-    engines: {node: '>=12'}
-
-  '@tanstack/query-core@5.90.11':
-    resolution: {integrity: sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==}
-
-  '@tanstack/react-query@5.90.11':
-    resolution: {integrity: sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==}
-    peerDependencies:
-      react: ^18 || ^19
-
-  '@tanstack/react-router@1.139.14':
-    resolution: {integrity: sha512-eNQvFu2F+7tjCRLUiXWCHZv5OhNjn/0LP6k7o5IiOg5+JR1TOu2ztxhk1EqZfBHrebuenTFQHyFXfXVDi+3wkA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-
-  '@tanstack/react-store@0.8.1':
-    resolution: {integrity: sha512-XItJt+rG8c5Wn/2L/bnxys85rBpm0BfMbhb4zmPVLXAKY9POrp1xd6IbU4PKoOI+jSEGc3vntPRfLGSgXfE2Ig==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/router-core@1.139.14':
-    resolution: {integrity: sha512-OjNeTlAti75G+8djiAaQsfio4mpnn9HBFfION15nzIgmv+VX6wOS/OyOYKkaKf+QSecXcjajyV3HHc8YornH/A==}
-    engines: {node: '>=12'}
-
-  '@tanstack/store@0.8.1':
-    resolution: {integrity: sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw==}
-
   '@tiptap/core@3.20.1':
     resolution: {integrity: sha512-SwkPEWIfaDEZjC8SEIi4kZjqIYUbRgLUHUuQezo5GbphUNC8kM1pi3C3EtoOPtxXrEbY6e4pWEzW54Pcrd+rVA==}
     peerDependencies:
@@ -956,9 +616,6 @@ packages:
   '@types/jasmine@3.10.19':
     resolution: {integrity: sha512-Bz6P2XoeIN13AhvVe0nS7+m2RfxVllETDjFQ/s6lyEwEfIVpPCc1Q8vPdFopFAOU5mzrU1zypXJ1xGDl5EVU9Q==}
 
-  '@types/js-cookie@2.2.7':
-    resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
-
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
@@ -1002,9 +659,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
-  '@xobotyi/scrollbar-width@1.9.5':
-    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1073,9 +727,6 @@ packages:
   compute-scroll-into-view@1.0.20:
     resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
 
-  cookie-es@2.0.0:
-    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
-
   copy-text-to-clipboard@2.2.0:
     resolution: {integrity: sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ==}
     engines: {node: '>=6'}
@@ -1088,13 +739,6 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
-
-  css-in-js-utils@3.1.0:
-    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1187,18 +831,9 @@ packages:
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
-
-  fast-shallow-equal@1.0.0:
-    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-
-  fastest-stable-stringify@2.0.2:
-    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1225,20 +860,11 @@ packages:
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
-  i18next@23.16.8:
-    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
-
-  immer@10.1.1:
-    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
-
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  inline-style-prefixer@7.0.1:
-    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1264,22 +890,12 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  isbot@5.1.36:
-    resolution: {integrity: sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ==}
-    engines: {node: '>=18'}
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  jsbi@4.3.2:
-    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1370,9 +986,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -1488,20 +1101,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nano-css@5.6.2:
-    resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   node-addon-api@7.1.1:
@@ -1640,18 +1242,6 @@ packages:
       react: '>= 16.3'
       react-dom: '>= 16.3'
 
-  react-universal-interface@0.6.2:
-    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
-    peerDependencies:
-      react: '*'
-      tslib: '*'
-
-  react-use@17.6.0:
-    resolution: {integrity: sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
   react-window@1.8.11:
     resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
     engines: {node: '>8.0.0'}
@@ -1711,14 +1301,8 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
-
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
-
-  rtl-css-js@1.16.1:
-    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -1848,40 +1432,14 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  screenfull@5.2.0:
-    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
-    engines: {node: '>=0.10.0'}
-
   scroll-into-view-if-needed@2.2.31:
     resolution: {integrity: sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==}
-
-  seroval-plugins@1.5.1:
-    resolution: {integrity: sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
-  seroval@1.5.1:
-    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
-    engines: {node: '>=10'}
-
-  set-harmonic-interval@1.0.1:
-    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
-    engines: {node: '>=6.9'}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.5.6:
-    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -1891,17 +1449,8 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  stack-generator@2.0.10:
-    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
-
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  stacktrace-gps@3.1.2:
-    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
-
-  stacktrace-js@2.0.2:
-    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -1911,9 +1460,6 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
-
-  stylis@4.3.6:
-    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -1932,16 +1478,6 @@ packages:
     resolution: {integrity: sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==}
     engines: {node: '>=16.0.0'}
 
-  throttle-debounce@3.0.1:
-    resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
-    engines: {node: '>=10'}
-
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
-  tiny-warning@1.0.3:
-    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
-
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
@@ -1950,9 +1486,6 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
-
-  ts-easing@0.2.0:
-    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1985,9 +1518,6 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
-  url-search-params-polyfill@8.2.5:
-    resolution: {integrity: sha512-FOEojW4XReTmtZOB7xqSHmJZhrNTmClhBriwLTmle4iA7bwuCo6ldSfbtsFSb8bTf3E0a3XpfonAdaur9vqq8A==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -2173,338 +1703,9 @@ snapshots:
   '@floating-ui/utils@0.2.11':
     optional: true
 
-  '@hongzhiyuan/preact@10.24.0-00213bad': {}
-
-  '@hongzhiyuan/preact@10.28.0-fc4af453': {}
-
-  '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@lynx-example/accessibility@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/action-sheet@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/animation@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/bankcards@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/composing-elements@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/css-api@0.7.1(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/css@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/design-guide@0.4.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.115.3(@types/react@18.3.28))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-      - react
-      - react-dom
-
-  '@lynx-example/element-manipulation@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/event@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/fetch@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/frame@0.1.2(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/gallery@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/hello-world@0.6.8(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.116.4(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/i18n@0.5.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      i18next: 23.16.8
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/ifr@0.5.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      jsbi: 4.3.2
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/image@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/input@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/layout@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/lazy-bundle@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/list@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/local-storage@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/lynx-api@0.1.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/main-thread@0.4.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.116.4(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/native-element@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/networking@0.4.7(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      '@tanstack/react-query': 5.90.11(react@18.3.1)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-      - react
-
-  '@lynx-example/overlay@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/page@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/performance-api@0.7.0(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/react-lifecycle@0.5.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/refresh@0.6.9(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/scroll-view@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/svg@0.6.8(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/swiper@0.5.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/tailwindcss@0.4.3(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/tanstack-router@0.6.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-      '@tanstack/react-router': 1.139.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      url-search-params-polyfill: 8.2.5
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-      - react
-      - react-dom
-
-  '@lynx-example/text@0.6.6(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/textarea@0.6.7(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/title-bar-view@0.6.11(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.116.4(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/view@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
-  '@lynx-example/zustand@0.6.5(@types/react@18.3.28)':
-    dependencies:
-      '@lynx-js/react': 0.115.1(@types/react@18.3.28)
-    transitivePeerDependencies:
-      - '@lynx-js/types'
-      - '@types/react'
-
   '@lynx-js/lynx-core@0.1.3': {}
 
   '@lynx-js/offscreen-document-canary@0.1.4': {}
-
-  '@lynx-js/react-use@0.1.3(@lynx-js/react@0.115.3(@types/react@18.3.28))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@lynx-js/react': 0.115.3(@types/react@18.3.28)
-      immer: 10.1.1
-      nanoid: 5.1.7
-      react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@lynx-js/react@0.115.1(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
-
-  '@lynx-js/react@0.115.3(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.24.0-00213bad'
-
-  '@lynx-js/react@0.116.4(@types/react@18.3.28)':
-    dependencies:
-      '@types/react': 18.3.28
-      preact: '@hongzhiyuan/preact@10.28.0-fc4af453'
 
   '@lynx-js/web-constants-canary@0.19.7-canary-20260126-5e7e43c5':
     dependencies:
@@ -2795,45 +1996,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/history@1.139.0': {}
-
-  '@tanstack/query-core@5.90.11': {}
-
-  '@tanstack/react-query@5.90.11(react@18.3.1)':
-    dependencies:
-      '@tanstack/query-core': 5.90.11
-      react: 18.3.1
-
-  '@tanstack/react-router@1.139.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@tanstack/history': 1.139.0
-      '@tanstack/react-store': 0.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/router-core': 1.139.14
-      isbot: 5.1.36
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/react-store@0.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@tanstack/store': 0.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
-  '@tanstack/router-core@1.139.14':
-    dependencies:
-      '@tanstack/history': 1.139.0
-      '@tanstack/store': 0.8.1
-      cookie-es: 2.0.0
-      seroval: 1.5.1
-      seroval-plugins: 1.5.1(seroval@1.5.1)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/store@0.8.1': {}
-
   '@tiptap/core@3.20.1(@tiptap/pm@3.20.1)':
     dependencies:
       '@tiptap/pm': 3.20.1
@@ -3055,8 +2217,6 @@ snapshots:
 
   '@types/jasmine@3.10.19': {}
 
-  '@types/js-cookie@2.2.7': {}
-
   '@types/linkify-it@5.0.0': {}
 
   '@types/markdown-it@14.1.2':
@@ -3096,8 +2256,6 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@xobotyi/scrollbar-width@1.9.5': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -3144,8 +2302,6 @@ snapshots:
 
   compute-scroll-into-view@1.0.20: {}
 
-  cookie-es@2.0.0: {}
-
   copy-text-to-clipboard@2.2.0: {}
 
   copy-to-clipboard@3.3.3:
@@ -3155,15 +2311,6 @@ snapshots:
   core-js@3.47.0: {}
 
   crelt@1.0.6: {}
-
-  css-in-js-utils@3.1.0:
-    dependencies:
-      hyphenate-style-name: 1.1.0
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
 
   csstype@3.2.3: {}
 
@@ -3257,13 +2404,7 @@ snapshots:
 
   fast-copy@3.0.2: {}
 
-  fast-deep-equal@3.1.3: {}
-
   fast-equals@5.4.0: {}
-
-  fast-shallow-equal@1.0.0: {}
-
-  fastest-stable-stringify@2.0.2: {}
 
   has-flag@4.0.0: {}
 
@@ -3332,19 +2473,9 @@ snapshots:
 
   hyphenate-style-name@1.1.0: {}
 
-  i18next@23.16.8:
-    dependencies:
-      '@babel/runtime': 7.28.6
-
-  immer@10.1.1: {}
-
   immutable@5.1.5: {}
 
   inline-style-parser@0.2.7: {}
-
-  inline-style-prefixer@7.0.1:
-    dependencies:
-      css-in-js-utils: 3.1.0
 
   is-alphabetical@2.0.1: {}
 
@@ -3367,15 +2498,9 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  isbot@5.1.36: {}
-
   jiti@2.6.1: {}
 
-  js-cookie@2.2.1: {}
-
   js-tokens@4.0.0: {}
-
-  jsbi@4.3.2: {}
 
   json5@2.2.3: {}
 
@@ -3578,8 +2703,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-
-  mdn-data@2.0.14: {}
 
   mdurl@2.0.0: {}
 
@@ -3851,22 +2974,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nano-css@5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      css-tree: 1.1.3
-      csstype: 3.2.3
-      fastest-stable-stringify: 2.0.2
-      inline-style-prefixer: 7.0.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      rtl-css-js: 1.16.1
-      stacktrace-js: 2.0.2
-      stylis: 4.3.6
-
   nanoid@3.3.11: {}
-
-  nanoid@5.1.7: {}
 
   node-addon-api@7.1.1:
     optional: true
@@ -4053,30 +3161,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-universal-interface@0.6.2(react@18.3.1)(tslib@2.8.1):
-    dependencies:
-      react: 18.3.1
-      tslib: 2.8.1
-
-  react-use@17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@types/js-cookie': 2.2.7
-      '@xobotyi/scrollbar-width': 1.9.5
-      copy-to-clipboard: 3.3.3
-      fast-deep-equal: 3.1.3
-      fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
-      nano-css: 5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-universal-interface: 0.6.2(react@18.3.1)(tslib@2.8.1)
-      resize-observer-polyfill: 1.5.1
-      screenfull: 5.2.0
-      set-harmonic-interval: 1.0.1
-      throttle-debounce: 3.0.1
-      ts-easing: 0.2.0
-      tslib: 2.8.1
-
   react-window@1.8.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -4181,13 +3265,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  resize-observer-polyfill@1.5.1: {}
-
   rope-sequence@1.3.4: {}
-
-  rtl-css-js@1.16.1:
-    dependencies:
-      '@babel/runtime': 7.28.6
 
   rxjs@7.8.2:
     dependencies:
@@ -4293,19 +3371,9 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  screenfull@5.2.0: {}
-
   scroll-into-view-if-needed@2.2.31:
     dependencies:
       compute-scroll-into-view: 1.0.20
-
-  seroval-plugins@1.5.1(seroval@1.5.1):
-    dependencies:
-      seroval: 1.5.1
-
-  seroval@1.5.1: {}
-
-  set-harmonic-interval@1.0.1: {}
 
   shiki@3.23.0:
     dependencies:
@@ -4320,30 +3388,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.5.6: {}
-
-  source-map@0.6.1: {}
-
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
-  stack-generator@2.0.10:
-    dependencies:
-      stackframe: 1.3.4
-
   stackframe@1.3.4: {}
-
-  stacktrace-gps@3.1.2:
-    dependencies:
-      source-map: 0.5.6
-      stackframe: 1.3.4
-
-  stacktrace-js@2.0.2:
-    dependencies:
-      error-stack-parser: 2.1.4
-      stack-generator: 2.0.10
-      stacktrace-gps: 3.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -4357,8 +3406,6 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
-
-  stylis@4.3.6: {}
 
   supports-color@8.1.1:
     dependencies:
@@ -4376,19 +3423,11 @@ snapshots:
 
   sync-message-port@1.2.0: {}
 
-  throttle-debounce@3.0.1: {}
-
-  tiny-invariant@1.3.3: {}
-
-  tiny-warning@1.0.3: {}
-
   toggle-selection@1.0.6: {}
 
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-easing@0.2.0: {}
 
   tslib@2.8.1: {}
 
@@ -4432,8 +3471,6 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
-
-  url-search-params-polyfill@8.2.5: {}
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -135,7 +135,7 @@ const StandaloneCodeBlock = ({
 declare global {
   interface ImportMeta {
     env: {
-      EXAMPLES: string[];
+      EXAMPLES: { name: string; version: string }[];
       SSG_PREVIEWS: Record<string, string>;
     };
   }
@@ -152,21 +152,25 @@ type PackagesSource = 'build' | 'fetching' | 'live' | 'error';
 function useExamplePackages() {
   // Initialize immediately from build-time data — zero latency on first render.
   // Build-time names like "vue-basic" must map back to their npm scope.
+  // Each entry now carries the version that was pinned at build time so the
+  // version dropdown is populated immediately (before the live npm fetch).
   const [packages, setPackages] = useState<NpmPackageInfo[]>(() =>
-    (import.meta.env.EXAMPLES ?? ['hello-world']).map((name: string) => {
-      const scopeConfig =
-        EXAMPLE_SCOPES.find((s) => s.prefix && name.startsWith(s.prefix)) ??
-        EXAMPLE_SCOPES[0];
-      const rawName = scopeConfig.prefix
-        ? name.slice(scopeConfig.prefix.length)
-        : name;
-      return {
-        name: `${scopeConfig.scope}${rawName}`,
-        shortName: name,
-        scope: scopeConfig,
-        version: '',
-      };
-    }),
+    (import.meta.env.EXAMPLES ?? [{ name: 'hello-world', version: '' }]).map(
+      ({ name, version }: { name: string; version: string }) => {
+        const scopeConfig =
+          EXAMPLE_SCOPES.find((s) => s.prefix && name.startsWith(s.prefix)) ??
+          EXAMPLE_SCOPES[0];
+        const rawName = scopeConfig.prefix
+          ? name.slice(scopeConfig.prefix.length)
+          : name;
+        return {
+          name: `${scopeConfig.scope}${rawName}`,
+          shortName: name,
+          scope: scopeConfig,
+          version,
+        };
+      },
+    ),
   );
   const [source, setSource] = useState<PackagesSource>('build');
 
@@ -191,6 +195,7 @@ function usePackageVersions(packageName: string) {
   const [loading, setLoading] = useState(false);
   useEffect(() => {
     if (!packageName) return;
+    setVersions([]);
     setLoading(true);
     fetchPackageVersions(packageName)
       .then(setVersions)
@@ -474,7 +479,7 @@ function ColumnResizer({
       const startW = widthRef.current!;
       const sign = reverse ? -1 : 1;
       const onPointerMove = (ev: PointerEvent) => {
-        onWidthChange(Math.max(80, startW + (ev.clientX - startX) * sign));
+        onWidthChange(Math.max(160, startW + (ev.clientX - startX) * sign));
       };
       const onPointerUp = () => {
         el.removeEventListener('pointermove', onPointerMove);
@@ -613,7 +618,13 @@ function App() {
   const [defaultFile, setDefaultFile] = useState(
     initial.file ?? ((initial.example ?? 'hello-world').startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx'),
   );
-  const [version, setVersion] = useState<string | undefined>(initial.version);
+  const [version, setVersion] = useState<string | undefined>(
+    initial.version ??
+      ((import.meta.env.EXAMPLES ?? []).find(
+        (e: { name: string; version: string }) =>
+          e.name === (initial.example ?? 'hello-world'),
+      )?.version || undefined),
+  );
   const [copied, setCopied] = useState(false);
   const [exampleSearch, setExampleSearch] = useState('');
   const [entrySearch, setEntrySearch] = useState('');
@@ -629,6 +640,16 @@ function App() {
   const currentPkg = examplePackages.find((p) => p.shortName === example);
   const currentPkgName = currentPkg?.name ?? `@lynx-example/${example}`;
 
+  // The version that was pinned when this site was built (from build-time EXAMPLES).
+  const getBuildVersion = useCallback(
+    (name: string) =>
+      (import.meta.env.EXAMPLES ?? []).find(
+        (e: { name: string; version: string }) => e.name === name,
+      )?.version ?? '',
+    [],
+  );
+  const buildVersion = getBuildVersion(example);
+
   const { versions: packageVersions } = usePackageVersions(currentPkgName);
 
   // Auto-select the newest concrete version once packageVersions loads.
@@ -636,13 +657,13 @@ function App() {
   const effectiveVersion =
     version ?? currentPkg?.version ?? packageVersions[0]?.version;
 
-  // Once packageVersions is available, pin `version` state to a real semver
-  // so the dropdown shows a selected value and the URL gets a concrete version.
+  // Fallback: if no build version is known for this example (e.g. a newly
+  // published package not yet in the build), auto-select the newest live version.
   useEffect(() => {
-    if (!version && packageVersions.length > 0) {
+    if (!version && !buildVersion && packageVersions.length > 0) {
       setVersion(packageVersions[0].version);
     }
-  }, [version, packageVersions]);
+  }, [version, buildVersion, packageVersions]);
 
   // Metadata & entry state
   const [metadata, setMetadata] = useState<Record<string, any> | null>(null);
@@ -661,15 +682,18 @@ function App() {
   const [metadataHtml, setMetadataHtml] = useState('');
 
   // Resizable column widths
-  const col1Ref = useRef(180);
-  const col2Ref = useRef(180);
-  const col4Ref = useRef(300);
-  const [col1W, setCol1W] = useState(180);
-  const [col2W, setCol2W] = useState(180);
-  const [col4W, setCol4W] = useState(300);
+  const col1Ref = useRef(220);
+  const col2Ref = useRef(220);
+  const col3Ref = useRef(220);
+  const col4Ref = useRef(220);
+  const [col1W, setCol1W] = useState(220);
+  const [col2W, setCol2W] = useState(220);
+  const [col3W, setCol3W] = useState(220);
+  const [col4W, setCol4W] = useState(220);
 
   const setCol1 = useCallback((w: number) => { col1Ref.current = w; setCol1W(w); }, []);
   const setCol2 = useCallback((w: number) => { col2Ref.current = w; setCol2W(w); }, []);
+  const setCol3 = useCallback((w: number) => { col3Ref.current = w; setCol3W(w); }, []);
   const setCol4 = useCallback((w: number) => { col4Ref.current = w; setCol4W(w); }, []);
 
   const jsxString = useMemo(
@@ -1050,7 +1074,7 @@ function App() {
                     data-active={example === name}
                     onClick={() => {
                       setExample(name);
-                      setVersion(undefined);
+                      setVersion(getBuildVersion(name) || undefined);
                       setDefaultFile(
                         source === 'vue' ? 'src/App.vue' : 'src/App.tsx',
                       );
@@ -1133,13 +1157,14 @@ function App() {
                 style={{
                   ...panelLabelStyle,
                   padding: '0 4px',
-                  marginBottom: 2,
+                  marginBottom: 4,
                   display: 'flex',
                   alignItems: 'center',
-                  gap: 6,
+                  gap: 4,
+                  flexWrap: 'wrap',
                 }}
               >
-                <span>Entries</span>
+                <span style={{ flexShrink: 0 }}>Entries</span>
                 <input
                   type="text"
                   value={entrySearch}
@@ -1155,22 +1180,9 @@ function App() {
                     fontSize: 10,
                     fontFamily: 'inherit',
                     outline: 'none',
-                    minWidth: 0,
+                    minWidth: 40,
                   }}
                 />
-              </div>
-              <div
-                style={{
-                  padding: '0 4px',
-                  marginBottom: 4,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 4,
-                }}
-              >
-                <span style={{ fontSize: 10, color: 'var(--sb-text-dim)', flexShrink: 0 }}>
-                  Version
-                </span>
                 <select
                   value={version ?? ''}
                   onChange={(e) => setVersion(e.target.value || undefined)}
@@ -1179,6 +1191,7 @@ function App() {
                     fontSize: 10,
                     padding: '1px 20px 1px 6px',
                     borderRadius: 4,
+                    flexShrink: 0,
                   }}
                 >
                   {packageVersions.length === 0 && (
@@ -1186,7 +1199,7 @@ function App() {
                   )}
                   {packageVersions.map((v) => (
                     <option key={v.version} value={v.version}>
-                      {v.version}
+                      {v.version}{v.version === buildVersion ? ' (build)' : ''}
                     </option>
                   ))}
                 </select>
@@ -1241,8 +1254,8 @@ function App() {
             {/* Col 3: controls */}
             <div
               style={{
-                flex: '1 1 0',
-                minWidth: 120,
+                flex: `0 0 ${col3W}px`,
+                minWidth: 160,
                 padding: '10px 16px',
                 overflow: 'hidden',
                 display: 'grid',
@@ -1306,9 +1319,9 @@ function App() {
               />
             </div>
 
-            <ColumnResizer widthRef={col4Ref} onWidthChange={setCol4} reverse />
+            <ColumnResizer widthRef={col3Ref} onWidthChange={setCol3} />
 
-            {/* Right: metadata JSON */}
+            {/* Col 4: metadata JSON */}
             <div
               style={{
                 flex: `0 0 ${col4W}px`,
@@ -1375,45 +1388,18 @@ function App() {
       </div>
 
       {/* ── Go component(s) — Desktop + Mobile ── */}
+      {/* App-level concern: don't render Go until we have a resolved CDN version.
+          This avoids the useCdn=false → useCdn=true double-mount when
+          effectiveVersion transitions from undefined to a real semver. */}
       <main>
         <PreviewErrorBoundary>
           <GoConfigProvider config={goConfig}>
-            <div className="dual-view">
-              {/* Desktop */}
-              <div style={{ flex: '1 1 500px', minWidth: 0 }}>
-                <Go
-                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${effectiveVersion}`}
-                  example={example}
-                  defaultFile={defaultFile}
-                  defaultTab={defaultTab}
-                  defaultEntryFile={defaultEntryFile || undefined}
-                  entry={entryFilter || undefined}
-                  highlight={highlight || undefined}
-                  img={img || undefined}
-                  schema={schema || undefined}
-                  version={effectiveVersion}
-                />
-                <div className="figure-caption">Desktop</div>
-              </div>
-              {/* Mobile — fixed 320×660 */}
-              <div
-                className="mobile-preview"
-                style={{
-                  flex: '0 0 320px',
-                  maxWidth: 320,
-                  overflow: 'hidden',
-                  containerType: 'inline-size' as any,
-                }}
-              >
-                <div
-                  style={{
-                    height: 660,
-                    overflow: 'hidden',
-                    borderRadius: 16,
-                  }}
-                >
+            {effectiveVersion ? (
+              <div className="dual-view">
+                {/* Desktop */}
+                <div style={{ flex: '1 1 500px', minWidth: 0 }}>
                   <Go
-                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${effectiveVersion}`}
+                    key={`desktop-${example}-${selectedEntry}-${defaultTab}-${effectiveVersion}`}
                     example={example}
                     defaultFile={defaultFile}
                     defaultTab={defaultTab}
@@ -1424,10 +1410,48 @@ function App() {
                     schema={schema || undefined}
                     version={effectiveVersion}
                   />
+                  <div className="figure-caption">Desktop</div>
                 </div>
-                <div className="figure-caption">Mobile (320 × 660)</div>
+                {/* Mobile — fixed 320×660 */}
+                <div
+                  className="mobile-preview"
+                  style={{
+                    flex: '0 0 320px',
+                    maxWidth: 320,
+                    overflow: 'hidden',
+                    containerType: 'inline-size' as any,
+                  }}
+                >
+                  <div
+                    style={{
+                      height: 660,
+                      overflow: 'hidden',
+                      borderRadius: 16,
+                    }}
+                  >
+                    <Go
+                      key={`mobile-${example}-${selectedEntry}-${defaultTab}-${effectiveVersion}`}
+                      example={example}
+                      defaultFile={defaultFile}
+                      defaultTab={defaultTab}
+                      defaultEntryFile={defaultEntryFile || undefined}
+                      entry={entryFilter || undefined}
+                      highlight={highlight || undefined}
+                      img={img || undefined}
+                      schema={schema || undefined}
+                      version={effectiveVersion}
+                    />
+                  </div>
+                  <div className="figure-caption">Mobile (320 × 660)</div>
+                </div>
               </div>
-            </div>
+            ) : (
+              <div className="dual-view" style={{ alignItems: 'center', justifyContent: 'center', minHeight: 400 }}>
+                <span style={{ color: 'var(--semi-color-text-2)', fontSize: 13 }}>
+                  Resolving package version…
+                </span>
+              </div>
+            )}
           </GoConfigProvider>
         </PreviewErrorBoundary>
       </main>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -10,6 +10,7 @@ import '@douyinfe/semi-ui/dist/css/semi.min.css';
 import {
   GoConfigProvider,
   Go,
+  EXAMPLE_SCOPES,
   searchExamplePackages,
   fetchPackageVersions,
   fetchExampleMetadata,
@@ -149,13 +150,23 @@ const SSG_PREVIEWS: Record<string, string> =
 type PackagesSource = 'build' | 'fetching' | 'live' | 'error';
 
 function useExamplePackages() {
-  // Initialize immediately from build-time data — zero latency on first render
+  // Initialize immediately from build-time data — zero latency on first render.
+  // Build-time names like "vue-basic" must map back to their npm scope.
   const [packages, setPackages] = useState<NpmPackageInfo[]>(() =>
-    (import.meta.env.EXAMPLES ?? ['hello-world']).map((name: string) => ({
-      name: `@lynx-example/${name}`,
-      shortName: name,
-      version: '',
-    })),
+    (import.meta.env.EXAMPLES ?? ['hello-world']).map((name: string) => {
+      const scopeConfig =
+        EXAMPLE_SCOPES.find((s) => s.prefix && name.startsWith(s.prefix)) ??
+        EXAMPLE_SCOPES[0];
+      const rawName = scopeConfig.prefix
+        ? name.slice(scopeConfig.prefix.length)
+        : name;
+      return {
+        name: `${scopeConfig.scope}${rawName}`,
+        shortName: name,
+        scope: scopeConfig,
+        version: '',
+      };
+    }),
   );
   const [source, setSource] = useState<PackagesSource>('build');
 
@@ -614,13 +625,14 @@ function App() {
     () => examplePackages.map((p) => p.shortName),
     [examplePackages],
   );
-  const { versions: packageVersions } = usePackageVersions(
-    `@lynx-example/${example}`,
-  );
+  // Derive the full package name from the packages list (scope-aware).
+  const currentPkg = examplePackages.find((p) => p.shortName === example);
+  const currentPkgName = currentPkg?.name ?? `@lynx-example/${example}`;
+
+  const { versions: packageVersions } = usePackageVersions(currentPkgName);
 
   // Auto-select the newest concrete version once packageVersions loads.
   // Never pass the virtual 'latest' tag to jsdelivr; the data API requires real semver.
-  const currentPkg = examplePackages.find((p) => p.shortName === example);
   const effectiveVersion =
     version ?? currentPkg?.version ?? packageVersions[0]?.version;
 
@@ -759,8 +771,7 @@ function App() {
     setMetadataLoading(true);
     setEntrySearch('');
 
-    const pkgName = `@lynx-example/${example}`;
-    const metadataPromise = fetchExampleMetadata(pkgName, effectiveVersion);
+    const metadataPromise = fetchExampleMetadata(currentPkgName, effectiveVersion);
 
     metadataPromise
       .then((data) => {

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -602,7 +602,7 @@ function App() {
   const [defaultFile, setDefaultFile] = useState(
     initial.file ?? ((initial.example ?? 'hello-world').startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx'),
   );
-  const [version, setVersion] = useState<string>(initial.version ?? 'latest');
+  const [version, setVersion] = useState<string | undefined>(initial.version);
   const [copied, setCopied] = useState(false);
   const [exampleSearch, setExampleSearch] = useState('');
   const [entrySearch, setEntrySearch] = useState('');
@@ -618,13 +618,19 @@ function App() {
     `@lynx-example/${example}`,
   );
 
-  // Resolve 'latest' to a real semver before passing to ExamplePreview,
-  // because the jsdelivr data API does not support dist-tags like 'latest'.
+  // Auto-select the newest concrete version once packageVersions loads.
+  // Never pass the virtual 'latest' tag to jsdelivr; the data API requires real semver.
   const currentPkg = examplePackages.find((p) => p.shortName === example);
   const effectiveVersion =
-    version === 'latest'
-      ? (currentPkg?.version ?? packageVersions[0]?.version)
-      : version;
+    version ?? currentPkg?.version ?? packageVersions[0]?.version;
+
+  // Once packageVersions is available, pin `version` state to a real semver
+  // so the dropdown shows a selected value and the URL gets a concrete version.
+  useEffect(() => {
+    if (!version && packageVersions.length > 0) {
+      setVersion(packageVersions[0].version);
+    }
+  }, [version, packageVersions]);
 
   // Metadata & entry state
   const [metadata, setMetadata] = useState<Record<string, any> | null>(null);
@@ -713,7 +719,7 @@ function App() {
       tab: defaultTab,
       file: defaultFile,
       example,
-      version: version !== 'latest' ? version : undefined,
+      version,
     });
   }, [dark, lang, defaultTab, defaultFile, example, version]);
 
@@ -1033,7 +1039,7 @@ function App() {
                     data-active={example === name}
                     onClick={() => {
                       setExample(name);
-                      setVersion('latest');
+                      setVersion(undefined);
                       setDefaultFile(
                         source === 'vue' ? 'src/App.vue' : 'src/App.tsx',
                       );
@@ -1074,8 +1080,7 @@ function App() {
                     )}
                     {example === name && (() => {
                       const pkg = examplePackages.find(p => p.shortName === name);
-                      const latestVer = pkg?.version;
-                      const displayVer = version === 'latest' ? latestVer : version;
+                      const displayVer = version ?? pkg?.version;
                       return displayVer ? (
                         <span
                           style={{
@@ -1156,8 +1161,8 @@ function App() {
                   Version
                 </span>
                 <select
-                  value={version}
-                  onChange={(e) => setVersion(e.target.value)}
+                  value={version ?? ''}
+                  onChange={(e) => setVersion(e.target.value || undefined)}
                   style={{
                     ...selectStyle,
                     fontSize: 10,
@@ -1165,7 +1170,9 @@ function App() {
                     borderRadius: 4,
                   }}
                 >
-                  <option value="latest">latest</option>
+                  {packageVersions.length === 0 && (
+                    <option value="" disabled>Loading…</option>
+                  )}
                   {packageVersions.map((v) => (
                     <option key={v.version} value={v.version}>
                       {v.version}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -572,6 +572,14 @@ function App() {
     `@lynx-example/${example}`,
   );
 
+  // Resolve 'latest' to a real semver before passing to ExamplePreview,
+  // because the jsdelivr data API does not support dist-tags like 'latest'.
+  const currentPkg = examplePackages.find((p) => p.shortName === example);
+  const effectiveVersion =
+    version === 'latest'
+      ? (currentPkg?.version ?? packageVersions[0]?.version)
+      : version;
+
   // Metadata & entry state
   const [metadata, setMetadata] = useState<Record<string, any> | null>(null);
   const [metadataLoading, setMetadataLoading] = useState(false);
@@ -690,14 +698,17 @@ function App() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  // Fetch example metadata when example or version changes
+  // Fetch example metadata when example or version changes.
+  // Use effectiveVersion (resolved semver) because the jsdelivr data API
+  // does not accept dist-tags like 'latest'.
   useEffect(() => {
+    if (!effectiveVersion) return; // still resolving 'latest', wait
     setMetadata(null);
     setMetadataLoading(true);
     setEntrySearch('');
 
     const pkgName = `@lynx-example/${example}`;
-    const metadataPromise = fetchExampleMetadata(pkgName, version);
+    const metadataPromise = fetchExampleMetadata(pkgName, effectiveVersion);
 
     metadataPromise
       .then((data) => {
@@ -720,7 +731,7 @@ function App() {
       })
       .catch(() => setMetadata(null))
       .finally(() => setMetadataLoading(false));
-  }, [example, version]);
+  }, [example, effectiveVersion]);
 
   // Highlight metadata JSON with shiki
   useEffect(() => {
@@ -1317,7 +1328,7 @@ function App() {
               {/* Desktop */}
               <div style={{ flex: '1 1 500px', minWidth: 0 }}>
                 <Go
-                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${version}`}
+                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${effectiveVersion}`}
                   example={example}
                   defaultFile={defaultFile}
                   defaultTab={defaultTab}
@@ -1326,7 +1337,7 @@ function App() {
                   highlight={highlight || undefined}
                   img={img || undefined}
                   schema={schema || undefined}
-                  version={version}
+                  version={effectiveVersion}
                 />
                 <div className="figure-caption">Desktop</div>
               </div>
@@ -1348,7 +1359,7 @@ function App() {
                   }}
                 >
                   <Go
-                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${version}`}
+                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${effectiveVersion}`}
                     example={example}
                     defaultFile={defaultFile}
                     defaultTab={defaultTab}
@@ -1357,7 +1368,7 @@ function App() {
                     highlight={highlight || undefined}
                     img={img || undefined}
                     schema={schema || undefined}
-                    version={version}
+                    version={effectiveVersion}
                   />
                 </div>
                 <div className="figure-caption">Mobile (320 × 660)</div>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -146,16 +146,33 @@ const SSG_PREVIEWS: Record<string, string> =
 // Runtime example & version fetching hooks
 // ---------------------------------------------------------------------------
 
+type PackagesSource = 'build' | 'fetching' | 'live' | 'error';
+
 function useExamplePackages() {
-  const [packages, setPackages] = useState<NpmPackageInfo[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Initialize immediately from build-time data — zero latency on first render
+  const [packages, setPackages] = useState<NpmPackageInfo[]>(() =>
+    (import.meta.env.EXAMPLES ?? ['hello-world']).map((name: string) => ({
+      name: `@lynx-example/${name}`,
+      shortName: name,
+      version: '',
+    })),
+  );
+  const [source, setSource] = useState<PackagesSource>('build');
+
   useEffect(() => {
+    setSource('fetching');
     searchExamplePackages()
-      .then(setPackages)
-      .catch((err) => console.error('Failed to fetch example packages:', err))
-      .finally(() => setLoading(false));
+      .then((pkgs) => {
+        setPackages(pkgs);
+        setSource('live');
+      })
+      .catch((err) => {
+        console.error('Failed to fetch example packages:', err);
+        setSource('error');
+      });
   }, []);
-  return { packages, loading };
+
+  return { packages, source };
 }
 
 function usePackageVersions(packageName: string) {
@@ -172,6 +189,38 @@ function usePackageVersions(packageName: string) {
       .finally(() => setLoading(false));
   }, [packageName]);
   return { versions, loading };
+}
+
+// ---------------------------------------------------------------------------
+// SourceBadge — shows whether the example list is from build-time or npm live
+// ---------------------------------------------------------------------------
+
+const SOURCE_BADGE_CONFIG: Record<
+  PackagesSource,
+  { label: string; className: string; dot: boolean }
+> = {
+  build:    { label: 'static', className: 'source-badge-build',    dot: false },
+  fetching: { label: 'fetching', className: 'source-badge-fetching', dot: true  },
+  live:     { label: 'live',    className: 'source-badge-live',     dot: true  },
+  error:    { label: 'offline', className: 'source-badge-error',    dot: false },
+};
+
+function SourceBadge({ source, count }: { source: PackagesSource; count: number }) {
+  const { label, className, dot } = SOURCE_BADGE_CONFIG[source];
+  return (
+    <span
+      className={`source-badge ${className}`}
+      title={
+        source === 'build'    ? `Showing ${count} examples from build-time bundle` :
+        source === 'fetching' ? 'Fetching latest examples from npm registry…' :
+        source === 'live'     ? `Showing ${count} examples fetched live from npm` :
+                                'npm fetch failed — showing build-time bundle'
+      }
+    >
+      {dot && <span className={`source-dot${source === 'fetching' ? ' source-dot-fetching' : ''}`} />}
+      {label}
+    </span>
+  );
 }
 
 function getExampleSource(name: string): 'vue' | 'lynx' {
@@ -559,13 +608,10 @@ function App() {
   const [entrySearch, setEntrySearch] = useState('');
 
   // Runtime: fetch example list and versions from npm
-  const { packages: examplePackages, loading: packagesLoading } =
+  const { packages: examplePackages, source: packagesSource } =
     useExamplePackages();
   const EXAMPLES = useMemo(
-    () =>
-      examplePackages.length > 0
-        ? examplePackages.map((p) => p.shortName)
-        : (import.meta.env.EXAMPLES ?? ['hello-world']),
+    () => examplePackages.map((p) => p.shortName),
     [examplePackages],
   );
   const { versions: packageVersions } = usePackageVersions(
@@ -952,6 +998,7 @@ function App() {
                 }}
               >
                 <span>Examples</span>
+                <SourceBadge source={packagesSource} count={EXAMPLES.length} />
                 <input
                   type="text"
                   value={exampleSearch}
@@ -971,17 +1018,6 @@ function App() {
                   }}
                 />
               </div>
-              {packagesLoading && (
-                <span
-                  style={{
-                    fontSize: 11,
-                    color: 'var(--sb-text-dim)',
-                    padding: '3px 8px',
-                  }}
-                >
-                  Loading from npm…
-                </span>
-              )}
               {EXAMPLES.filter(
                 (name) =>
                   !exampleSearch ||

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -7,7 +7,14 @@ import React, {
 } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@douyinfe/semi-ui/dist/css/semi.min.css';
-import { GoConfigProvider, Go } from '../../src/index';
+import {
+  GoConfigProvider,
+  Go,
+  searchExamplePackages,
+  fetchPackageVersions,
+  fetchExampleMetadata,
+} from '../../src/index';
+import type { NpmPackageInfo, PackageVersionInfo } from '../../src/index';
 import type { PreviewTab, GoConfig } from '../../src/config';
 import type { ShikiTransformer, BundledLanguage } from 'shiki';
 import './styles.css';
@@ -123,7 +130,7 @@ const StandaloneCodeBlock = ({
   );
 };
 
-// Build-time injected list of available examples and SSG previews
+// Build-time injected SSG previews (example list is now fetched at runtime)
 declare global {
   interface ImportMeta {
     env: {
@@ -132,9 +139,40 @@ declare global {
     };
   }
 }
-const EXAMPLES: string[] = import.meta.env.EXAMPLES ?? ['hello-world'];
 const SSG_PREVIEWS: Record<string, string> =
   import.meta.env.SSG_PREVIEWS ?? {};
+
+// ---------------------------------------------------------------------------
+// Runtime example & version fetching hooks
+// ---------------------------------------------------------------------------
+
+function useExamplePackages() {
+  const [packages, setPackages] = useState<NpmPackageInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    searchExamplePackages()
+      .then(setPackages)
+      .catch((err) => console.error('Failed to fetch example packages:', err))
+      .finally(() => setLoading(false));
+  }, []);
+  return { packages, loading };
+}
+
+function usePackageVersions(packageName: string) {
+  const [versions, setVersions] = useState<PackageVersionInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!packageName) return;
+    setLoading(true);
+    fetchPackageVersions(packageName)
+      .then(setVersions)
+      .catch((err) =>
+        console.error(`Failed to fetch versions for ${packageName}:`, err),
+      )
+      .finally(() => setLoading(false));
+  }, [packageName]);
+  return { versions, loading };
+}
 
 function getExampleSource(name: string): 'vue' | 'lynx' {
   return name.startsWith('vue-') ? 'vue' : 'lynx';
@@ -150,6 +188,7 @@ interface UrlState {
   tab?: PreviewTab;
   file?: string;
   example?: string;
+  version?: string;
 }
 
 function readUrlState(): UrlState {
@@ -514,9 +553,24 @@ function App() {
   const [defaultFile, setDefaultFile] = useState(
     initial.file ?? ((initial.example ?? 'hello-world').startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx'),
   );
+  const [version, setVersion] = useState<string>(initial.version ?? 'latest');
   const [copied, setCopied] = useState(false);
   const [exampleSearch, setExampleSearch] = useState('');
   const [entrySearch, setEntrySearch] = useState('');
+
+  // Runtime: fetch example list and versions from npm
+  const { packages: examplePackages, loading: packagesLoading } =
+    useExamplePackages();
+  const EXAMPLES = useMemo(
+    () =>
+      examplePackages.length > 0
+        ? examplePackages.map((p) => p.shortName)
+        : (import.meta.env.EXAMPLES ?? ['hello-world']),
+    [examplePackages],
+  );
+  const { versions: packageVersions } = usePackageVersions(
+    `@lynx-example/${example}`,
+  );
 
   // Metadata & entry state
   const [metadata, setMetadata] = useState<Record<string, any> | null>(null);
@@ -599,8 +653,15 @@ function App() {
 
   // Persist state to URL hash
   useEffect(() => {
-    writeUrlState({ dark, lang, tab: defaultTab, file: defaultFile, example });
-  }, [dark, lang, defaultTab, defaultFile, example]);
+    writeUrlState({
+      dark,
+      lang,
+      tab: defaultTab,
+      file: defaultFile,
+      example,
+      version: version !== 'latest' ? version : undefined,
+    });
+  }, [dark, lang, defaultTab, defaultFile, example, version]);
 
   // Apply Semi UI dark/light mode
   useEffect(() => {
@@ -629,16 +690,16 @@ function App() {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  // Fetch example metadata when example changes
+  // Fetch example metadata when example or version changes
   useEffect(() => {
     setMetadata(null);
     setMetadataLoading(true);
     setEntrySearch('');
-    fetch(`/lynx-examples/${example}/example-metadata.json`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
-      })
+
+    const pkgName = `@lynx-example/${example}`;
+    const metadataPromise = fetchExampleMetadata(pkgName, version);
+
+    metadataPromise
       .then((data) => {
         setMetadata(data);
         const first = data.templateFiles?.[0];
@@ -659,7 +720,7 @@ function App() {
       })
       .catch(() => setMetadata(null))
       .finally(() => setMetadataLoading(false));
-  }, [example]);
+  }, [example, version]);
 
   // Highlight metadata JSON with shiki
   useEffect(() => {
@@ -703,7 +764,7 @@ function App() {
   }, []);
 
   const goConfig: GoConfig = {
-    exampleBasePath: '/lynx-examples',
+    exampleBasePath: '/lynx-examples', // fallback for non-versioned mode
     defaultTab,
     explorerUrl: {
       en: 'https://lynxjs.org/guide/start/quick-start.html#download-lynx-explorer',
@@ -799,6 +860,21 @@ function App() {
                 ]}
                 onChange={(v) => setDefaultTab(v as PreviewTab)}
               />
+            </ControlGroup>
+
+            <ControlGroup label="Version">
+              <select
+                value={version}
+                onChange={(e) => setVersion(e.target.value)}
+                style={selectStyle}
+              >
+                <option value="latest">latest</option>
+                {packageVersions.map((v) => (
+                  <option key={v.version} value={v.version}>
+                    {v.version}
+                  </option>
+                ))}
+              </select>
             </ControlGroup>
 
             {/* JSX button */}
@@ -899,6 +975,17 @@ function App() {
                   }}
                 />
               </div>
+              {packagesLoading && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--sb-text-dim)',
+                    padding: '3px 8px',
+                  }}
+                >
+                  Loading from npm…
+                </span>
+              )}
               {EXAMPLES.filter(
                 (name) =>
                   !exampleSearch ||
@@ -914,6 +1001,7 @@ function App() {
                     data-active={example === name}
                     onClick={() => {
                       setExample(name);
+                      setVersion('latest');
                       setDefaultFile(
                         source === 'vue' ? 'src/App.vue' : 'src/App.tsx',
                       );
@@ -1192,7 +1280,7 @@ function App() {
               {/* Desktop */}
               <div style={{ flex: '1 1 500px', minWidth: 0 }}>
                 <Go
-                  key={`desktop-${example}-${selectedEntry}-${defaultTab}`}
+                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${version}`}
                   example={example}
                   defaultFile={defaultFile}
                   defaultTab={defaultTab}
@@ -1201,6 +1289,7 @@ function App() {
                   highlight={highlight || undefined}
                   img={img || undefined}
                   schema={schema || undefined}
+                  version={version}
                 />
                 <div className="figure-caption">Desktop</div>
               </div>
@@ -1222,7 +1311,7 @@ function App() {
                   }}
                 >
                   <Go
-                    key={`mobile-${example}-${selectedEntry}-${defaultTab}`}
+                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${version}`}
                     example={example}
                     defaultFile={defaultFile}
                     defaultTab={defaultTab}
@@ -1231,6 +1320,7 @@ function App() {
                     highlight={highlight || undefined}
                     img={img || undefined}
                     schema={schema || undefined}
+                    version={version}
                   />
                 </div>
                 <div className="figure-caption">Mobile (320 × 660)</div>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -862,21 +862,6 @@ function App() {
               />
             </ControlGroup>
 
-            <ControlGroup label="Version">
-              <select
-                value={version}
-                onChange={(e) => setVersion(e.target.value)}
-                style={selectStyle}
-              >
-                <option value="latest">latest</option>
-                {packageVersions.map((v) => (
-                  <option key={v.version} value={v.version}>
-                    {v.version}
-                  </option>
-                ))}
-              </select>
-            </ControlGroup>
-
             {/* JSX button */}
             <button
               className="toolbar-btn"
@@ -1040,6 +1025,28 @@ function App() {
                         Vue
                       </span>
                     )}
+                    {example === name && (() => {
+                      const pkg = examplePackages.find(p => p.shortName === name);
+                      const latestVer = pkg?.version;
+                      const displayVer = version === 'latest' ? latestVer : version;
+                      return displayVer ? (
+                        <span
+                          style={{
+                            fontSize: 9,
+                            padding: '0 4px',
+                            borderRadius: 3,
+                            lineHeight: '16px',
+                            fontWeight: 500,
+                            flexShrink: 0,
+                            background: 'rgba(255,255,255,0.25)',
+                            color: 'inherit',
+                            marginLeft: 'auto',
+                          }}
+                        >
+                          v{displayVer}
+                        </span>
+                      ) : null;
+                    })()}
                   </button>
                 );
               })}
@@ -1063,7 +1070,7 @@ function App() {
                 style={{
                   ...panelLabelStyle,
                   padding: '0 4px',
-                  marginBottom: 4,
+                  marginBottom: 2,
                   display: 'flex',
                   alignItems: 'center',
                   gap: 6,
@@ -1088,6 +1095,36 @@ function App() {
                     minWidth: 0,
                   }}
                 />
+              </div>
+              <div
+                style={{
+                  padding: '0 4px',
+                  marginBottom: 4,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                }}
+              >
+                <span style={{ fontSize: 10, color: 'var(--sb-text-dim)', flexShrink: 0 }}>
+                  Version
+                </span>
+                <select
+                  value={version}
+                  onChange={(e) => setVersion(e.target.value)}
+                  style={{
+                    ...selectStyle,
+                    fontSize: 10,
+                    padding: '1px 20px 1px 6px',
+                    borderRadius: 4,
+                  }}
+                >
+                  <option value="latest">latest</option>
+                  {packageVersions.map((v) => (
+                    <option key={v.version} value={v.version}>
+                      {v.version}
+                    </option>
+                  ))}
+                </select>
               </div>
               {metadata?.templateFiles?.filter(
                 (t: any) =>

--- a/example/src/styles.css
+++ b/example/src/styles.css
@@ -243,6 +243,60 @@ html[style*='color-scheme: dark'] .shiki span {
   left: 1.5px;
 }
 
+/* ------------------------------------------------------------------ */
+/* npm source badge (build / fetching / live / error)                 */
+/* ------------------------------------------------------------------ */
+.source-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.source-badge-build {
+  background: rgba(245, 158, 11, 0.12);
+  color: #d97706;
+}
+
+.source-badge-fetching {
+  background: rgba(59, 130, 246, 0.12);
+  color: #3b82f6;
+}
+
+.source-badge-live {
+  background: rgba(16, 185, 129, 0.12);
+  color: #059669;
+}
+
+.source-badge-error {
+  background: rgba(239, 68, 68, 0.12);
+  color: #dc2626;
+}
+
+.source-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+@keyframes source-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
+.source-dot-fetching {
+  animation: source-pulse 1.2s ease-in-out infinite;
+}
+
 /* Example version tags                                                */
 /* ------------------------------------------------------------------ */
 .example-tag {

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -26,6 +26,7 @@ import { FileTree } from './file-tree';
 import { CodeView } from './code-view';
 import { SwitchSchema } from './switch-schema';
 import { PreviewImg } from './preview-img';
+import { LoadingOverlay } from './loading-overlay';
 import { SplitPane, type SplitPaneHandle } from './split-pane';
 
 import {
@@ -278,7 +279,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
               }
               second={
                 <div className={s['preview-wrap']}>
-                  <div className={s['preview-wrap-content']}>
+                  <div className={s['preview-wrap-content']} style={{ position: 'relative' }}>
                     <div className={s['preview-header']}>
                       <div style={{ width: 24, flexShrink: 0 }} />
                       <RadioGroup
@@ -341,6 +342,9 @@ export const ExampleContent: FC<ExampleContentProps> = ({
                         }}
                       />
                     </div>
+
+                    {/* Show loading overlay while metadata is fetching (before initState=true) */}
+                    <LoadingOverlay visible={!initState} />
 
                     {previewType === PreviewType.QRCode && currentEntry && (
                       <div className={s.qrcode}>

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -7,6 +7,7 @@ import { isAssetFileType } from './utils/example-data';
 import type { SchemaOptionsData } from './hooks/use-switch-schema';
 import { useGoConfig } from '../config';
 import type { PreviewTab } from '../config';
+import { fetchExampleMetadata, getCdnBaseUrl } from '../npm-registry';
 
 const DefaultErrorWrap = ({
   example,
@@ -59,6 +60,12 @@ export interface ExamplePreviewProps {
    * - `'qrcode'`  — QR code for Lynx Explorer
    */
   defaultTab?: PreviewTab;
+  /**
+   * When set, fetches example files from the npm registry (via jsdelivr CDN)
+   * at the specified version instead of from local/static files.
+   * Use `'latest'` for the newest published version, or a specific semver string.
+   */
+  version?: string;
 }
 
 export interface ExampleMetadata {
@@ -100,7 +107,15 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     schemaOptions,
     langAlias,
     defaultTab: propsDefaultTab,
+    version,
   } = props;
+
+  // When version is set, use CDN URLs; otherwise use local static files.
+  const packageName = `@lynx-example/${example}`;
+  const useCdn = !!version;
+  const fileBase = useCdn
+    ? getCdnBaseUrl(packageName, version)
+    : `${EXAMPLE_BASE_URL}/${example}`;
 
   // Instance prop > config provider > undefined (let ExampleContent decide)
   const defaultTab = propsDefaultTab ?? configDefaultTab;
@@ -113,17 +128,29 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
   const [defaultWebPreviewFile, setDefaultWebPreviewFile] = useState('');
   const [initState, setInitState] = useState(false);
   const storeRef = useRef<Record<string, string>>({});
+  // Clear file content cache when version/example changes (fileBase encodes both)
+  const prevFileBase = useRef(fileBase);
+  if (prevFileBase.current !== fileBase) {
+    storeRef.current = {};
+    prevFileBase.current = fileBase;
+  }
   const highlightData = useMemo(() => {
     return typeof highlight === 'string'
       ? { [defaultFile]: highlight }
       : highlight || {};
   }, [highlight, defaultFile]);
 
+  // Metadata: from CDN (constructed from jsdelivr API) or from local static file
   const { error, data: exampleData } = useSWR<ExampleMetadata>(
-    `${EXAMPLE_BASE_URL}/${example}/example-metadata.json`,
+    useCdn
+      ? `cdn:${packageName}@${version}`
+      : `${EXAMPLE_BASE_URL}/${example}/example-metadata.json`,
 
-    async (url) => {
-      const response = await fetch(url);
+    async (key) => {
+      if (useCdn) {
+        return await fetchExampleMetadata(packageName, version);
+      }
+      const response = await fetch(key);
       if (!response.ok) {
         throw new Error(response.status.toString());
       }
@@ -133,7 +160,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
   );
 
   const { trigger } = useSWRMutation(
-    `${EXAMPLE_BASE_URL}/${example}/${currentName}`,
+    `${fileBase}/${currentName}`,
     async (url) => {
       const response = await fetch(url);
       if (!response.ok) {
@@ -149,7 +176,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
   };
   useEffect(() => {
     if (isAssetFile) {
-      setCurrentFile(`${EXAMPLE_BASE_URL}/${example}/${currentName}`);
+      setCurrentFile(`${fileBase}/${currentName}`);
     } else {
       if (storeRef.current[currentName]) {
         setCurrentFile(storeRef.current[currentName]);
@@ -160,14 +187,16 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
         });
       }
     }
-  }, [currentName, isAssetFile]);
+  }, [currentName, isAssetFile, fileBase]);
 
   const currentEntryFileUrl = useMemo(() => {
     const file = exampleData?.templateFiles?.find(
       (file) => file.name === currentEntry,
     );
     if (file) {
-      const url = `${window.location.origin}${EXAMPLE_BASE_URL}/${example}/${file?.file}`;
+      const url = useCdn
+        ? `${fileBase}/${file.file}`
+        : `${window.location.origin}${EXAMPLE_BASE_URL}/${example}/${file?.file}`;
       if (schema) {
         const schemaUrl = schema.replace('{{{url}}}', url);
         return schemaUrl;
@@ -175,7 +204,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       return url;
     }
     return '';
-  }, [exampleData, currentEntry, schema]);
+  }, [exampleData, currentEntry, schema, fileBase, useCdn]);
   useEffect(() => {
     if (exampleData?.templateFiles && exampleData?.templateFiles.length > 0) {
       let tmpEntry;
@@ -203,7 +232,9 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       }
       if (tmpEntry) {
         if (tmpEntry.webFile) {
-          const fullWebFile = `${window.location.origin}${EXAMPLE_BASE_URL}/${example}/${tmpEntry.webFile}`;
+          const fullWebFile = useCdn
+            ? `${fileBase}/${tmpEntry.webFile}`
+            : `${window.location.origin}${EXAMPLE_BASE_URL}/${example}/${tmpEntry.webFile}`;
           setDefaultWebPreviewFile(fullWebFile);
         }
         setCurrentEntry(tmpEntry.name);
@@ -233,7 +264,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       previewImage={
         img ||
         (exampleData?.previewImage
-          ? `${EXAMPLE_BASE_URL}/${example}/${exampleData?.previewImage}`
+          ? `${fileBase}/${exampleData?.previewImage}`
           : '')
       }
       langAlias={langAlias}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,12 @@ export type { ExampleMetadata } from './example-preview';
 export { GoConfigProvider, useGoConfig } from './config';
 export type { GoConfig, PreviewTab } from './config';
 export { getFileCodeLanguage } from './example-preview/utils/example-data';
+export {
+  searchExamplePackages,
+  fetchPackageVersions,
+  fetchExampleMetadata,
+  getCdnBaseUrl,
+  getCdnFileUrl,
+  type NpmPackageInfo,
+  type PackageVersionInfo,
+} from './npm-registry';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,14 @@ export { GoConfigProvider, useGoConfig } from './config';
 export type { GoConfig, PreviewTab } from './config';
 export { getFileCodeLanguage } from './example-preview/utils/example-data';
 export {
+  EXAMPLE_SCOPES,
+  findScopeForPackage,
   searchExamplePackages,
   fetchPackageVersions,
   fetchExampleMetadata,
   getCdnBaseUrl,
   getCdnFileUrl,
+  type ExampleScopeConfig,
   type NpmPackageInfo,
   type PackageVersionInfo,
 } from './npm-registry';

--- a/src/npm-registry.ts
+++ b/src/npm-registry.ts
@@ -1,24 +1,48 @@
 /**
- * Runtime helpers for fetching @lynx-example packages from the npm registry
+ * Runtime helpers for fetching example packages from the npm registry
  * and serving their files via the jsdelivr CDN.
+ *
+ * Supports multiple package scopes (@lynx-example, @vue-lynx-example, etc.)
+ * via the shared EXAMPLE_SCOPES configuration.
  *
  * This module enables fetching any version of any example package directly
  * in the browser — no build-time preparation needed.
  */
 
-const NPM_SEARCH_URL =
-  'https://registry.npmjs.org/-/v1/search?text=%40lynx-example&size=250';
 const JSDELIVR_DATA_BASE = 'https://data.jsdelivr.com/v1/packages/npm';
 const JSDELIVR_CDN_BASE = 'https://cdn.jsdelivr.net/npm';
 
-const EXAMPLE_GIT_BASE_URL =
-  'https://github.com/lynx-family/lynx-examples/tree/main';
+// --- Scope configuration (shared source of truth) ---
+
+export interface ExampleScopeConfig {
+  /** npm scope including trailing slash, e.g. '@lynx-example/' */
+  scope: string;
+  /** Directory/shortName prefix for this scope, e.g. '' or 'vue-' */
+  prefix: string;
+  /** Git base URL for linking to example source */
+  exampleGitBaseUrl: string;
+}
+
+export const EXAMPLE_SCOPES: ExampleScopeConfig[] = [
+  {
+    scope: '@lynx-example/',
+    prefix: '',
+    exampleGitBaseUrl:
+      'https://github.com/lynx-family/lynx-examples/tree/main',
+  },
+  {
+    scope: '@vue-lynx-example/',
+    prefix: 'vue-',
+    exampleGitBaseUrl: 'https://github.com/Huxpro/vue-lynx/tree/main',
+  },
+];
 
 // --- Types ---
 
 export interface NpmPackageInfo {
   name: string;
   shortName: string;
+  scope: ExampleScopeConfig;
   description?: string;
   version: string;
 }
@@ -44,20 +68,45 @@ interface JsdelivrEntry {
 // --- Public API ---
 
 /**
- * Search the npm registry for all @lynx-example/* packages.
+ * Look up the scope config for a given package name.
+ */
+export function findScopeForPackage(
+  packageName: string,
+): ExampleScopeConfig | undefined {
+  return EXAMPLE_SCOPES.find((s) => packageName.startsWith(s.scope));
+}
+
+/**
+ * Search the npm registry for example packages across all configured scopes.
  */
 export async function searchExamplePackages(): Promise<NpmPackageInfo[]> {
-  const res = await fetch(NPM_SEARCH_URL);
-  if (!res.ok) throw new Error(`npm search failed: HTTP ${res.status}`);
-  const data = await res.json();
-  return data.objects
-    .filter((obj: any) => obj.package.name.startsWith('@lynx-example/'))
-    .map((obj: any) => ({
-      name: obj.package.name,
-      shortName: obj.package.name.replace('@lynx-example/', ''),
-      description: obj.package.description,
-      version: obj.package.version,
-    }))
+  const results = await Promise.all(
+    EXAMPLE_SCOPES.map(async (scopeConfig) => {
+      const encoded = encodeURIComponent(
+        scopeConfig.scope.slice(0, -1), // drop trailing /
+      );
+      const url = `https://registry.npmjs.org/-/v1/search?text=${encoded}&size=250`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`npm search failed: HTTP ${res.status}`);
+      const data = await res.json();
+      return data.objects
+        .filter((obj: any) =>
+          obj.package.name.startsWith(scopeConfig.scope),
+        )
+        .map((obj: any) => ({
+          name: obj.package.name,
+          shortName:
+            scopeConfig.prefix +
+            obj.package.name.replace(scopeConfig.scope, ''),
+          scope: scopeConfig,
+          description: obj.package.description,
+          version: obj.package.version,
+        }));
+    }),
+  );
+
+  return results
+    .flat()
     .sort((a: NpmPackageInfo, b: NpmPackageInfo) =>
       a.shortName.localeCompare(b.shortName),
     );
@@ -132,7 +181,10 @@ export async function fetchExampleMetadata(
   version: string,
 ): Promise<ExampleMetadata> {
   const allFiles = await fetchPackageFiles(packageName, version);
-  const shortName = packageName.replace('@lynx-example/', '');
+  const scopeConfig = findScopeForPackage(packageName);
+  const shortName = scopeConfig
+    ? packageName.replace(scopeConfig.scope, '')
+    : packageName;
 
   const filtered = allFiles.filter(
     (f) => !PREVIEW_IMAGE_RE.test(f) && !IGNORE_FILES.includes(f),
@@ -162,7 +214,8 @@ export async function fetchExampleMetadata(
     files: sorted,
     templateFiles,
     previewImage,
-    exampleGitBaseUrl: EXAMPLE_GIT_BASE_URL,
+    exampleGitBaseUrl:
+      scopeConfig?.exampleGitBaseUrl ?? EXAMPLE_SCOPES[0].exampleGitBaseUrl,
   };
 }
 

--- a/src/npm-registry.ts
+++ b/src/npm-registry.ts
@@ -1,0 +1,214 @@
+/**
+ * Runtime helpers for fetching @lynx-example packages from the npm registry
+ * and serving their files via the jsdelivr CDN.
+ *
+ * This module enables fetching any version of any example package directly
+ * in the browser — no build-time preparation needed.
+ */
+
+const NPM_SEARCH_URL =
+  'https://registry.npmjs.org/-/v1/search?text=%40lynx-example&size=250';
+const JSDELIVR_DATA_BASE = 'https://data.jsdelivr.com/v1/packages/npm';
+const JSDELIVR_CDN_BASE = 'https://cdn.jsdelivr.net/npm';
+
+const EXAMPLE_GIT_BASE_URL =
+  'https://github.com/lynx-family/lynx-examples/tree/main';
+
+// --- Types ---
+
+export interface NpmPackageInfo {
+  name: string;
+  shortName: string;
+  description?: string;
+  version: string;
+}
+
+export interface PackageVersionInfo {
+  version: string;
+}
+
+interface JsdelivrFile {
+  name: string;
+  hash: string;
+  size: number;
+}
+
+interface JsdelivrEntry {
+  type: 'file' | 'directory';
+  name: string;
+  hash?: string;
+  size?: number;
+  files?: JsdelivrEntry[];
+}
+
+// --- Public API ---
+
+/**
+ * Search the npm registry for all @lynx-example/* packages.
+ */
+export async function searchExamplePackages(): Promise<NpmPackageInfo[]> {
+  const res = await fetch(NPM_SEARCH_URL);
+  if (!res.ok) throw new Error(`npm search failed: HTTP ${res.status}`);
+  const data = await res.json();
+  return data.objects
+    .filter((obj: any) => obj.package.name.startsWith('@lynx-example/'))
+    .map((obj: any) => ({
+      name: obj.package.name,
+      shortName: obj.package.name.replace('@lynx-example/', ''),
+      description: obj.package.description,
+      version: obj.package.version,
+    }))
+    .sort((a: NpmPackageInfo, b: NpmPackageInfo) =>
+      a.shortName.localeCompare(b.shortName),
+    );
+}
+
+/**
+ * Fetch all published versions for a given package.
+ */
+export async function fetchPackageVersions(
+  packageName: string,
+): Promise<PackageVersionInfo[]> {
+  const res = await fetch(`${JSDELIVR_DATA_BASE}/${packageName}`);
+  if (!res.ok)
+    throw new Error(`jsdelivr versions failed: HTTP ${res.status}`);
+  const data = await res.json();
+  // versions come newest-first from jsdelivr
+  return (data.versions ?? []).map((v: any) => ({ version: v.version }));
+}
+
+/**
+ * Fetch file listing for a specific package version from jsdelivr.
+ * Returns a flat list of relative file paths (matching the format of
+ * the build-time example-metadata.json `files` field).
+ */
+export async function fetchPackageFiles(
+  packageName: string,
+  version: string,
+): Promise<string[]> {
+  const res = await fetch(`${JSDELIVR_DATA_BASE}/${packageName}@${version}`);
+  if (!res.ok)
+    throw new Error(`jsdelivr package files failed: HTTP ${res.status}`);
+  const data = await res.json();
+  return flattenJsdelivrTree(data.files ?? []);
+}
+
+/**
+ * Build a CDN URL for a specific file in a package version.
+ */
+export function getCdnFileUrl(
+  packageName: string,
+  version: string,
+  filePath: string,
+): string {
+  return `${JSDELIVR_CDN_BASE}/${packageName}@${version}/${filePath}`;
+}
+
+/**
+ * Build a CDN base URL for a package version (used as exampleBasePath).
+ */
+export function getCdnBaseUrl(
+  packageName: string,
+  version: string,
+): string {
+  return `${JSDELIVR_CDN_BASE}/${packageName}@${version}`;
+}
+
+// --- ExampleMetadata construction ---
+
+import type { ExampleMetadata } from './example-preview';
+
+const LYNX_ENTRY_SUFFIX = '.lynx.bundle';
+const WEB_ENTRY_SUFFIX = '.web.bundle';
+const PREVIEW_IMAGE_RE = /^preview-image\.(png|jpg|jpeg|webp|gif)$/;
+const IGNORE_FILES = ['LICENSE', '.DS_Store', 'example-metadata.json'];
+
+/**
+ * Construct an ExampleMetadata object from a jsdelivr file listing,
+ * compatible with the existing ExamplePreview component.
+ */
+export async function fetchExampleMetadata(
+  packageName: string,
+  version: string,
+): Promise<ExampleMetadata> {
+  const allFiles = await fetchPackageFiles(packageName, version);
+  const shortName = packageName.replace('@lynx-example/', '');
+
+  const filtered = allFiles.filter(
+    (f) => !PREVIEW_IMAGE_RE.test(f) && !IGNORE_FILES.includes(f),
+  );
+
+  const sorted = sortFiles(filtered);
+  const previewImage = allFiles.find((f) => PREVIEW_IMAGE_RE.test(f));
+  const templateFiles = getTemplateFiles(filtered);
+
+  // Try to read repository.directory from package.json for the name field
+  let name = shortName;
+  try {
+    const pkgUrl = getCdnFileUrl(packageName, version, 'package.json');
+    const res = await fetch(pkgUrl);
+    if (res.ok) {
+      const pkg = await res.json();
+      if (pkg.repository?.directory) {
+        name = pkg.repository.directory;
+      }
+    }
+  } catch {
+    // ignore — use shortName
+  }
+
+  return {
+    name,
+    files: sorted,
+    templateFiles,
+    previewImage,
+    exampleGitBaseUrl: EXAMPLE_GIT_BASE_URL,
+  };
+}
+
+// --- Internal helpers ---
+
+function flattenJsdelivrTree(
+  entries: JsdelivrEntry[],
+  prefix = '',
+): string[] {
+  const result: string[] = [];
+  for (const entry of entries) {
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.type === 'file') {
+      result.push(path);
+    } else if (entry.type === 'directory' && entry.files) {
+      result.push(...flattenJsdelivrTree(entry.files, path));
+    }
+  }
+  return result;
+}
+
+function getTemplateFiles(
+  files: string[],
+): ExampleMetadata['templateFiles'] {
+  const entries: ExampleMetadata['templateFiles'] = [];
+  for (const file of files) {
+    if (file.endsWith(LYNX_ENTRY_SUFFIX)) {
+      const parts = file.split('/');
+      const basename = parts[parts.length - 1];
+      const name =
+        basename.replace(LYNX_ENTRY_SUFFIX, '') ||
+        parts[parts.length - 2] ||
+        '';
+      const entry: ExampleMetadata['templateFiles'][number] = { name, file };
+      const webFile = file.replace(LYNX_ENTRY_SUFFIX, WEB_ENTRY_SUFFIX);
+      if (files.includes(webFile)) {
+        entry.webFile = webFile;
+      }
+      entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+function sortFiles(files: string[]): string[] {
+  const dirs = files.filter((f) => f.includes('/')).sort();
+  const flat = files.filter((f) => !f.includes('/')).sort();
+  return [...dirs, ...flat];
+}


### PR DESCRIPTION
## Summary

Implemented runtime npm registry discovery for @lynx-example packages, enabling browsing any version directly from the CDN without build-time preparation.

- **New npm-registry.ts**: Runtime helpers for npm search API and jsdelivr CDN queries
- **Version support**: ExamplePreview now accepts optional `version` prop to fetch from CDN
- **Example app UI**: Added version selector dropdown and runtime example list discovery
- **Zero build overhead**: Examples no longer cached in public/; enables instant version switching

## Test Plan

- [ ] Load example app at http://localhost:5969
- [ ] Verify example list populates from npm (loading indicator shows briefly)
- [ ] Select an example and verify version dropdown fills with available versions
- [ ] Switch versions and verify metadata reloads from CDN
- [ ] Switch examples and verify version resets to latest