### PR TITLE
fix(example-preview): make lynx-view rpx/vh/vw container-relative

### DIFF
--- a/.changeset/dark-ants-smash.md
+++ b/.changeset/dark-ants-smash.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Fix `<lynx-view>` unit scaling so `rpx`/`vh`/`vw` match mobile behavior in embedded contexts.

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -23,6 +23,10 @@ type CSSVarProperties = {
   [key: `--${string}`]: string | number;
 };
 
+// Container-relative unit hooks for Lynx runtime:
+// - `containerType: 'size'` enables `cqw/cqh` units based on the host element box.
+// - `--vh-unit/--vw-unit` make `vh/vw` behave like "container viewport" inside `<lynx-view>`.
+// - `--rpx-unit` aligns `rpx` scaling with a 750-wide design baseline (mobile-like behavior).
 const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
   width: '100%',
   height: '100%',
@@ -32,6 +36,9 @@ const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
   '--vh-unit': '1cqh',
   '--vw-unit': '1cqw',
 };
+
+// Use a shared group so multiple Lynx views can reuse web workers.
+const LYNX_GROUP_ID = 42;
 
 // Shared promise so multiple WebIframe instances don't duplicate the dynamic import
 let runtimeReady: Promise<void> | null = null;
@@ -47,47 +54,6 @@ function ensureRuntime() {
 // Pre-compiled regex for webpack public path rewriting in customTemplateLoader
 // Matches .p=\"<anything>\" — handles empty, single-char, and multi-char paths
 const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
-
-/**
- * Rewrite CSS viewport units (vh/vw) in a Lynx template's styleInfo to use
- * CSS custom properties (--lynx-vh / --lynx-vw). This fixes viewport-unit
- * sizing inside the <lynx-view> shadow DOM, where native CSS vh/vw resolve
- * to the browser viewport rather than the preview container.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function rewriteViewportUnits(template: any): void {
-  if (!template.styleInfo) return;
-
-  const rewrite = (value: string) =>
-    value
-      .replace(/(-?\d+\.?\d*)vh/g, (_, num) => {
-        const n = Number.parseFloat(num);
-        if (n === 100) return 'var(--lynx-vh, 100vh)';
-        return `calc(var(--lynx-vh, 100vh) * ${n / 100})`;
-      })
-      .replace(/(-?\d+\.?\d*)vw/g, (_, num) => {
-        const n = Number.parseFloat(num);
-        if (n === 100) return 'var(--lynx-vw, 100vw)';
-        return `calc(var(--lynx-vw, 100vw) * ${n / 100})`;
-      });
-
-  for (const key of Object.keys(template.styleInfo)) {
-    const info = template.styleInfo[key];
-    if (info.content) {
-      info.content = info.content.map((s: string) => rewrite(s));
-    }
-    if (info.rules) {
-      for (const rule of info.rules) {
-        if (rule.decl) {
-          rule.decl = rule.decl.map(([prop, val]: [string, string]) => [
-            prop,
-            rewrite(val),
-          ]);
-        }
-      }
-    }
-  }
-}
 
 // DEV: ?simulateError=runtime|template|shadow|render
 const simulateError =
@@ -192,9 +158,6 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
                 `var __webpack_require__={p:"${baseUrl}"};` + root;
             }
           }
-
-          // Rewrite vh/vw units in CSS to use container-relative custom properties
-          rewriteViewportUnits(template);
 
           return template;
         } catch (err) {
@@ -352,7 +315,7 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
         <lynx-view
           ref={lynxViewRef}
           style={LYNX_VIEW_STYLE}
-          lynx-group-id={2}
+          lynx-group-id={LYNX_GROUP_ID}
           transform-vh={true}
           transform-vw={true}
         />

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -19,6 +19,20 @@ interface WebIframeProps {
   src: string;
 }
 
+type CSSVarProperties = {
+  [key: `--${string}`]: string | number;
+};
+
+const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
+  width: '100%',
+  height: '100%',
+  contain: 'strict',
+  containerType: 'size',
+  '--rpx-unit': 'calc(100cqw / 750)',
+  '--vh-unit': '1cqh',
+  '--vw-unit': '1cqw',
+};
+
 // Shared promise so multiple WebIframe instances don't duplicate the dynamic import
 let runtimeReady: Promise<void> | null = null;
 function ensureRuntime() {
@@ -130,19 +144,6 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       pixelWidth: Math.round(w * window.devicePixelRatio),
       pixelHeight: Math.round(h * window.devicePixelRatio),
     };
-
-    const rule = `:host { --lynx-vh: ${h}px; --lynx-vw: ${w}px; }`;
-
-    // Set injectStyleRules for initial template load (before shadow DOM exists)
-    // @ts-ignore
-    lynxViewRef.current.injectStyleRules = [rule];
-
-    // Also set CSS custom properties directly on the host element's inline
-    // style for live resize updates. Inline custom properties on the host
-    // are inherited by shadow DOM descendants immediately.
-    const el = lynxViewRef.current as unknown as HTMLElement;
-    el.style.setProperty('--lynx-vh', `${h}px`);
-    el.style.setProperty('--lynx-vw', `${w}px`);
   }, []);
 
   // Set URL only after runtime is ready AND element is mounted
@@ -350,7 +351,10 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       {show && src && (
         <lynx-view
           ref={lynxViewRef}
-          style={{ width: '100%', height: '100%' }}
+          style={LYNX_VIEW_STYLE}
+          lynx-group-id={2}
+          transform-vh={true}
+          transform-vw={true}
         />
       )}
     </div>

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -6,13 +6,16 @@ import { LoadingOverlay } from './loading-overlay';
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'lynx-view': React.DetailedHTMLProps<
-        React.HTMLAttributes<HTMLElement>,
-        HTMLElement
-      >;
+      'lynx-view': React.DetailedHTMLProps<LynxViewAttributes, HTMLElement>;
     }
   }
 }
+
+type LynxViewAttributes = React.HTMLAttributes<HTMLElement> & {
+  'lynx-group-id'?: number;
+  'transform-vh'?: boolean;
+  'transform-vw'?: boolean;
+};
 
 interface WebIframeProps {
   show: boolean;
@@ -27,10 +30,11 @@ type CSSVarProperties = {
 // - `containerType: 'size'` enables `cqw/cqh` units based on the host element box.
 // - `--vh-unit/--vw-unit` make `vh/vw` behave like "container viewport" inside `<lynx-view>`.
 // - `--rpx-unit` aligns `rpx` scaling with a 750-wide design baseline (mobile-like behavior).
+// Note: web-core already applies `contain: content` internally; combined with `containerType: 'size'`
+// this effectively behaves like `contain: strict` without us overriding containment explicitly.
 const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
   width: '100%',
   height: '100%',
-  contain: 'strict',
   containerType: 'size',
   '--rpx-unit': 'calc(100cqw / 750)',
   '--vh-unit': '1cqh',


### PR DESCRIPTION
### Problem
The web example preview embeds Lynx content inside a `<lynx-view>` container. Unit conversion for `rpx` / `vh` / `vw` could end up behaving like “browser viewport based” instead of “preview container based”, causing layout/scale differences compared to mobile expectations.

### What changed
- Enabled container query sizing on the `<lynx-view>` host via `containerType: 'size'`.
- Defined container-relative unit hooks via CSS custom properties on the host:
  - `--vh-unit: 1cqh`
  - `--vw-unit: 1cqw`
  - `--rpx-unit: calc(100cqw / 750)` (750 design width baseline)
- Added a small TypeScript helper type to allow `--*` custom properties on `style` without errors, and moved the style object to a module-level constant to avoid re-creating it on each render.

### Result
Web preview sizing becomes container-relative and closer to mobile behavior for `rpx` scaling and `vh/vw`-driven layouts.

### Verification
- `pnpm -s typecheck`

### Related
- Relates to lynx-family/lynx-stack#2469