### PR TITLE
fix: keep <lynx-view> mounted across tab switches to prevent flash

### DIFF
--- a/.changeset/giant-ravens-begin.md
+++ b/.changeset/giant-ravens-begin.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Fix white flash when switching to Web preview tab by keeping `<lynx-view>` mounted and eagerly preloading content.

--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -104,6 +104,19 @@
       flex-direction: column;
       align-items: center;
     }
+    .preview-body {
+      width: 100%;
+      flex: 1;
+      min-height: 0;
+      position: relative;
+      overflow: hidden;
+    }
+    .preview-panel {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
     .preview-header {
       width: 100%;
       height: 36px;

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -313,93 +313,117 @@ export function ExampleContent({
             }}
           />
         </div>
-
-        {previewType === PreviewType.QRCode && currentEntry && (
-          <div className={s.qrcode}>
-            <Typography.Text
-              size="small"
-              type="tertiary"
-              style={{ margin: '28px 12px', textAlign: 'center' }}
-            >
-              {t('go.scan.message-1')}
-              <Typography.Text
-                link={{
-                  href: withBaseFn(
-                    lang === 'zh' ? LYNX_EXPLORER_URL_CN : LYNX_EXPLORER_URL_EN,
-                  ),
-                  target: '_blank',
-                }}
-                size="small"
-                underline
-              >
-                {lynxExplorerText}
-              </Typography.Text>{' '}
-              {t('go.scan.message-2')}
-            </Typography.Text>
-            <div className={s['qrcode-svg']}>
-              <QRCodeSVG value={qrcodeUrl} />
-            </div>
-            <div style={{ marginBottom: '32px' }}>
-              <CopyToClipboard
-                onCopy={() => {
-                  Toast.success(t('go.qrcode.copied'));
-                }}
-                text={qrcodeUrl}
-              >
-                <Button
+        <div className={s['preview-body']}>
+          {previewType === PreviewType.QRCode && currentEntry && (
+            <div className={s['preview-panel']}>
+              <div className={s.qrcode}>
+                <Typography.Text
+                  size="small"
                   type="tertiary"
-                  style={{ fontSize: '12px' }}
-                  icon={<IconCopyLink style={{ fontSize: '16px' }} />}
+                  style={{ margin: '28px 12px', textAlign: 'center' }}
                 >
-                  {t('go.qrcode.copy-link')}
-                </Button>
-              </CopyToClipboard>
+                  {t('go.scan.message-1')}
+                  <Typography.Text
+                    link={{
+                      href: withBaseFn(
+                        lang === 'zh'
+                          ? LYNX_EXPLORER_URL_CN
+                          : LYNX_EXPLORER_URL_EN,
+                      ),
+                      target: '_blank',
+                    }}
+                    size="small"
+                    underline
+                  >
+                    {lynxExplorerText}
+                  </Typography.Text>{' '}
+                  {t('go.scan.message-2')}
+                </Typography.Text>
+                <div className={s['qrcode-svg']}>
+                  <QRCodeSVG value={qrcodeUrl} />
+                </div>
+                <div style={{ marginBottom: '32px' }}>
+                  <CopyToClipboard
+                    onCopy={() => {
+                      Toast.success(t('go.qrcode.copied'));
+                    }}
+                    text={qrcodeUrl}
+                  >
+                    <Button
+                      type="tertiary"
+                      style={{ fontSize: '12px' }}
+                      icon={<IconCopyLink style={{ fontSize: '16px' }} />}
+                    >
+                      {t('go.qrcode.copy-link')}
+                    </Button>
+                  </CopyToClipboard>
+                </div>
+                {schemaOptions && (
+                  <SwitchSchema
+                    optionsData={schemaOptions}
+                    currentEntryFileUrl={currentEntryFileUrl}
+                    onSwitchSchema={onSwitchSchema}
+                  />
+                )}
+                <div className={s['qrcode-entry']}>
+                  <Typography.Text
+                    size="small"
+                    type="tertiary"
+                    style={{ marginRight: '12px', flexShrink: 0 }}
+                  >
+                    {t('go.qrcode.entry')}
+                  </Typography.Text>
+                  <Select
+                    style={{ width: '100%', maxWidth: '200px' }}
+                    value={currentEntry}
+                    onChange={(v) => setCurrentEntry(v as string)}
+                  >
+                    {entryFiles?.map((file) => (
+                      <Select.Option key={file.name} value={file.name}>
+                        {file.name}
+                      </Select.Option>
+                    ))}
+                  </Select>
+                </div>
+              </div>
             </div>
-            {schemaOptions && (
-              <SwitchSchema
-                optionsData={schemaOptions}
-                currentEntryFileUrl={currentEntryFileUrl}
-                onSwitchSchema={onSwitchSchema}
-              />
-            )}
-            <div className={s['qrcode-entry']}>
-              <Typography.Text
-                size="small"
-                type="tertiary"
-                style={{ marginRight: '12px', flexShrink: 0 }}
-              >
-                {t('go.qrcode.entry')}
-              </Typography.Text>
-              <Select
-                style={{ width: '100%', maxWidth: '200px' }}
-                value={currentEntry}
-                onChange={(v) => setCurrentEntry(v as string)}
-              >
-                {entryFiles?.map((file) => (
-                  <Select.Option key={file.name} value={file.name}>
-                    {file.name}
-                  </Select.Option>
-                ))}
-              </Select>
+          )}
+          {previewImage && (
+            <div
+              className={s['preview-panel']}
+              style={{
+                zIndex: previewType === PreviewType.Preview ? 1 : 0,
+                visibility:
+                  previewType === PreviewType.Preview ? 'visible' : 'hidden',
+                pointerEvents:
+                  previewType === PreviewType.Preview ? 'auto' : 'none',
+              }}
+            >
+              <PreviewImg previewImage={previewImage} />
             </div>
-          </div>
-        )}
-        {previewImage && (
-          <PreviewImg
-            show={previewType === PreviewType.Preview}
-            previewImage={previewImage}
-          />
-        )}
-        {hasWebPreview && (
-          <NoSSRComponent>
-            <Suspense fallback={<div>Loading...</div>}>
-              <WebIframe
-                show={previewType === PreviewType.Web}
-                src={defaultWebPreviewFile || ''}
-              />
-            </Suspense>
-          </NoSSRComponent>
-        )}
+          )}
+          {hasWebPreview && (
+            <div
+              className={s['preview-panel']}
+              style={{
+                zIndex: previewType === PreviewType.Web ? 1 : 0,
+                visibility:
+                  previewType === PreviewType.Web ? 'visible' : 'hidden',
+                pointerEvents:
+                  previewType === PreviewType.Web ? 'auto' : 'none',
+              }}
+            >
+              <NoSSRComponent>
+                <Suspense fallback={<div>Loading...</div>}>
+                  <WebIframe
+                    show={previewType === PreviewType.Web}
+                    src={defaultWebPreviewFile || ''}
+                  />
+                </Suspense>
+              </NoSSRComponent>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -399,7 +399,10 @@ export function ExampleContent({
                   previewType === PreviewType.Preview ? 'auto' : 'none',
               }}
             >
-              <PreviewImg previewImage={previewImage} />
+              <PreviewImg
+                previewImage={previewImage}
+                active={previewType === PreviewType.Preview}
+              />
             </div>
           )}
           {hasWebPreview && (

--- a/src/example-preview/components/preview-img.tsx
+++ b/src/example-preview/components/preview-img.tsx
@@ -1,17 +1,11 @@
 import { isVideo } from '../utils/example-data';
 
-export const PreviewImg = ({
-  show,
-  previewImage,
-}: {
-  show: boolean;
-  previewImage: string;
-}) => {
+export const PreviewImg = ({ previewImage }: { previewImage: string }) => {
   return (
     <div
       style={{
         minHeight: '0px',
-        display: show ? 'flex' : 'none',
+        display: 'flex',
         width: '100%',
         height: '100%',
         alignItems: 'center',
@@ -24,6 +18,7 @@ export const PreviewImg = ({
           loop
           playsInline
           autoPlay
+          preload="auto"
           style={{
             maxWidth: '100%',
             maxHeight: '100%',
@@ -36,6 +31,8 @@ export const PreviewImg = ({
         <img
           src={previewImage}
           alt=""
+          loading="eager"
+          decoding="async"
           style={{
             maxWidth: '100%',
             maxHeight: '100%',

--- a/src/example-preview/components/preview-img.tsx
+++ b/src/example-preview/components/preview-img.tsx
@@ -1,6 +1,29 @@
+import { useEffect, useRef } from 'react';
 import { isVideo } from '../utils/example-data';
 
-export const PreviewImg = ({ previewImage }: { previewImage: string }) => {
+export const PreviewImg = ({
+  previewImage,
+  active,
+}: {
+  previewImage: string;
+  active: boolean;
+}) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  // Pause video when inactive to save CPU/battery, play when active
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (active) {
+      video.play().catch(() => {
+        /* ignore play interruptions */
+      });
+    } else {
+      video.pause();
+    }
+  }, [active]);
+
   return (
     <div
       style={{
@@ -14,10 +37,11 @@ export const PreviewImg = ({ previewImage }: { previewImage: string }) => {
     >
       {isVideo(previewImage) ? (
         <video
+          ref={videoRef}
           muted
           loop
           playsInline
-          autoPlay
+          autoPlay={active}
           preload="auto"
           style={{
             maxWidth: '100%',

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -171,67 +171,73 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       lynxViewRef.current &&
       containerRef.current
     ) {
-      // Skip if URL hasn't changed
-      if (lastUrlRef.current === src) return;
+      // Skip URL assignment only, not the rest of initialization
+      const urlAlreadySet = lastUrlRef.current === src;
 
       const t0 = performance.now();
       const tag = `[WebIframe ${src.split('/').pop()}]`;
-      console.log(tag, 'effect start', { ready, src });
+      console.log(tag, 'effect start', { ready, src, urlAlreadySet });
 
       const initialized = setDimensions();
       if (!initialized) return;
 
-      // @ts-ignore
-      lynxViewRef.current.customTemplateLoader = async (url: string) => {
-        try {
-          if (simulateError === 'template') {
-            throw new Error('simulated template load error');
-          }
-          const res = await fetch(url);
-          if (!res.ok) {
-            throw new Error(`HTTP ${res.status} loading ${url}`);
-          }
-          const text = await res.text();
-
-          // Rewrite webpack's public path in the bundle JS so that asset
-          // URLs (images etc.) resolve relative to the bundle location,
-          // not the page URL.
-          const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
-          const rewritten = text.replace(
-            WEBPACK_PUBLIC_PATH_RE,
-            `.p=\\"${baseUrl}\\"`,
-          );
-          const template = JSON.parse(rewritten);
-
-          // Workaround: when no template modules reference publicPath (no asset
-          // imports), rspack omits the local webpack runtime from lepusCode and
-          // emits a bare `__webpack_require__` reference. Inject a minimal shim
-          // so the entry-point executor (`__webpack_require__.x`) can run.
-          if (template.lepusCode?.root) {
-            const root = template.lepusCode.root;
-            if (
-              typeof root === 'string' &&
-              root.includes('__webpack_require__') &&
-              !root.includes('function __webpack_require__')
-            ) {
-              template.lepusCode.root =
-                `var __webpack_require__={p:"${baseUrl}"};` + root;
+      if (!urlAlreadySet) {
+        // @ts-ignore
+        lynxViewRef.current.customTemplateLoader = async (url: string) => {
+          try {
+            if (simulateError === 'template') {
+              throw new Error('simulated template load error');
             }
+            const res = await fetch(url);
+            if (!res.ok) {
+              throw new Error(`HTTP ${res.status} loading ${url}`);
+            }
+            const text = await res.text();
+
+            // Rewrite webpack's public path in the bundle JS so that asset
+            // URLs (images etc.) resolve relative to the bundle location,
+            // not the page URL.
+            const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
+            const rewritten = text.replace(
+              WEBPACK_PUBLIC_PATH_RE,
+              `.p=\\"${baseUrl}\\"`,
+            );
+            const template = JSON.parse(rewritten);
+
+            // Workaround: when no template modules reference publicPath (no asset
+            // imports), rspack omits the local webpack runtime from lepusCode and
+            // emits a bare `__webpack_require__` reference. Inject a minimal shim
+            // so the entry-point executor (`__webpack_require__.x`) can run.
+            if (template.lepusCode?.root) {
+              const root = template.lepusCode.root;
+              if (
+                typeof root === 'string' &&
+                root.includes('__webpack_require__') &&
+                !root.includes('function __webpack_require__')
+              ) {
+                template.lepusCode.root =
+                  `var __webpack_require__={p:"${baseUrl}"};` + root;
+              }
+            }
+
+            return template;
+          } catch (err) {
+            console.error(tag, 'template load failed', err);
+            setError(
+              `Failed to load template: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            throw err;
           }
+        };
 
-          return template;
-        } catch (err) {
-          console.error(tag, 'template load failed', err);
-          setError(
-            `Failed to load template: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          throw err;
-        }
-      };
-
-      console.log(tag, 'url set', `+${(performance.now() - t0).toFixed(0)}ms`);
-      lynxViewRef.current.url = src;
-      lastUrlRef.current = src;
+        console.log(
+          tag,
+          'url set',
+          `+${(performance.now() - t0).toFixed(0)}ms`,
+        );
+        lynxViewRef.current.url = src;
+        lastUrlRef.current = src;
+      }
 
       // Workaround: web-core reads MouseEvent.x/.y (viewport-relative) for
       // tap event detail.x/.y. When the <lynx-view> is embedded at a non-zero
@@ -311,37 +317,49 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
         return () => {};
       }
 
-      const pollStart = performance.now();
-      const pollShadow = () => {
-        if (disposed) return;
-        if (performance.now() - pollStart > 3000) {
-          console.error(tag, 'shadow root timeout');
-          setError('Preview timed out: shadow root was not created');
-          return;
-        }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      if (!renderedRef.current) {
+        const pollStart = performance.now();
+        const pollShadow = () => {
+          if (disposed) return;
+          if (performance.now() - pollStart > 3000) {
+            console.error(tag, 'shadow root timeout');
+            setError('Preview timed out: shadow root was not created');
+            return;
+          }
+          const shadow = el.shadowRoot;
+          if (shadow) {
+            setupShadow(shadow);
+          } else {
+            requestAnimationFrame(pollShadow);
+          }
+        };
+        pollShadow();
+
+        // Fallback: error if rendering doesn't complete within 5s
+        timer = setTimeout(() => {
+          if (!renderedRef.current) {
+            console.error(
+              tag,
+              'render timeout',
+              `+${(performance.now() - t0).toFixed(0)}ms`,
+            );
+            setError('Preview timed out: rendering did not complete within 5s');
+          }
+        }, 5000);
+      } else {
         const shadow = el.shadowRoot;
         if (shadow) {
-          setupShadow(shadow);
-        } else {
-          requestAnimationFrame(pollShadow);
+          shadow.addEventListener('click', adjustClickCoords, true);
+          removeClickFix = () =>
+            shadow.removeEventListener('click', adjustClickCoords, true);
         }
-      };
-      pollShadow();
+      }
 
-      // Fallback: error if rendering doesn't complete within 5s
-      const timer = setTimeout(() => {
-        if (!renderedRef.current) {
-          console.error(
-            tag,
-            'render timeout',
-            `+${(performance.now() - t0).toFixed(0)}ms`,
-          );
-          setError('Preview timed out: rendering did not complete within 5s');
-        }
-      }, 5000);
       return () => {
         disposed = true;
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         mo?.disconnect();
         removeClickFix?.();
       };

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -72,15 +72,17 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
   const [rendered, setRendered] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const renderedRef = useRef(false);
+  const lastUrlRef = useRef<string>('');
 
   // Reset state when src changes
   useEffect(() => {
     setRendered(false);
     setError(null);
     renderedRef.current = false;
+    lastUrlRef.current = '';
   }, [src]);
 
-  // Load web-core + web-elements eagerly on mount
+  // Load web-core eagerly on mount
   useEffect(() => {
     const t = performance.now();
     if (simulateError === 'runtime') {
@@ -103,9 +105,9 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       });
   }, []);
 
-  // Update lynx-view dimensions to match the container.
-  // Called on initial setup and on container resize.
-  const updateDimensions = useCallback(() => {
+  // Set lynx-view dimensions to match the container.
+  // Called on initial setup, SystemInfo cannot be updated after that.
+  const setDimensions = useCallback(() => {
     if (!lynxViewRef.current || !containerRef.current) return;
     const w = containerRef.current.clientWidth;
     const h = containerRef.current.clientHeight;
@@ -113,17 +115,23 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
     lynxViewRef.current.browserConfig = {
       pixelWidth: Math.round(w * window.devicePixelRatio),
       pixelHeight: Math.round(h * window.devicePixelRatio),
+      pixelRatio: window.devicePixelRatio,
     };
   }, []);
 
-  // Set URL only after runtime is ready AND element is mounted
+  // Set URL eagerly once runtime is ready and element is mounted.
+  // No longer gates on `show` — content is preloaded so tab switches are instant.
+  // `lastUrlRef` prevents redundant url assignments that could trigger reloads.
   useEffect(() => {
-    if (ready && show && src && lynxViewRef.current && containerRef.current) {
+    if (ready && src && lynxViewRef.current && containerRef.current) {
+      // Skip if URL hasn't changed
+      if (lastUrlRef.current === src) return;
+
       const t0 = performance.now();
       const tag = `[WebIframe ${src.split('/').pop()}]`;
-      console.log(tag, 'effect start', { ready, show, src });
+      console.log(tag, 'effect start', { ready, src });
 
-      updateDimensions();
+      setDimensions();
 
       // @ts-ignore
       lynxViewRef.current.customTemplateLoader = async (url: string) => {
@@ -175,6 +183,7 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
 
       console.log(tag, 'url set', `+${(performance.now() - t0).toFixed(0)}ms`);
       lynxViewRef.current.url = src;
+      lastUrlRef.current = src;
 
       // Workaround: web-core reads MouseEvent.x/.y (viewport-relative) for
       // tap event detail.x/.y. When the <lynx-view> is embedded at a non-zero
@@ -289,17 +298,9 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
         removeClickFix?.();
       };
     }
-  }, [ready, show, src, updateDimensions]);
+  }, [ready, src, setDimensions]);
 
-  // Keep lynx-view dimensions in sync when the container is resized
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !ready) return;
-    const ro = new ResizeObserver(() => updateDimensions());
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [ready, updateDimensions]);
-
+  // Only show loading state when the view is actually visible
   const loading = show && (!ready || !rendered || !!error);
 
   return (
@@ -315,8 +316,12 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       }}
     >
       <LoadingOverlay visible={loading} error={error} />
-      {show && src && (
+      {/* Always mount <lynx-view> when src exists so the ref 
+          is always populated and shadow DOM persists
+          across tab switches. */}
+      {src && (
         <lynx-view
+          key={src}
           ref={lynxViewRef}
           style={LYNX_VIEW_STYLE}
           lynx-group-id={LYNX_GROUP_ID}

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -41,6 +41,24 @@ const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
   '--vw-unit': '1cqw',
 };
 
+const MEASURE_CONTAINER: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
+const INNER_VISIBLE: React.CSSProperties = {
+  display: 'flex',
+  width: '100%',
+  height: '100%',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const INNER_HIDDEN: React.CSSProperties = {
+  display: 'none',
+};
+
 // Use a shared group so multiple Lynx views can reuse web workers.
 const LYNX_GROUP_ID = 42;
 
@@ -109,13 +127,20 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
   // Called on initial setup, SystemInfo cannot be updated after that.
   const setDimensions = useCallback(() => {
     if (!lynxViewRef.current || !containerRef.current) return;
-    const w = containerRef.current.clientWidth;
-    const h = containerRef.current.clientHeight;
+
+    const pixelRatio = window.devicePixelRatio;
+    const pixelWidth = Math.round(
+      containerRef.current.clientWidth * pixelRatio,
+    );
+    const pixelHeight = Math.round(
+      containerRef.current.clientHeight * pixelRatio,
+    );
+
     // @ts-ignore
     lynxViewRef.current.browserConfig = {
-      pixelWidth: Math.round(w * window.devicePixelRatio),
-      pixelHeight: Math.round(h * window.devicePixelRatio),
-      pixelRatio: window.devicePixelRatio,
+      pixelWidth,
+      pixelHeight,
+      pixelRatio,
     };
   }, []);
 
@@ -303,32 +328,26 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
   // Only show loading state when the view is actually visible
   const loading = show && (!ready || !rendered || !!error);
 
+  // Always mount <lynx-view> when src exists so the ref
+  // is always populated and shadow DOM persists
+  // across tab switches.
   return (
-    <div
-      ref={containerRef}
-      style={{
-        display: show ? 'flex' : 'none',
-        width: '100%',
-        height: '100%',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-      }}
-    >
-      <LoadingOverlay visible={loading} error={error} />
-      {/* Always mount <lynx-view> when src exists so the ref 
-          is always populated and shadow DOM persists
-          across tab switches. */}
-      {src && (
-        <lynx-view
-          key={src}
-          ref={lynxViewRef}
-          style={LYNX_VIEW_STYLE}
-          lynx-group-id={LYNX_GROUP_ID}
-          transform-vh={true}
-          transform-vw={true}
-        />
-      )}
+    // Outer: always in layout for dimension measurement
+    // Inner: controls visibility
+    <div style={MEASURE_CONTAINER} ref={containerRef}>
+      <div style={show ? INNER_VISIBLE : INNER_HIDDEN}>
+        <LoadingOverlay visible={loading} error={error} />
+        {src && (
+          <lynx-view
+            key={src}
+            ref={lynxViewRef}
+            style={LYNX_VIEW_STYLE}
+            lynx-group-id={LYNX_GROUP_ID}
+            transform-vh={true}
+            transform-vw={true}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -87,6 +87,7 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
   const lynxViewRef = useRef<LynxView>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);
+  const [dimsReady, setDimsReady] = useState(false);
   const [rendered, setRendered] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const renderedRef = useRef(false);
@@ -125,16 +126,16 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
 
   // Set lynx-view dimensions to match the container.
   // Called on initial setup, SystemInfo cannot be updated after that.
-  const setDimensions = useCallback(() => {
-    if (!lynxViewRef.current || !containerRef.current) return;
+  const setDimensions = useCallback((): boolean => {
+    if (!lynxViewRef.current || !containerRef.current) return false;
+
+    const width = containerRef.current.clientWidth;
+    const height = containerRef.current.clientHeight;
+    if (width === 0 || height === 0) return false;
 
     const pixelRatio = window.devicePixelRatio;
-    const pixelWidth = Math.round(
-      containerRef.current.clientWidth * pixelRatio,
-    );
-    const pixelHeight = Math.round(
-      containerRef.current.clientHeight * pixelRatio,
-    );
+    const pixelWidth = Math.round(width * pixelRatio);
+    const pixelHeight = Math.round(height * pixelRatio);
 
     // @ts-ignore
     lynxViewRef.current.browserConfig = {
@@ -142,13 +143,34 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       pixelHeight,
       pixelRatio,
     };
+    return true;
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const update = () => {
+      setDimsReady(el.clientWidth > 0 && el.clientHeight > 0);
+    };
+    update();
+
+    const ro = new ResizeObserver(() => update());
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   // Set URL eagerly once runtime is ready and element is mounted.
   // No longer gates on `show` — content is preloaded so tab switches are instant.
   // `lastUrlRef` prevents redundant url assignments that could trigger reloads.
   useEffect(() => {
-    if (ready && src && lynxViewRef.current && containerRef.current) {
+    if (
+      ready &&
+      dimsReady &&
+      src &&
+      lynxViewRef.current &&
+      containerRef.current
+    ) {
       // Skip if URL hasn't changed
       if (lastUrlRef.current === src) return;
 
@@ -156,7 +178,8 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       const tag = `[WebIframe ${src.split('/').pop()}]`;
       console.log(tag, 'effect start', { ready, src });
 
-      setDimensions();
+      const initialized = setDimensions();
+      if (!initialized) return;
 
       // @ts-ignore
       lynxViewRef.current.customTemplateLoader = async (url: string) => {
@@ -323,7 +346,7 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
         removeClickFix?.();
       };
     }
-  }, [ready, src, setDimensions]);
+  }, [ready, dimsReady, src, setDimensions]);
 
   // Only show loading state when the view is actually visible
   const loading = show && (!ready || !rendered || !!error);


### PR DESCRIPTION
## Problem

Switching away from and back to the Web tab shows a blank frame / white flash, even when `src` hasn’t changed.

**Root cause:** `<lynx-view>` was previously conditionally rendered (`show && src && ...`), so tab switches unmounted and remounted the element and its shadow DOM. The URL assignment and “rendered” detection run after paint, so the remounted view briefly appears empty before web-core rebuilds its shadow DOM.

## Fix

- **Always mount `<lynx-view>`** when `src` exists; hide via container `display: none` instead of conditional rendering, so the view instance (and shadow DOM) can persist across tab switches.
- **Eagerly set URL** once runtime is ready and the element ref exists (no longer gated on `show`) so content can preload before the Web tab is opened.
- **Deduplicate URL assignment** via `lastUrlRef` to avoid redundant reloads when the effect re-runs with the same `src`.