### PR TITLE
fix: make props panel responsive with equal columns on mobile

### DIFF
--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -867,7 +867,7 @@ function App() {
             {/* Col 1: examples list */}
             <div
               style={{
-                flex: col1W != null ? `0 0 ${col1W}px` : '1 1 0',
+                flex: col1W != null ? `0 0 ${col1W}px` : '2 1 0',
                 minWidth: 140,
                 padding: '10px 12px',
                 overflow: 'auto',
@@ -970,7 +970,7 @@ function App() {
             {/* Col 2: entry list */}
             <div
               style={{
-                flex: col2W != null ? `0 0 ${col2W}px` : '1 1 0',
+                flex: col2W != null ? `0 0 ${col2W}px` : '2 1 0',
                 minWidth: 120,
                 padding: '10px 12px',
                 overflow: 'auto',
@@ -1060,7 +1060,7 @@ function App() {
             {/* Col 3: controls */}
             <div
               style={{
-                flex: col3W != null ? `0 0 ${col3W}px` : '1 1 0',
+                flex: col3W != null ? `0 0 ${col3W}px` : '3 1 0',
                 minWidth: 200,
                 padding: '10px 16px',
                 overflow: 'hidden',
@@ -1130,7 +1130,7 @@ function App() {
             {/* Right: metadata JSON */}
             <div
               style={{
-                flex: col4W != null ? `0 0 ${col4W}px` : '1 1 0',
+                flex: col4W != null ? `0 0 ${col4W}px` : '3 1 0',
                 minWidth: 160,
                 padding: '10px 16px',
                 overflow: 'auto',

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -363,7 +363,7 @@ function ColumnResizer({
   onWidthChange,
   reverse,
 }: {
-  widthRef: React.RefObject<number>;
+  widthRef: React.RefObject<number | null>;
   onWidthChange: (w: number) => void;
   reverse?: boolean;
 }) {
@@ -373,7 +373,9 @@ function ColumnResizer({
       const el = e.currentTarget as HTMLElement;
       el.setPointerCapture(e.pointerId);
       const startX = e.clientX;
-      const startW = widthRef.current!;
+      // If no pixel width yet (initial 25% mode), measure the adjacent column
+      const sibling = reverse ? el.nextElementSibling : el.previousElementSibling;
+      const startW = widthRef.current ?? (sibling as HTMLElement)?.offsetWidth ?? 200;
       const sign = reverse ? -1 : 1;
       const onPointerMove = (ev: PointerEvent) => {
         onWidthChange(Math.max(80, startW + (ev.clientX - startX) * sign));
@@ -535,16 +537,19 @@ function App() {
   const jsxPreRef = useRef<HTMLPreElement>(null);
   const [metadataHtml, setMetadataHtml] = useState('');
 
-  // Resizable column widths
-  const col1Ref = useRef(180);
-  const col2Ref = useRef(180);
-  const col4Ref = useRef(300);
-  const [col1W, setCol1W] = useState(180);
-  const [col2W, setCol2W] = useState(180);
-  const [col4W, setCol4W] = useState(300);
+  // Resizable column widths – null means "use flex: 1 1 0" (equal 25%)
+  const col1Ref = useRef<number | null>(null);
+  const col2Ref = useRef<number | null>(null);
+  const col3Ref = useRef<number | null>(null);
+  const col4Ref = useRef<number | null>(null);
+  const [col1W, setCol1W] = useState<number | null>(null);
+  const [col2W, setCol2W] = useState<number | null>(null);
+  const [col3W, setCol3W] = useState<number | null>(null);
+  const [col4W, setCol4W] = useState<number | null>(null);
 
   const setCol1 = useCallback((w: number) => { col1Ref.current = w; setCol1W(w); }, []);
   const setCol2 = useCallback((w: number) => { col2Ref.current = w; setCol2W(w); }, []);
+  const setCol3 = useCallback((w: number) => { col3Ref.current = w; setCol3W(w); }, []);
   const setCol4 = useCallback((w: number) => { col4Ref.current = w; setCol4W(w); }, []);
 
   const jsxString = useMemo(
@@ -856,12 +861,14 @@ function App() {
               background: 'var(--sb-bg)',
               display: 'flex',
               overflowX: 'auto',
+              minWidth: 0,
             }}
           >
             {/* Col 1: examples list */}
             <div
               style={{
-                flex: `0 0 ${col1W}px`,
+                flex: col1W != null ? `0 0 ${col1W}px` : '1 1 0',
+                minWidth: 140,
                 padding: '10px 12px',
                 overflow: 'auto',
                 maxHeight: 200,
@@ -963,7 +970,8 @@ function App() {
             {/* Col 2: entry list */}
             <div
               style={{
-                flex: `0 0 ${col2W}px`,
+                flex: col2W != null ? `0 0 ${col2W}px` : '1 1 0',
+                minWidth: 120,
                 padding: '10px 12px',
                 overflow: 'auto',
                 maxHeight: 200,
@@ -1052,8 +1060,8 @@ function App() {
             {/* Col 3: controls */}
             <div
               style={{
-                flex: '1 1 0',
-                minWidth: 120,
+                flex: col3W != null ? `0 0 ${col3W}px` : '1 1 0',
+                minWidth: 200,
                 padding: '10px 16px',
                 overflow: 'hidden',
                 display: 'grid',
@@ -1117,13 +1125,13 @@ function App() {
               />
             </div>
 
-            <ColumnResizer widthRef={col4Ref} onWidthChange={setCol4} reverse />
+            <ColumnResizer widthRef={col3Ref} onWidthChange={setCol3} />
 
             {/* Right: metadata JSON */}
             <div
               style={{
-                flex: `0 0 ${col4W}px`,
-                minWidth: 0,
+                flex: col4W != null ? `0 0 ${col4W}px` : '1 1 0',
+                minWidth: 160,
                 padding: '10px 16px',
                 overflow: 'auto',
                 maxHeight: 200,

--- a/src/example-preview/components/code.tsx
+++ b/src/example-preview/components/code.tsx
@@ -26,6 +26,11 @@ export const Code: FC<CodeProps> = ({
   const [highlightVal, setHighlightVal] = useState(highlight);
   const defaultValRef = useRef(val);
 
+  // Track whether shiki has finished rendering the current code.
+  // Hide the code block until highlighting is complete to avoid FOUC.
+  const [renderedVal, setRenderedVal] = useState('');
+  const isCodeReady = val !== '' && val === renderedVal;
+
   function scrollToFirstHighlightLine() {
     if (!val) {
       return;
@@ -81,10 +86,15 @@ export const Code: FC<CodeProps> = ({
     setHighlightVal(highlight);
   }, [highlight]);
   return (
-    <div ref={containerRef} className={styles.code}>
+    <div
+      ref={containerRef}
+      className={styles.code}
+      style={{ visibility: isCodeReady ? 'visible' : 'hidden' }}
+    >
       <CodeBlock
         lang={language}
         onRendered={() => {
+          setRenderedVal(val);
           scrollToFirstHighlightLine();
         }}
         code={val}

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -27,6 +27,7 @@ import { CodeView } from './code-view';
 import { SwitchSchema } from './switch-schema';
 import { PreviewImg } from './preview-img';
 import { SplitPane, type SplitPaneHandle } from './split-pane';
+import { LoadingOverlay } from './loading-overlay';
 
 import {
   IconGithub,
@@ -80,6 +81,8 @@ interface ExampleContentProps {
   exampleGitBaseUrl?: string;
   langAlias?: Record<string, string>;
   defaultTab?: PreviewTab;
+  /** Go-level loading state: true while metadata + initial code are being fetched. */
+  loading?: boolean;
 }
 
 export const ExampleContent: FC<ExampleContentProps> = ({
@@ -104,6 +107,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   exampleGitBaseUrl,
   langAlias,
   defaultTab,
+  loading,
 }) => {
   const {
     explorerUrl,
@@ -208,6 +212,11 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   return (
     <div className={`${s.box} ${fullscreenMode !== 'off' ? s['box-fullscreen'] : ''} ${!showCode ? s['box-code-collapsed'] : ''} ${hasPreview && !showPreview ? s['box-preview-collapsed'] : ''}`} ref={boxRef}>
       <div className={s.container} ref={containerRef}>
+        {loading && (
+          <div style={{ position: 'absolute', inset: 0, zIndex: 2 }}>
+            <LoadingOverlay visible />
+          </div>
+        )}
         <div className={s.content}>
           {hasPreview ? (
             <SplitPane

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -27,7 +27,6 @@ import { CodeView } from './code-view';
 import { SwitchSchema } from './switch-schema';
 import { PreviewImg } from './preview-img';
 import { SplitPane, type SplitPaneHandle } from './split-pane';
-import { LoadingOverlay } from './loading-overlay';
 
 import {
   IconGithub,
@@ -81,8 +80,6 @@ interface ExampleContentProps {
   exampleGitBaseUrl?: string;
   langAlias?: Record<string, string>;
   defaultTab?: PreviewTab;
-  /** Go-level loading state: true while metadata + initial code are being fetched. */
-  loading?: boolean;
 }
 
 export const ExampleContent: FC<ExampleContentProps> = ({
@@ -107,7 +104,6 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   exampleGitBaseUrl,
   langAlias,
   defaultTab,
-  loading,
 }) => {
   const {
     explorerUrl,
@@ -212,11 +208,6 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   return (
     <div className={`${s.box} ${fullscreenMode !== 'off' ? s['box-fullscreen'] : ''} ${!showCode ? s['box-code-collapsed'] : ''} ${hasPreview && !showPreview ? s['box-preview-collapsed'] : ''}`} ref={boxRef}>
       <div className={s.container} ref={containerRef}>
-        {loading && (
-          <div style={{ position: 'absolute', inset: 0, zIndex: 2 }}>
-            <LoadingOverlay visible />
-          </div>
-        )}
         <div className={s.content}>
           {hasPreview ? (
             <SplitPane

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -113,6 +113,28 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
   const [defaultWebPreviewFile, setDefaultWebPreviewFile] = useState('');
   const [initState, setInitState] = useState(false);
   const storeRef = useRef<Record<string, string>>({});
+  const [isExampleLoading, setIsExampleLoading] = useState(true);
+
+  // Reset internal state when the example changes so that
+  // we get a clean loading → ready transition with no stale data.
+  useEffect(() => {
+    setIsExampleLoading(true);
+    setCurrentName(defaultFile);
+    setCurrentFile('');
+    setIsAssetFile(isAssetFileType(defaultFile));
+    setCurrentEntry('');
+    setDefaultWebPreviewFile('');
+    setInitState(false);
+    storeRef.current = {};
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [example]);
+
+  // Hide the loading overlay once metadata and initial code are both ready.
+  useEffect(() => {
+    if (initState && currentFile) {
+      setIsExampleLoading(false);
+    }
+  }, [initState, currentFile]);
   const highlightData = useMemo(() => {
     return typeof highlight === 'string'
       ? { [defaultFile]: highlight }
@@ -249,6 +271,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       schemaOptions={schema ? undefined : schemaOptions}
       exampleGitBaseUrl={exampleData?.exampleGitBaseUrl}
       defaultTab={defaultTab}
+      loading={isExampleLoading}
     />
   );
 };

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -113,12 +113,10 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
   const [defaultWebPreviewFile, setDefaultWebPreviewFile] = useState('');
   const [initState, setInitState] = useState(false);
   const storeRef = useRef<Record<string, string>>({});
-  const [isExampleLoading, setIsExampleLoading] = useState(true);
 
   // Reset internal state when the example changes so that
-  // we get a clean loading → ready transition with no stale data.
+  // stale data from the previous example is not shown.
   useEffect(() => {
-    setIsExampleLoading(true);
     setCurrentName(defaultFile);
     setCurrentFile('');
     setIsAssetFile(isAssetFileType(defaultFile));
@@ -128,13 +126,6 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     storeRef.current = {};
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [example]);
-
-  // Hide the loading overlay once metadata and initial code are both ready.
-  useEffect(() => {
-    if (initState && currentFile) {
-      setIsExampleLoading(false);
-    }
-  }, [initState, currentFile]);
   const highlightData = useMemo(() => {
     return typeof highlight === 'string'
       ? { [defaultFile]: highlight }
@@ -271,7 +262,6 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       schemaOptions={schema ? undefined : schemaOptions}
       exampleGitBaseUrl={exampleData?.exampleGitBaseUrl}
       defaultTab={defaultTab}
-      loading={isExampleLoading}
     />
   );
 };


### PR DESCRIPTION
Change all 4 columns in the props panel to default to equal flex-basis (25%) with reasonable min-widths. This enables horizontal scrolling on mobile instead of over-compressing the props content. Add col3 (Props) to the resizable system and update ColumnResizer to handle initial flex-based widths.

## Changes
- All columns now start with equal 25% width (flex: 1 1 0)
- Each column has reasonable min-widths: 140px, 120px, 200px, 160px
- Props column (col3) is now also resizable
- Container uses horizontal scroll on narrow viewports instead of compressing text