### PR TITLE
feat: decouple source and preview panels

### DIFF
--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -151,6 +151,7 @@ interface UrlState {
   tab?: PreviewTab;
   file?: string;
   example?: string;
+  mode?: 'linked' | 'preview-only' | 'source-only';
 }
 
 function readUrlState(): UrlState {
@@ -416,6 +417,7 @@ function buildJsxString({
   highlight,
   img,
   schema,
+  mode,
 }: {
   example: string;
   defaultFile: string;
@@ -425,13 +427,14 @@ function buildJsxString({
   highlight: string;
   img: string;
   schema: string;
+  mode: 'linked' | 'preview-only' | 'source-only';
 }): string {
   const props: string[] = [`example="${example}"`];
-  if (defaultFile) props.push(`defaultFile="${defaultFile}"`);
-  if (defaultTab !== 'web') props.push(`defaultTab="${defaultTab}"`);
-  if (defaultEntryFile) props.push(`defaultEntryFile="${defaultEntryFile}"`);
-  if (highlight) props.push(`highlight="${highlight}"`);
-  if (entryFilter) {
+  if (defaultFile && mode !== 'preview-only') props.push(`defaultFile="${defaultFile}"`);
+  if (defaultTab !== 'web' && mode !== 'source-only') props.push(`defaultTab="${defaultTab}"`);
+  if (defaultEntryFile && mode !== 'source-only') props.push(`defaultEntryFile="${defaultEntryFile}"`);
+  if (highlight && mode !== 'preview-only') props.push(`highlight="${highlight}"`);
+  if (entryFilter && mode !== 'source-only') {
     if (entryFilter.includes(',')) {
       props.push(
         `entry={${JSON.stringify(entryFilter.split(',').map((s) => s.trim()))}}`,
@@ -440,8 +443,9 @@ function buildJsxString({
       props.push(`entry="${entryFilter}"`);
     }
   }
-  if (schema) props.push(`schema="${schema}"`);
-  if (img) props.push(`img="${img}"`);
+  if (schema && mode !== 'source-only') props.push(`schema="${schema}"`);
+  if (img && mode !== 'source-only') props.push(`img="${img}"`);
+  if (mode !== 'linked') props.push(`mode="${mode}"`);
 
   if (props.length <= 2) {
     return `<Go ${props.join(' ')} />`;
@@ -515,6 +519,9 @@ function App() {
   const [defaultFile, setDefaultFile] = useState(
     initial.file ?? ((initial.example ?? 'hello-world').startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx'),
   );
+  const [mode, setMode] = useState<'linked' | 'preview-only' | 'source-only'>(
+    initial.mode ?? 'linked'
+  );
   const [copied, setCopied] = useState(false);
   const [exampleSearch, setExampleSearch] = useState('');
   const [entrySearch, setEntrySearch] = useState('');
@@ -558,6 +565,7 @@ function App() {
         highlight,
         img,
         schema,
+        mode,
       }),
     [
       example,
@@ -568,6 +576,7 @@ function App() {
       highlight,
       img,
       schema,
+      mode,
     ],
   );
 
@@ -600,8 +609,8 @@ function App() {
 
   // Persist state to URL hash
   useEffect(() => {
-    writeUrlState({ dark, lang, tab: defaultTab, file: defaultFile, example });
-  }, [dark, lang, defaultTab, defaultFile, example]);
+    writeUrlState({ dark, lang, tab: defaultTab, file: defaultFile, example, mode: mode === 'linked' ? undefined : mode });
+  }, [dark, lang, defaultTab, defaultFile, example, mode]);
 
   // Apply Semi UI dark/light mode
   useEffect(() => {
@@ -799,6 +808,18 @@ function App() {
                   { value: 'qrcode', label: 'QR' },
                 ]}
                 onChange={(v) => setDefaultTab(v as PreviewTab)}
+              />
+            </ControlGroup>
+
+            <ControlGroup label="Mode">
+              <AdaptiveControl
+                value={mode}
+                options={[
+                  { value: 'linked', label: 'Linked' },
+                  { value: 'preview-only', label: 'Preview Only' },
+                  { value: 'source-only', label: 'Source Only' },
+                ]}
+                onChange={(v) => setMode(v as 'linked' | 'preview-only' | 'source-only')}
               />
             </ControlGroup>
 
@@ -1193,7 +1214,7 @@ function App() {
               {/* Desktop */}
               <div style={{ flex: '1 1 500px', minWidth: 0 }}>
                 <Go
-                  key={`desktop-${example}-${selectedEntry}-${defaultTab}`}
+                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${mode}`}
                   example={example}
                   defaultFile={defaultFile}
                   defaultTab={defaultTab}
@@ -1202,6 +1223,7 @@ function App() {
                   highlight={highlight || undefined}
                   img={img || undefined}
                   schema={schema || undefined}
+                  mode={mode}
                 />
                 <div className="figure-caption">Desktop</div>
               </div>
@@ -1223,7 +1245,7 @@ function App() {
                   }}
                 >
                   <Go
-                    key={`mobile-${example}-${selectedEntry}-${defaultTab}`}
+                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${mode}`}
                     example={example}
                     defaultFile={defaultFile}
                     defaultTab={defaultTab}
@@ -1232,6 +1254,7 @@ function App() {
                     highlight={highlight || undefined}
                     img={img || undefined}
                     schema={schema || undefined}
+                    mode={mode}
                   />
                 </div>
                 <div className="figure-caption">Mobile (320 × 660)</div>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -151,7 +151,7 @@ interface UrlState {
   tab?: PreviewTab;
   file?: string;
   example?: string;
-  mode?: 'linked' | 'preview-only' | 'source-only';
+  mode?: 'linked' | 'preview' | 'source';
 }
 
 function readUrlState(): UrlState {
@@ -427,14 +427,14 @@ function buildJsxString({
   highlight: string;
   img: string;
   schema: string;
-  mode: 'linked' | 'preview-only' | 'source-only';
+  mode: 'linked' | 'preview' | 'source';
 }): string {
   const props: string[] = [`example="${example}"`];
-  if (defaultFile && mode !== 'preview-only') props.push(`defaultFile="${defaultFile}"`);
-  if (defaultTab !== 'web' && mode !== 'source-only') props.push(`defaultTab="${defaultTab}"`);
-  if (defaultEntryFile && mode !== 'source-only') props.push(`defaultEntryFile="${defaultEntryFile}"`);
-  if (highlight && mode !== 'preview-only') props.push(`highlight="${highlight}"`);
-  if (entryFilter && mode !== 'source-only') {
+  if (defaultFile && mode !== 'preview') props.push(`defaultFile="${defaultFile}"`);
+  if (defaultTab !== 'web' && mode !== 'source') props.push(`defaultTab="${defaultTab}"`);
+  if (defaultEntryFile && mode !== 'source') props.push(`defaultEntryFile="${defaultEntryFile}"`);
+  if (highlight && mode !== 'preview') props.push(`highlight="${highlight}"`);
+  if (entryFilter && mode !== 'source') {
     if (entryFilter.includes(',')) {
       props.push(
         `entry={${JSON.stringify(entryFilter.split(',').map((s) => s.trim()))}}`,
@@ -443,8 +443,8 @@ function buildJsxString({
       props.push(`entry="${entryFilter}"`);
     }
   }
-  if (schema && mode !== 'source-only') props.push(`schema="${schema}"`);
-  if (img && mode !== 'source-only') props.push(`img="${img}"`);
+  if (schema && mode !== 'source') props.push(`schema="${schema}"`);
+  if (img && mode !== 'source') props.push(`img="${img}"`);
   if (mode !== 'linked') props.push(`mode="${mode}"`);
 
   if (props.length <= 2) {
@@ -519,7 +519,7 @@ function App() {
   const [defaultFile, setDefaultFile] = useState(
     initial.file ?? ((initial.example ?? 'hello-world').startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx'),
   );
-  const [mode, setMode] = useState<'linked' | 'preview-only' | 'source-only'>(
+  const [mode, setMode] = useState<'linked' | 'preview' | 'source'>(
     initial.mode ?? 'linked'
   );
   const [copied, setCopied] = useState(false);
@@ -816,10 +816,10 @@ function App() {
                 value={mode}
                 options={[
                   { value: 'linked', label: 'Linked' },
-                  { value: 'preview-only', label: 'Preview Only' },
-                  { value: 'source-only', label: 'Source Only' },
+                  { value: 'preview', label: 'Preview' },
+                  { value: 'source', label: 'Source' },
                 ]}
-                onChange={(v) => setMode(v as 'linked' | 'preview-only' | 'source-only')}
+                onChange={(v) => setMode(v as 'linked' | 'preview' | 'source')}
               />
             </ControlGroup>
 

--- a/package.json
+++ b/package.json
@@ -57,5 +57,6 @@
     "react-copy-to-clipboard": "^5.1.0",
     "swr": "^2.2.5",
     "vscode-icons-js": "^11.6.1"
-  }
+  },
+  "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321"
 }

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -123,8 +123,8 @@ export const ExampleContent: FC<ExampleContentProps> = ({
 
   const { treeData, doChangeExpand, selectedKeys, expandedKeys, entryData } =
     useTreeController({ fileNames, value: currentFileName, entry });
-  const [showPreview, setShowPreview] = useState(mode !== 'source-only');
-  const [showCode, setShowCode] = useState(mode !== 'preview-only');
+  const [showPreview, setShowPreview] = useState(mode !== 'source');
+  const [showCode, setShowCode] = useState(mode !== 'preview');
   const [showFileTree, setShowFileTree] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const boxRef = useRef<HTMLDivElement>(null);
@@ -425,9 +425,9 @@ export const ExampleContent: FC<ExampleContentProps> = ({
     <div className={`${s.box} ${fullscreenMode !== 'off' ? s['box-fullscreen'] : ''} ${!showCode ? s['box-code-collapsed'] : ''} ${hasPreview && !showPreview ? s['box-preview-collapsed'] : ''}`} ref={boxRef}>
       <div className={s.container} ref={containerRef}>
         <div className={s.content}>
-          {mode === 'preview-only' ? (
+          {mode === 'preview' ? (
             renderPreviewWrap()
-          ) : mode === 'source-only' ? (
+          ) : mode === 'source' ? (
             renderCodeWrap()
           ) : hasPreview ? (
             <SplitPane
@@ -460,7 +460,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
               whiteSpace: 'nowrap',
             }}
           >
-            {mode !== 'preview-only' && (
+            {mode !== 'preview' && (
               <Button
                 theme="borderless"
                 icon={<IconList style={{ color: 'var(--semi-color-text-2)' }} />}
@@ -477,7 +477,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
               >
                 {name}
               </Typography.Text>
-              {mode !== 'preview-only' && (
+              {mode !== 'preview' && (
                 <>
                   <IconChevronRightStroked
                     style={{ color: 'var(--semi-color-text-2)', fontSize: '12px' }}
@@ -494,7 +494,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
             </Space>
           </Space>
           <Space spacing={7}>
-            {mode !== 'preview-only' && (
+            {mode !== 'preview' && (
               <Button
                 theme="borderless"
                 icon={
@@ -552,7 +552,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
                 />
               </Space>
             )}
-            {mode !== 'preview-only' && (
+            {mode !== 'preview' && (
               <Button
                 theme="borderless"
                 icon={

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -58,6 +58,8 @@ enum PreviewType {
   Web = 'Web',
 }
 
+import type { ExamplePreviewMode } from '../index';
+
 interface ExampleContentProps {
   fileNames: string[];
   previewImage: string;
@@ -80,6 +82,7 @@ interface ExampleContentProps {
   exampleGitBaseUrl?: string;
   langAlias?: Record<string, string>;
   defaultTab?: PreviewTab;
+  mode?: ExamplePreviewMode;
 }
 
 export const ExampleContent: FC<ExampleContentProps> = ({
@@ -104,6 +107,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   exampleGitBaseUrl,
   langAlias,
   defaultTab,
+  mode = 'linked',
 }) => {
   const {
     explorerUrl,
@@ -119,8 +123,8 @@ export const ExampleContent: FC<ExampleContentProps> = ({
 
   const { treeData, doChangeExpand, selectedKeys, expandedKeys, entryData } =
     useTreeController({ fileNames, value: currentFileName, entry });
-  const [showPreview, setShowPreview] = useState(true);
-  const [showCode, setShowCode] = useState(true);
+  const [showPreview, setShowPreview] = useState(mode !== 'source-only');
+  const [showCode, setShowCode] = useState(mode !== 'preview-only');
   const [showFileTree, setShowFileTree] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const boxRef = useRef<HTMLDivElement>(null);
@@ -205,11 +209,227 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   const qrcodeUrl = qrcodeUrlWithSchema || currentEntryFileUrl;
 
   const showCodeTab = entryData && entryData?.length > 1;
+
+  const renderCodeWrap = () => (
+    <div className={s['code-wrap']}>
+      <div className={s['code-tab-container']}>
+        {showCodeTab && (
+          <div
+            className={s['code-tab']}
+            ref={(tabsRef) => {
+              tabScrollToTop(tabsRef);
+            }}
+          >
+            <Tabs
+              activeKey={currentFileName}
+              onChange={(v) => updateCurrentName(v)}
+              size="small"
+              preventScroll={true}
+              onTabClose={() => {
+                updateCurrentName(entryData[entryData.length - 1].value);
+                setTmpCurrentFileName('');
+              }}
+            >
+              {entryData.map((file) => (
+                <TabPane
+                  key={file.value}
+                  itemKey={file.value}
+                  tab={file.label}
+                />
+              ))}
+              {tmpCurrentFileName && (
+                <TabPane
+                  key={tmpCurrentFileName}
+                  itemKey={tmpCurrentFileName}
+                  tab={tmpCurrentFileName?.split('/').pop()}
+                  closable={true}
+                />
+              )}
+            </Tabs>
+          </div>
+        )}
+        <div
+          className={`${s['code-view-container']} ${showCodeTab ? s['code-view-container-tab-show'] : ''}`}
+        >
+          <CodeView
+            currentFileName={currentFileName}
+            currentFile={currentFile}
+            isAssetFile={isAssetFile}
+            highlight={highlight}
+            langAlias={langAlias}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderPreviewWrap = () => (
+    <div className={s['preview-wrap']}>
+      <div className={s['preview-wrap-content']}>
+        <div className={s['preview-header']}>
+          <div style={{ width: 24, flexShrink: 0 }} />
+          <RadioGroup
+            onChange={(e) => setPreviewType(e.target.value)}
+            value={previewType}
+            type="button"
+            style={{
+              display: 'flex',
+              flex: 1,
+              minWidth: 0,
+              justifyContent: 'center',
+            }}
+          >
+            {initState ? (
+              <>
+                {previewImage && (
+                  <Radio value={PreviewType.Preview}>
+                    {t('go.preview')}
+                  </Radio>
+                )}
+                {hasWebPreview && (
+                  <Radio value={PreviewType.Web}>Web</Radio>
+                )}
+                {currentEntry && (
+                  <Radio value={PreviewType.QRCode}>
+                    {t('go.qrcode')}
+                  </Radio>
+                )}
+              </>
+            ) : (
+              <div style={{ width: '100%', height: '32px' }}></div>
+            )}
+          </RadioGroup>
+          <Button
+            theme="borderless"
+            icon={
+              fullscreenMode !== 'off' && !showCode ? (
+                <IconExitFullscreen
+                  style={{ color: 'var(--semi-color-text-2)' }}
+                />
+              ) : (
+                <IconFullscreen
+                  style={{ color: 'var(--semi-color-text-2)' }}
+                />
+              )
+            }
+            type="tertiary"
+            size="small"
+            onClick={() => {
+              if (fullscreenMode !== 'off' && !showCode) {
+                setFullscreenMode('off');
+                setShowCode(true);
+              } else if (fullscreenMode !== 'off' && showCode) {
+                setShowCode(false);
+              } else {
+                splitPaneRef.current?.ensureSecondMinSize(320);
+                setFullscreenMode('all');
+                setShowCode(false);
+              }
+            }}
+          />
+        </div>
+
+        {previewType === PreviewType.QRCode && currentEntry && (
+          <div className={s.qrcode}>
+            <Typography.Text
+              size="small"
+              type="tertiary"
+              style={{ margin: '28px 12px', textAlign: 'center' }}
+            >
+              {t('go.scan.message-1')}
+              <Typography.Text
+                link={{
+                  href: withBaseFn(
+                    lang === 'zh'
+                      ? LYNX_EXPLORER_URL_CN
+                      : LYNX_EXPLORER_URL_EN,
+                  ),
+                  target: '_blank',
+                }}
+                size="small"
+                underline
+              >
+                {lynxExplorerText}
+              </Typography.Text>{' '}
+              {t('go.scan.message-2')}
+            </Typography.Text>
+            <div className={s['qrcode-svg']}>
+              <QRCodeSVG value={qrcodeUrl} />
+            </div>
+            <div style={{ marginBottom: '32px' }}>
+              <CopyToClipboard
+                onCopy={() => {
+                  Toast.success(t('go.qrcode.copied'));
+                }}
+                text={qrcodeUrl}
+              >
+                <Button
+                  type="tertiary"
+                  style={{ fontSize: '12px' }}
+                  icon={<IconCopyLink style={{ fontSize: '16px' }} />}
+                >
+                  {t('go.qrcode.copy-link')}
+                </Button>
+              </CopyToClipboard>
+            </div>
+            {schemaOptions && (
+              <SwitchSchema
+                optionsData={schemaOptions}
+                currentEntryFileUrl={currentEntryFileUrl}
+                onSwitchSchema={onSwitchSchema}
+              />
+            )}
+            <div className={s['qrcode-entry']}>
+              <Typography.Text
+                size="small"
+                type="tertiary"
+                style={{ marginRight: '12px', flexShrink: 0 }}
+              >
+                {t('go.qrcode.entry')}
+              </Typography.Text>
+              <Select
+                style={{ width: '100%', maxWidth: '200px' }}
+                value={currentEntry}
+                onChange={(v) => setCurrentEntry(v as string)}
+              >
+                {entryFiles?.map((file) => (
+                  <Select.Option key={file.name} value={file.name}>
+                    {file.name}
+                  </Select.Option>
+                ))}
+              </Select>
+            </div>
+          </div>
+        )}
+        {previewImage && (
+          <PreviewImg
+            show={previewType === PreviewType.Preview}
+            previewImage={previewImage}
+          />
+        )}
+        {hasWebPreview && (
+          <NoSSRComponent>
+            <Suspense fallback={<div>Loading...</div>}>
+              <WebIframe
+                show={previewType === PreviewType.Web}
+                src={defaultWebPreviewFile || ''}
+              />
+            </Suspense>
+          </NoSSRComponent>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className={`${s.box} ${fullscreenMode !== 'off' ? s['box-fullscreen'] : ''} ${!showCode ? s['box-code-collapsed'] : ''} ${hasPreview && !showPreview ? s['box-preview-collapsed'] : ''}`} ref={boxRef}>
       <div className={s.container} ref={containerRef}>
         <div className={s.content}>
-          {hasPreview ? (
+          {mode === 'preview-only' ? (
+            renderPreviewWrap()
+          ) : mode === 'source-only' ? (
+            renderCodeWrap()
+          ) : hasPreview ? (
             <SplitPane
               ref={splitPaneRef}
               show={hasPreview}
@@ -224,267 +444,11 @@ export const ExampleContent: FC<ExampleContentProps> = ({
                 setShowCode(!c);
                 if (c && !showPreview) setShowPreview(true);
               }}
-              first={
-                <div className={s['code-wrap']}>
-                  <div className={s['code-tab-container']}>
-                    {showCodeTab && (
-                      <div
-                        className={s['code-tab']}
-                        ref={(tabsRef) => {
-                          tabScrollToTop(tabsRef);
-                        }}
-                      >
-                        <Tabs
-                          activeKey={currentFileName}
-                          onChange={(v) => updateCurrentName(v)}
-                          size="small"
-                          preventScroll={true}
-                          onTabClose={() => {
-                            updateCurrentName(entryData[entryData.length - 1].value);
-                            setTmpCurrentFileName('');
-                          }}
-                        >
-                          {entryData.map((file) => (
-                            <TabPane
-                              key={file.value}
-                              itemKey={file.value}
-                              tab={file.label}
-                            />
-                          ))}
-                          {tmpCurrentFileName && (
-                            <TabPane
-                              key={tmpCurrentFileName}
-                              itemKey={tmpCurrentFileName}
-                              tab={tmpCurrentFileName?.split('/').pop()}
-                              closable={true}
-                            />
-                          )}
-                        </Tabs>
-                      </div>
-                    )}
-                    <div
-                      className={`${s['code-view-container']} ${showCodeTab ? s['code-view-container-tab-show'] : ''}`}
-                    >
-                      <CodeView
-                        currentFileName={currentFileName}
-                        currentFile={currentFile}
-                        isAssetFile={isAssetFile}
-                        highlight={highlight}
-                        langAlias={langAlias}
-                      />
-                    </div>
-                  </div>
-                </div>
-              }
-              second={
-                <div className={s['preview-wrap']}>
-                  <div className={s['preview-wrap-content']}>
-                    <div className={s['preview-header']}>
-                      <div style={{ width: 24, flexShrink: 0 }} />
-                      <RadioGroup
-                        onChange={(e) => setPreviewType(e.target.value)}
-                        value={previewType}
-                        type="button"
-                        style={{
-                          display: 'flex',
-                          flex: 1,
-                          minWidth: 0,
-                          justifyContent: 'center',
-                        }}
-                      >
-                        {initState ? (
-                          <>
-                            {previewImage && (
-                              <Radio value={PreviewType.Preview}>
-                                {t('go.preview')}
-                              </Radio>
-                            )}
-                            {hasWebPreview && (
-                              <Radio value={PreviewType.Web}>Web</Radio>
-                            )}
-                            {currentEntry && (
-                              <Radio value={PreviewType.QRCode}>
-                                {t('go.qrcode')}
-                              </Radio>
-                            )}
-                          </>
-                        ) : (
-                          <div style={{ width: '100%', height: '32px' }}></div>
-                        )}
-                      </RadioGroup>
-                      <Button
-                        theme="borderless"
-                        icon={
-                          fullscreenMode !== 'off' && !showCode ? (
-                            <IconExitFullscreen
-                              style={{ color: 'var(--semi-color-text-2)' }}
-                            />
-                          ) : (
-                            <IconFullscreen
-                              style={{ color: 'var(--semi-color-text-2)' }}
-                            />
-                          )
-                        }
-                        type="tertiary"
-                        size="small"
-                        onClick={() => {
-                          if (fullscreenMode !== 'off' && !showCode) {
-                            setFullscreenMode('off');
-                            setShowCode(true);
-                          } else if (fullscreenMode !== 'off' && showCode) {
-                            setShowCode(false);
-                          } else {
-                            splitPaneRef.current?.ensureSecondMinSize(320);
-                            setFullscreenMode('all');
-                            setShowCode(false);
-                          }
-                        }}
-                      />
-                    </div>
-
-                    {previewType === PreviewType.QRCode && currentEntry && (
-                      <div className={s.qrcode}>
-                        <Typography.Text
-                          size="small"
-                          type="tertiary"
-                          style={{ margin: '28px 12px', textAlign: 'center' }}
-                        >
-                          {t('go.scan.message-1')}
-                          <Typography.Text
-                            link={{
-                              href: withBaseFn(
-                                lang === 'zh'
-                                  ? LYNX_EXPLORER_URL_CN
-                                  : LYNX_EXPLORER_URL_EN,
-                              ),
-                              target: '_blank',
-                            }}
-                            size="small"
-                            underline
-                          >
-                            {lynxExplorerText}
-                          </Typography.Text>{' '}
-                          {t('go.scan.message-2')}
-                        </Typography.Text>
-                        <div className={s['qrcode-svg']}>
-                          <QRCodeSVG value={qrcodeUrl} />
-                        </div>
-                        <div style={{ marginBottom: '32px' }}>
-                          <CopyToClipboard
-                            onCopy={() => {
-                              Toast.success(t('go.qrcode.copied'));
-                            }}
-                            text={qrcodeUrl}
-                          >
-                            <Button
-                              type="tertiary"
-                              style={{ fontSize: '12px' }}
-                              icon={<IconCopyLink style={{ fontSize: '16px' }} />}
-                            >
-                              {t('go.qrcode.copy-link')}
-                            </Button>
-                          </CopyToClipboard>
-                        </div>
-                        {schemaOptions && (
-                          <SwitchSchema
-                            optionsData={schemaOptions}
-                            currentEntryFileUrl={currentEntryFileUrl}
-                            onSwitchSchema={onSwitchSchema}
-                          />
-                        )}
-                        <div className={s['qrcode-entry']}>
-                          <Typography.Text
-                            size="small"
-                            type="tertiary"
-                            style={{ marginRight: '12px', flexShrink: 0 }}
-                          >
-                            {t('go.qrcode.entry')}
-                          </Typography.Text>
-                          <Select
-                            style={{ width: '100%', maxWidth: '200px' }}
-                            value={currentEntry}
-                            onChange={(v) => setCurrentEntry(v as string)}
-                          >
-                            {entryFiles?.map((file) => (
-                              <Select.Option key={file.name} value={file.name}>
-                                {file.name}
-                              </Select.Option>
-                            ))}
-                          </Select>
-                        </div>
-                      </div>
-                    )}
-                    {previewImage && (
-                      <PreviewImg
-                        show={previewType === PreviewType.Preview}
-                        previewImage={previewImage}
-                      />
-                    )}
-                    {hasWebPreview && (
-                      <NoSSRComponent>
-                        <Suspense fallback={<div>Loading...</div>}>
-                          <WebIframe
-                            show={previewType === PreviewType.Web}
-                            src={defaultWebPreviewFile || ''}
-                          />
-                        </Suspense>
-                      </NoSSRComponent>
-                    )}
-                  </div>
-                </div>
-              }
+              first={renderCodeWrap()}
+              second={renderPreviewWrap()}
             />
           ) : (
-            <div className={s['code-wrap']}>
-              <div className={s['code-tab-container']}>
-                {showCodeTab && (
-                  <div
-                    className={s['code-tab']}
-                    ref={(tabsRef) => {
-                      tabScrollToTop(tabsRef);
-                    }}
-                  >
-                    <Tabs
-                      activeKey={currentFileName}
-                      onChange={(v) => updateCurrentName(v)}
-                      size="small"
-                      preventScroll={true}
-                      onTabClose={() => {
-                        updateCurrentName(entryData[entryData.length - 1].value);
-                        setTmpCurrentFileName('');
-                      }}
-                    >
-                      {entryData.map((file) => (
-                        <TabPane
-                          key={file.value}
-                          itemKey={file.value}
-                          tab={file.label}
-                        />
-                      ))}
-                      {tmpCurrentFileName && (
-                        <TabPane
-                          key={tmpCurrentFileName}
-                          itemKey={tmpCurrentFileName}
-                          tab={tmpCurrentFileName?.split('/').pop()}
-                          closable={true}
-                        />
-                      )}
-                    </Tabs>
-                  </div>
-                )}
-                <div
-                  className={`${s['code-view-container']} ${showCodeTab ? s['code-view-container-tab-show'] : ''}`}
-                >
-                  <CodeView
-                    currentFileName={currentFileName}
-                    currentFile={currentFile}
-                    isAssetFile={isAssetFile}
-                    highlight={highlight}
-                    langAlias={langAlias}
-                  />
-                </div>
-              </div>
-            </div>
+            renderCodeWrap()
           )}
         </div>
         <div className={s.footer}>
@@ -496,13 +460,15 @@ export const ExampleContent: FC<ExampleContentProps> = ({
               whiteSpace: 'nowrap',
             }}
           >
-            <Button
-              theme="borderless"
-              icon={<IconList style={{ color: 'var(--semi-color-text-2)' }} />}
-              type="tertiary"
-              size="small"
-              onClick={() => setShowFileTree(true)}
-            />
+            {mode !== 'preview-only' && (
+              <Button
+                theme="borderless"
+                icon={<IconList style={{ color: 'var(--semi-color-text-2)' }} />}
+                type="tertiary"
+                size="small"
+                onClick={() => setShowFileTree(true)}
+              />
+            )}
             <Space spacing={2} style={{ overflow: 'hidden' }}>
               <Typography.Text
                 size="small"
@@ -511,34 +477,40 @@ export const ExampleContent: FC<ExampleContentProps> = ({
               >
                 {name}
               </Typography.Text>
-              <IconChevronRightStroked
-                style={{ color: 'var(--semi-color-text-2)', fontSize: '12px' }}
-              />
-              <Typography.Text
-                size="small"
-                type="tertiary"
-                ellipsis={{ showTooltip: true }}
-              >
-                {currentFileName}
-              </Typography.Text>
+              {mode !== 'preview-only' && (
+                <>
+                  <IconChevronRightStroked
+                    style={{ color: 'var(--semi-color-text-2)', fontSize: '12px' }}
+                  />
+                  <Typography.Text
+                    size="small"
+                    type="tertiary"
+                    ellipsis={{ showTooltip: true }}
+                  >
+                    {currentFileName}
+                  </Typography.Text>
+                </>
+              )}
             </Space>
           </Space>
           <Space spacing={7}>
-            <Button
-              theme="borderless"
-              icon={
-                <IconGithub style={{ color: 'var(--semi-color-text-2)' }} />
-              }
-              type="tertiary"
-              size="small"
-              onClick={() => {
-                window.open(
-                  `${exampleGitBaseUrl}/${directory}/${currentFileName}`,
-                  '_blank',
-                );
-              }}
-            />
-            {hasPreview && (
+            {mode !== 'preview-only' && (
+              <Button
+                theme="borderless"
+                icon={
+                  <IconGithub style={{ color: 'var(--semi-color-text-2)' }} />
+                }
+                type="tertiary"
+                size="small"
+                onClick={() => {
+                  window.open(
+                    `${exampleGitBaseUrl}/${directory}/${currentFileName}`,
+                    '_blank',
+                  );
+                }}
+              />
+            )}
+            {hasPreview && mode === 'linked' && (
               <Space spacing={6}>
                 <Typography.Text size="small" type="tertiary" className={s['toggle-label']}>
                   Code
@@ -559,7 +531,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
                 />
               </Space>
             )}
-            {hasPreview && (
+            {hasPreview && mode === 'linked' && (
               <Space spacing={6}>
                 <Typography.Text size="small" type="tertiary" className={s['toggle-label']}>
                   {t('go.preview')}
@@ -580,31 +552,33 @@ export const ExampleContent: FC<ExampleContentProps> = ({
                 />
               </Space>
             )}
-            <Button
-              theme="borderless"
-              icon={
-                fullscreenMode !== 'off' ? (
-                  <IconExitFullscreen
-                    style={{ color: 'var(--semi-color-text-2)' }}
-                  />
-                ) : (
-                  <IconFullscreen
-                    style={{ color: 'var(--semi-color-text-2)' }}
-                  />
-                )
-              }
-              type="tertiary"
-              size="small"
-              onClick={() => {
-                if (fullscreenMode !== 'off') {
-                  setFullscreenMode('off');
-                  setShowCode(true);
-                } else {
-                  splitPaneRef.current?.ensureSecondMinSize(320);
-                  setFullscreenMode('all');
+            {mode !== 'preview-only' && (
+              <Button
+                theme="borderless"
+                icon={
+                  fullscreenMode !== 'off' ? (
+                    <IconExitFullscreen
+                      style={{ color: 'var(--semi-color-text-2)' }}
+                    />
+                  ) : (
+                    <IconFullscreen
+                      style={{ color: 'var(--semi-color-text-2)' }}
+                    />
+                  )
                 }
-              }}
-            />
+                type="tertiary"
+                size="small"
+                onClick={() => {
+                  if (fullscreenMode !== 'off') {
+                    setFullscreenMode('off');
+                    setShowCode(true);
+                  } else {
+                    splitPaneRef.current?.ensureSecondMinSize(320);
+                    setFullscreenMode('all');
+                  }
+                }}
+              />
+            )}
             {rightFooter}
           </Space>
         </div>

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -38,9 +38,11 @@ const DefaultErrorWrap = ({
   );
 };
 
+export type ExamplePreviewMode = 'linked' | 'preview-only' | 'source-only';
+
 export interface ExamplePreviewProps {
   example: string;
-  defaultFile: string;
+  defaultFile?: string;
   img?: string;
   defaultEntryFile?: string;
   defaultEntryName?: string;
@@ -50,6 +52,7 @@ export interface ExamplePreviewProps {
   rightFooter?: React.ReactNode;
   schemaOptions?: SchemaOptionsData;
   langAlias?: Record<string, string>;
+  mode?: ExamplePreviewMode;
   /**
    * Override the default preview tab for this instance.
    * Takes precedence over the site-level `GoConfig.defaultTab`.
@@ -100,6 +103,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     schemaOptions,
     langAlias,
     defaultTab: propsDefaultTab,
+    mode = 'linked',
   } = props;
 
   // Instance prop > config provider > undefined (let ExampleContent decide)
@@ -148,6 +152,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     setIsAssetFile(isAssetFileType(v));
   };
   useEffect(() => {
+    if (mode === 'preview-only') return;
     if (isAssetFile) {
       setCurrentFile(`${EXAMPLE_BASE_URL}/${example}/${currentName}`);
     } else {
@@ -160,7 +165,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
         });
       }
     }
-  }, [currentName, isAssetFile]);
+  }, [currentName, isAssetFile, mode]);
 
   const currentEntryFileUrl = useMemo(() => {
     const file = exampleData?.templateFiles?.find(
@@ -249,6 +254,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       schemaOptions={schema ? undefined : schemaOptions}
       exampleGitBaseUrl={exampleData?.exampleGitBaseUrl}
       defaultTab={defaultTab}
+      mode={mode}
     />
   );
 };

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -38,7 +38,7 @@ const DefaultErrorWrap = ({
   );
 };
 
-export type ExamplePreviewMode = 'linked' | 'preview-only' | 'source-only';
+export type ExamplePreviewMode = 'linked' | 'preview' | 'source';
 
 export interface ExamplePreviewProps {
   example: string;
@@ -152,7 +152,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     setIsAssetFile(isAssetFileType(v));
   };
   useEffect(() => {
-    if (mode === 'preview-only') return;
+    if (mode === 'preview') return;
     if (isAssetFile) {
       setCurrentFile(`${EXAMPLE_BASE_URL}/${example}/${currentName}`);
     } else {


### PR DESCRIPTION
## Description
This PR decouples the Source code viewer and Preview panel in the `ExamplePreview` component, enabling them to be rendered independently or linked.

- Added a `mode` prop to `ExamplePreview` supporting `'linked' | 'preview-only' | 'source-only'`.
- When `mode=preview-only`, network requests for raw source files are completely bypassed.
- Refactored UI layouts and footers to adapt smoothly when only one panel is active.
- Added a dropdown to the demo playground (`example/src/main.tsx`) to toggle and test between the three modes.

## Related Issues
Closes # (if applicable)

## Testing
- Selected 'Preview Only' mode in the demo playground; verified no raw files were downloaded.
- Selected 'Source Only' mode; verified the UI rendered only the code tree and viewer cleanly.