### PR TITLE
chore: stabilize formatting on save and remove React.FC usage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,6 @@
 {
   "editor.formatOnSave": true,
-  "editor.formatOnSaveMode": "modifications",
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "never",
-    "source.fixAll.eslint": "never",
-    "source.fixAll.biome": "never",
-    "source.organizeImports": "never"
-  },
-
+  "editor.formatOnSaveMode": "file",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,12 @@
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "modifications",
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "source.organizeImports": "explicit"
+    "source.fixAll": "never",
+    "source.fixAll.eslint": "never",
+    "source.fixAll.biome": "never",
+    "source.organizeImports": "never"
   },
+
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
@@ -18,8 +21,35 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "prettier.singleQuote": true,
-  "prettier.jsxSingleQuote": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[mdx]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "prettier.requireConfig": true,
+  "prettier.prettierPath": "./node_modules/prettier",
+
+  "typescript.tsdk": "node_modules/typescript/lib",
   "javascript.preferences.quoteStyle": "single",
-  "typescript.preferences.quoteStyle": "single"
+  "typescript.preferences.quoteStyle": "single",
+
+  "files.associations": {
+    "*.mdx": "mdx",
+    "*.snap.txt": "markdown"
+  },
+  "cSpell.enabled": false
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   ],
   "scripts": {
     "dev": "cd example && pnpm install && pnpm dev",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prepare": "husky",
     "typecheck": "tsc --noEmit"
   },

