### PR TITLE
chore(release): include CHANGELOG.md in npm package

### DIFF
--- a/.changeset/tame-lemons-dig.md
+++ b/.changeset/tame-lemons-dig.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Include CHANGELOG.md in the published package and improve package metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-js/go-web
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release. ([#27](https://github.com/lynx-community/go-web/pull/27))

--- a/package.json
+++ b/package.json
@@ -2,9 +2,23 @@
   "name": "@lynx-js/go-web",
   "version": "0.1.0",
   "description": "Interactive <Go> component for embedding live Lynx examples on the web. The example/ website doubles as the community example gallery.",
+  "keywords": [
+    "lynx",
+    "lynxjs",
+    "go-web",
+    "go",
+    "react",
+    "component",
+    "embed",
+    "gallery",
+    "ssg",
+    "rspress",
+    "qr-code",
+    "live-preview"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lynx-community/go-web.git"
+    "url": "git+https://github.com/lynx-community/go-web.git"
   },
   "license": "Apache-2.0",
   "type": "module",
@@ -17,7 +31,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [
-    "src"
+    "src",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "dev": "cd example && pnpm install && pnpm dev",
@@ -74,5 +89,8 @@
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "engines": {
     "node": "^22 || ^24"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Context

This is a **patch publish** before the upcoming Lynx for Web (`@lynx-js/web-core`) upgrade. The main goal is to **exercise and validate the full Changesets release flow** (release PR → publish) with a low-risk change set, so the pipeline is proven before larger updates land.

## What’s in this patch

- Include `CHANGELOG.md` in the published npm package (via `package.json#files`)
- Improve package metadata
  - Add `keywords`
  - Normalize `repository.url` to the strict `git+https://...git` form

## Why

- Pre-flight the release/publish pipeline ahead of the `@lynx-js/web-core` upgrade
- Small user-facing improvement: consumers can read `CHANGELOG.md` directly from the installed package, and npm metadata/search is clearer

## Verification

- `pnpm format:check`
- `pnpm typecheck`

## Expected release flow after merge

- Merging this PR triggers the automated `changeset-release/*` **Release PR**
- Merging the Release PR triggers **publish** and releases a patch version (e.g. `0.1.1`)
- After publish, the package tarball should contain `CHANGELOG.md`

## Follow-up

- Next PR will upgrade Lynx for Web: `@lynx-js/web-core` (not included here)