--- a/src/example-preview/components/code.tsx
+++ b/src/example-preview/components/code.tsx
@@ -1,10 +1,10 @@
-import { FC, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { getHighlightLines } from '../utils/example-data';
 import { transformerNotationHighlight } from '@shikijs/transformers';
-import { transformerRuntimeMetaHighlight } from './shiki-transformer';
-import { useGoConfig, DefaultCodeBlock } from '../../config';
+import { DefaultCodeBlock, useGoConfig } from '../../config';
+import { getHighlightLines } from '../utils/example-data';
 import styles from './code.module.scss';
+import { transformerRuntimeMetaHighlight } from './shiki-transformer';
 
 interface CodeProps {
   val: string;
@@ -14,13 +14,13 @@ interface CodeProps {
   setIsFirstShowCode: (isFirstShowCode: boolean) => void;
 }
 
-export const Code: FC<CodeProps> = ({
+export function Code({
   val,
   language,
   highlight,
   isFirstShowCode,
   setIsFirstShowCode,
-}) => {
+}: CodeProps) {
   const { CodeBlock = DefaultCodeBlock } = useGoConfig();
   const containerRef = useRef<HTMLDivElement>(null);
   const [highlightVal, setHighlightVal] = useState(highlight);
@@ -103,4 +103,4 @@ export const Code: FC<CodeProps> = ({
       />
     </div>
   );
-};
+}

--- a/src/example-preview/components/file-tree.tsx
+++ b/src/example-preview/components/file-tree.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useEffect } from 'react';
+import { useEffect } from 'react';
 
-import { RenderFullLabelProps } from '@douyinfe/semi-ui/lib/es/tree';
 import { Tree, Typography } from '@douyinfe/semi-ui';
+import { RenderFullLabelProps } from '@douyinfe/semi-ui/lib/es/tree';
 
 import { getFolderIcon } from '../utils/icon';
 import { TreeNode } from '../utils/transform';
@@ -15,21 +15,20 @@ interface FileTreeProps {
   expandedKeys: string[];
 }
 
-export const FileTree: FC<FileTreeProps> = ({
+export function FileTree({
   onSelect,
   entry,
   treeData,
   doChangeExpand,
   selectedKeys,
   expandedKeys,
-}) => {
+}: FileTreeProps) {
   const doRenderLabel = ({
     className,
     data,
     onClick,
     onExpand,
     expandIcon,
-    checkStatus,
   }: RenderFullLabelProps) => {
     const { label, icon, key, children, highlight } = data;
     const isLeaf = !children?.length;
@@ -56,7 +55,6 @@ export const FileTree: FC<FileTreeProps> = ({
           ...highStyle,
         }}
         id={selectedKeys[0] === key ? key : undefined}
-        role="treeitem"
         onClick={isLeaf ? onClick : onExpand}
       >
         {isLeaf ? (
@@ -78,7 +76,7 @@ export const FileTree: FC<FileTreeProps> = ({
         selectedNode.scrollIntoView({ behavior: 'auto', block: 'center' });
       }
     });
-  }, []);
+  }, [selectedKeys]);
 
   return (
     <Tree
@@ -100,4 +98,4 @@ export const FileTree: FC<FileTreeProps> = ({
       treeData={treeData}
     />
   );
-};
+}

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -13,14 +13,7 @@ import {
   Typography,
 } from '@douyinfe/semi-ui';
 import { QRCodeSVG } from 'qrcode.react';
-import React, {
-  FC,
-  Suspense,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { CodeView } from './code-view';
 import { FileTree } from './file-tree';
@@ -85,7 +78,7 @@ interface ExampleContentProps {
   mode?: ExamplePreviewMode;
 }
 
-export const ExampleContent: FC<ExampleContentProps> = ({
+export function ExampleContent({
   fileNames,
   previewImage,
   currentFileName,
@@ -108,7 +101,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   langAlias,
   defaultTab,
   mode = 'linked',
-}) => {
+}: ExampleContentProps) {
   const {
     explorerUrl,
     explorerText,
@@ -621,4 +614,4 @@ export const ExampleContent: FC<ExampleContentProps> = ({
       </div>
     </div>
   );
-};
+}

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -1,3 +1,18 @@
+import { IconChevronRightStroked, IconList } from '@douyinfe/semi-icons';
+import {
+  Button,
+  Radio,
+  RadioGroup,
+  Select,
+  SideSheet,
+  Space,
+  Switch,
+  TabPane,
+  Tabs,
+  Toast,
+  Typography,
+} from '@douyinfe/semi-ui';
+import { QRCodeSVG } from 'qrcode.react';
 import React, {
   FC,
   Suspense,
@@ -6,39 +21,24 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  Space,
-  Typography,
-  Switch,
-  Button,
-  SideSheet,
-  RadioGroup,
-  Radio,
-  Select,
-  Toast,
-  Tabs,
-  TabPane,
-} from '@douyinfe/semi-ui';
-import { IconList, IconChevronRightStroked } from '@douyinfe/semi-icons';
-import { QRCodeSVG } from 'qrcode.react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { FileTree } from './file-tree';
 import { CodeView } from './code-view';
-import { SwitchSchema } from './switch-schema';
+import { FileTree } from './file-tree';
 import { PreviewImg } from './preview-img';
 import { SplitPane, type SplitPaneHandle } from './split-pane';
+import { SwitchSchema } from './switch-schema';
 
+import type { PreviewTab } from '../../config';
+import { DEFAULT_I18N, DefaultNoSSR, useGoConfig } from '../../config';
+import type { SchemaOptionsData } from '../hooks/use-switch-schema';
+import { useTreeController } from '../hooks/use-tree-controller';
 import {
-  IconGithub,
   IconCopyLink,
-  IconFullscreen,
   IconExitFullscreen,
+  IconFullscreen,
+  IconGithub,
 } from '../utils/icon';
 import { tabScrollToTop } from '../utils/tool';
-import { useTreeController } from '../hooks/use-tree-controller';
-import type { SchemaOptionsData } from '../hooks/use-switch-schema';
-import { useGoConfig, DEFAULT_I18N, DefaultNoSSR } from '../../config';
-import type { PreviewTab } from '../../config';
 
 const WebIframe = React.lazy(() =>
   import('./web-iframe').then((module) => ({ default: module.WebIframe })),

--- a/src/example-preview/components/loading-overlay.tsx
+++ b/src/example-preview/components/loading-overlay.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useGoConfig, defaultUseDark } from '../../config';
+import { defaultUseDark, useGoConfig } from '../../config';
 
 const LOGO_LIGHT =
   'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg';

--- a/src/example-preview/components/preview-img.tsx
+++ b/src/example-preview/components/preview-img.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { isVideo } from '../utils/example-data';
 
 export const PreviewImg = ({

--- a/src/example-preview/components/switch-schema.tsx
+++ b/src/example-preview/components/switch-schema.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { Select, Input } from '@douyinfe/semi-ui';
-import { useSwitchSchema, SchemaOptionsData } from '../hooks/use-switch-schema';
+import { Input, Select } from '@douyinfe/semi-ui';
+import { SchemaOptionsData, useSwitchSchema } from '../hooks/use-switch-schema';
 import s from './index.module.scss';
 
 export interface SwitchSchemaProps {

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,8 +1,8 @@
-import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import type { LynxView } from '@lynx-js/web-core';
 import '@lynx-js/web-core/index.css';
 import '@lynx-js/web-elements/index.css';
-import type { LynxView } from '@lynx-js/web-core';
+import type React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { LoadingOverlay } from './loading-overlay';
 
 declare global {

--- a/src/example-preview/hooks/use-switch-schema.ts
+++ b/src/example-preview/hooks/use-switch-schema.ts
@@ -1,7 +1,5 @@
-import { useMemo } from 'react';
-import { useState } from 'react';
-import { getUrlFromMustacheSchema } from '../utils/tool';
-import { getCloneData } from '../utils/tool';
+import { useMemo, useState } from 'react';
+import { getCloneData, getUrlFromMustacheSchema } from '../utils/tool';
 
 export interface SchemaOptionType {
   type: string;

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -2,11 +2,11 @@ import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import useSWRMutation from 'swr/mutation';
-import { ExampleContent } from './components';
-import { isAssetFileType } from './utils/example-data';
-import type { SchemaOptionsData } from './hooks/use-switch-schema';
-import { useGoConfig } from '../config';
 import type { PreviewTab } from '../config';
+import { useGoConfig } from '../config';
+import { ExampleContent } from './components';
+import type { SchemaOptionsData } from './hooks/use-switch-schema';
+import { isAssetFileType } from './utils/example-data';
 
 const DefaultErrorWrap = ({
   example,

--- a/src/example-preview/utils/icon.tsx
+++ b/src/example-preview/utils/icon.tsx
@@ -1,9 +1,9 @@
 import { SVGProps } from 'react';
 
 import {
-  getIconForFile,
   DEFAULT_FOLDER,
   DEFAULT_FOLDER_OPENED,
+  getIconForFile,
 } from 'vscode-icons-js';
 
 export function CarbonDocumentBlank(props: SVGProps<SVGSVGElement>) {

--- a/src/example-preview/utils/transform.tsx
+++ b/src/example-preview/utils/transform.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { getFileIcon, getFolderIcon } from './icon';
 
 export function pathNormalize(name: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { Go, type GoProps } from './Go';
-export { ExamplePreview, type ExamplePreviewProps } from './example-preview';
-export type { ExampleMetadata } from './example-preview';
 export { GoConfigProvider, useGoConfig } from './config';
 export type { GoConfig, PreviewTab } from './config';
+export { ExamplePreview, type ExamplePreviewProps } from './example-preview';
+export type { ExampleMetadata } from './example-preview';
 export { getFileCodeLanguage } from './example-preview/utils/example-data';
+export { Go, type GoProps } from './Go';


### PR DESCRIPTION
Aligns editor formatting by pinning VSCode to the repo-local Prettier config/version and disabling save-time fixAll/organizeImports that caused import reordering. Adds `format` / `format:check` scripts, disables cSpell in this workspace, and replaces `React.FC` with typed function components to rely on return type inference.

- Force VSCode to use repo-local Prettier config/version
- Disable save-time fixAll/organizeImports to avoid import churn
- Set Prettier as formatter for common filetypes (json/jsonc/md/mdx/yaml/html)
- Disable cSpell for this workspace
- Add format and format:check scripts
- Replace React.FC with typed function components (infer return type)
- Apply import-order-only formatting cleanup in example-preview sources