### PR TITLE
refactor(example-preview): simplify WebIframe for viewport-mode prep

### DIFF
--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -245,14 +245,14 @@ function useWebIframeController({
     };
 
     if (simulateError === 'shadow') {
-      setTimeout(
-        () =>
-          setError(
-            'Preview timed out: shadow root was not created (simulated)',
-          ),
-        500,
-      );
-      return () => {};
+      const shadowErrorTimer = setTimeout(() => {
+        if (disposed) return;
+        setError('Preview timed out: shadow root was not created (simulated)');
+      }, 500);
+      return () => {
+        disposed = true;
+        clearTimeout(shadowErrorTimer);
+      };
     }
 
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -303,7 +303,7 @@ function useWebIframeController({
 
 export const WebIframe = ({ show, src }: WebIframeProps) => {
   const lynxViewRef = useRef<LynxView>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const { ready, rendered, error } = useWebIframeController({
     src,
     lynxViewRef,

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,6 +1,7 @@
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useContainerResize } from '../hooks/use-container-resize';
 import { LoadingOverlay } from './loading-overlay';
 
 declare global {
@@ -59,6 +60,12 @@ const INNER_HIDDEN: React.CSSProperties = {
   display: 'none',
 };
 
+const STAGE: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
 // Use a shared group so multiple Lynx views can reuse web workers.
 const LYNX_GROUP_ID = 42;
 
@@ -73,25 +80,32 @@ function ensureRuntime() {
   return runtimeReady;
 }
 
-// Pre-compiled regex for webpack public path rewriting in customTemplateLoader
-// Matches .p=\"<anything>\" — handles empty, single-char, and multi-char paths
-const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
-
-// DEV: ?simulateError=runtime|template|shadow|render
+// DEV: ?simulateError=runtime|shadow|render
 const simulateError =
   typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('simulateError')
     : null;
 
-export const WebIframe = ({ show, src }: WebIframeProps) => {
-  const lynxViewRef = useRef<LynxView>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+type UseWebIframeControllerArgs = {
+  src: string;
+  lynxViewRef: React.RefObject<LynxView>;
+  containerRef: React.RefObject<HTMLDivElement>;
+};
+
+function useWebIframeController({
+  src,
+  lynxViewRef,
+  containerRef,
+}: UseWebIframeControllerArgs) {
   const [ready, setReady] = useState(false);
   const [dimsReady, setDimsReady] = useState(false);
   const [rendered, setRendered] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
   const renderedRef = useRef(false);
   const lastUrlRef = useRef<string>('');
+  const containerSizeRef = useRef({ width: 0, height: 0 });
+  const dimsReadyRef = useRef(false);
 
   // Reset state when src changes
   useEffect(() => {
@@ -124,247 +138,177 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       });
   }, []);
 
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const width = el.clientWidth;
+    const height = el.clientHeight;
+    containerSizeRef.current = { width, height };
+    const nextDimsReady = width > 0 && height > 0;
+    dimsReadyRef.current = nextDimsReady;
+    setDimsReady(nextDimsReady);
+  }, []);
+
+  useContainerResize({
+    ref: containerRef,
+    onResize: ({ width, height }) => {
+      const w = width ?? 0;
+      const h = height ?? 0;
+      containerSizeRef.current = { width: w, height: h };
+      const nextDimsReady = w > 0 && h > 0;
+      if (nextDimsReady !== dimsReadyRef.current) {
+        dimsReadyRef.current = nextDimsReady;
+        setDimsReady(nextDimsReady);
+      }
+    },
+  });
+
   // Set lynx-view dimensions to match the container.
   // Called on initial setup, SystemInfo cannot be updated after that.
   const setDimensions = useCallback((): boolean => {
-    if (!lynxViewRef.current || !containerRef.current) return false;
+    if (!lynxViewRef.current) return false;
 
-    const width = containerRef.current.clientWidth;
-    const height = containerRef.current.clientHeight;
+    const { width, height } = containerSizeRef.current;
     if (width === 0 || height === 0) return false;
 
     const pixelRatio = window.devicePixelRatio;
     const pixelWidth = Math.round(width * pixelRatio);
     const pixelHeight = Math.round(height * pixelRatio);
 
-    // @ts-ignore
     lynxViewRef.current.browserConfig = {
       pixelWidth,
       pixelHeight,
       pixelRatio,
     };
     return true;
-  }, []);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    const update = () => {
-      setDimsReady(el.clientWidth > 0 && el.clientHeight > 0);
-    };
-    update();
-
-    const ro = new ResizeObserver(() => update());
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+  }, [lynxViewRef]);
 
   // Set URL eagerly once runtime is ready and element is mounted.
   // No longer gates on `show` — content is preloaded so tab switches are instant.
   // `lastUrlRef` prevents redundant url assignments that could trigger reloads.
   useEffect(() => {
-    if (
-      ready &&
-      dimsReady &&
-      src &&
-      lynxViewRef.current &&
-      containerRef.current
-    ) {
-      // Skip URL assignment only, not the rest of initialization
-      const urlAlreadySet = lastUrlRef.current === src;
+    const lynxView = lynxViewRef.current;
+    if (!ready || !dimsReady || !src || !lynxView) return;
 
-      const t0 = performance.now();
-      const tag = `[WebIframe ${src.split('/').pop()}]`;
-      console.log(tag, 'effect start', { ready, src, urlAlreadySet });
+    const urlAlreadySet = lastUrlRef.current === src;
 
-      const initialized = setDimensions();
-      if (!initialized) return;
+    const t0 = performance.now();
+    const tag = `[WebIframe ${src.split('/').pop()}]`;
+    console.log(tag, 'effect start', { ready, src, urlAlreadySet });
 
-      if (!urlAlreadySet) {
-        // @ts-ignore
-        lynxViewRef.current.customTemplateLoader = async (url: string) => {
-          try {
-            if (simulateError === 'template') {
-              throw new Error('simulated template load error');
-            }
-            const res = await fetch(url);
-            if (!res.ok) {
-              throw new Error(`HTTP ${res.status} loading ${url}`);
-            }
-            const text = await res.text();
+    const initialized = setDimensions();
+    if (!initialized) return;
 
-            // Rewrite webpack's public path in the bundle JS so that asset
-            // URLs (images etc.) resolve relative to the bundle location,
-            // not the page URL.
-            const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
-            const rewritten = text.replace(
-              WEBPACK_PUBLIC_PATH_RE,
-              `.p=\\"${baseUrl}\\"`,
-            );
-            const template = JSON.parse(rewritten);
+    if (!urlAlreadySet) {
+      console.log(tag, 'url set', `+${(performance.now() - t0).toFixed(0)}ms`);
+      lynxView.url = src;
+      lastUrlRef.current = src;
+    }
 
-            // Workaround: when no template modules reference publicPath (no asset
-            // imports), rspack omits the local webpack runtime from lepusCode and
-            // emits a bare `__webpack_require__` reference. Inject a minimal shim
-            // so the entry-point executor (`__webpack_require__.x`) can run.
-            if (template.lepusCode?.root) {
-              const root = template.lepusCode.root;
-              if (
-                typeof root === 'string' &&
-                root.includes('__webpack_require__') &&
-                !root.includes('function __webpack_require__')
-              ) {
-                template.lepusCode.root =
-                  `var __webpack_require__={p:"${baseUrl}"};` + root;
-              }
-            }
+    const el = lynxView as unknown as HTMLElement;
+    let disposed = false;
+    let mo: MutationObserver | undefined;
 
-            return template;
-          } catch (err) {
-            console.error(tag, 'template load failed', err);
-            setError(
-              `Failed to load template: ${err instanceof Error ? err.message : String(err)}`,
-            );
-            throw err;
-          }
-        };
+    const markRendered = (source: string) => {
+      if (renderedRef.current) return;
+      if (simulateError === 'render') return;
+      console.log(
+        tag,
+        `rendered (${source})`,
+        `+${(performance.now() - t0).toFixed(0)}ms`,
+      );
+      renderedRef.current = true;
+      setRendered(true);
+    };
 
-        console.log(
-          tag,
-          'url set',
-          `+${(performance.now() - t0).toFixed(0)}ms`,
-        );
-        lynxViewRef.current.url = src;
-        lastUrlRef.current = src;
-      }
+    const setupShadow = (shadow: ShadowRoot) => {
+      console.log(
+        tag,
+        'shadow found',
+        `+${(performance.now() - t0).toFixed(0)}ms`,
+        {
+          childElementCount: shadow.childElementCount,
+        },
+      );
 
-      // Workaround: web-core reads MouseEvent.x/.y (viewport-relative) for
-      // tap event detail.x/.y. When the <lynx-view> is embedded at a non-zero
-      // offset, coordinates are wrong. Override the coordinate getters on the
-      // original event in a capture-phase listener (before web-core reads
-      // them on the element's bubbling handler).
-      const el = lynxViewRef.current as unknown as HTMLElement;
-      let disposed = false;
-      let mo: MutationObserver | undefined;
-      let removeClickFix: (() => void) | undefined;
-
-      const adjustClickCoords = (e: Event) => {
-        const me = e as MouseEvent;
-        const rect = el.getBoundingClientRect();
-        const adjustedX = me.clientX - rect.left;
-        const adjustedY = me.clientY - rect.top;
-        Object.defineProperties(me, {
-          clientX: { get: () => adjustedX },
-          clientY: { get: () => adjustedY },
-          x: { get: () => adjustedX },
-          y: { get: () => adjustedY },
-          pageX: { get: () => adjustedX },
-          pageY: { get: () => adjustedY },
-        });
-      };
-
-      // The shadow root is created asynchronously by web-core after url is
-      // set, so we poll until it becomes available before attaching observers.
-      const markRendered = (source: string) => {
-        if (renderedRef.current) return;
-        if (simulateError === 'render') return; // simulate render timeout
-        console.log(
-          tag,
-          `rendered (${source})`,
-          `+${(performance.now() - t0).toFixed(0)}ms`,
-        );
-        renderedRef.current = true;
-        setRendered(true);
-      };
-
-      const setupShadow = (shadow: ShadowRoot) => {
-        console.log(
-          tag,
-          'shadow found',
-          `+${(performance.now() - t0).toFixed(0)}ms`,
-          {
-            childElementCount: shadow.childElementCount,
-          },
-        );
-
-        // If shadow already has children when we attach, we missed the mutation
-        if (shadow.childElementCount > 0) {
-          markRendered('immediate');
-        } else {
-          mo = new MutationObserver(() => {
-            if (shadow.childElementCount > 0) {
-              markRendered('observer');
-              mo!.disconnect();
-            }
-          });
-          mo.observe(shadow, { childList: true, subtree: true });
-        }
-
-        shadow.addEventListener('click', adjustClickCoords, true);
-        removeClickFix = () =>
-          shadow.removeEventListener('click', adjustClickCoords, true);
-      };
-
-      if (simulateError === 'shadow') {
-        setTimeout(
-          () =>
-            setError(
-              'Preview timed out: shadow root was not created (simulated)',
-            ),
-          500,
-        );
-        return () => {};
-      }
-
-      let timer: ReturnType<typeof setTimeout> | undefined;
-
-      if (!renderedRef.current) {
-        const pollStart = performance.now();
-        const pollShadow = () => {
-          if (disposed) return;
-          if (performance.now() - pollStart > 3000) {
-            console.error(tag, 'shadow root timeout');
-            setError('Preview timed out: shadow root was not created');
-            return;
-          }
-          const shadow = el.shadowRoot;
-          if (shadow) {
-            setupShadow(shadow);
-          } else {
-            requestAnimationFrame(pollShadow);
-          }
-        };
-        pollShadow();
-
-        // Fallback: error if rendering doesn't complete within 5s
-        timer = setTimeout(() => {
-          if (!renderedRef.current) {
-            console.error(
-              tag,
-              'render timeout',
-              `+${(performance.now() - t0).toFixed(0)}ms`,
-            );
-            setError('Preview timed out: rendering did not complete within 5s');
-          }
-        }, 5000);
+      if (shadow.childElementCount > 0) {
+        markRendered('immediate');
       } else {
+        mo = new MutationObserver(() => {
+          if (shadow.childElementCount > 0) {
+            markRendered('observer');
+            mo!.disconnect();
+          }
+        });
+        mo.observe(shadow, { childList: true, subtree: true });
+      }
+    };
+
+    if (simulateError === 'shadow') {
+      setTimeout(
+        () =>
+          setError(
+            'Preview timed out: shadow root was not created (simulated)',
+          ),
+        500,
+      );
+      return () => {};
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (!renderedRef.current) {
+      const pollStart = performance.now();
+      const pollShadow = () => {
+        if (disposed) return;
+        if (performance.now() - pollStart > 3000) {
+          if (timer) clearTimeout(timer);
+          console.error(tag, 'shadow root timeout');
+          setError('Preview timed out: shadow root was not created');
+          return;
+        }
         const shadow = el.shadowRoot;
         if (shadow) {
-          shadow.addEventListener('click', adjustClickCoords, true);
-          removeClickFix = () =>
-            shadow.removeEventListener('click', adjustClickCoords, true);
+          setupShadow(shadow);
+        } else {
+          requestAnimationFrame(pollShadow);
         }
-      }
-
-      return () => {
-        disposed = true;
-        if (timer) clearTimeout(timer);
-        mo?.disconnect();
-        removeClickFix?.();
       };
+      pollShadow();
+
+      timer = setTimeout(() => {
+        if (!renderedRef.current) {
+          console.error(
+            tag,
+            'render timeout',
+            `+${(performance.now() - t0).toFixed(0)}ms`,
+          );
+          setError('Preview timed out: rendering did not complete within 5s');
+        }
+      }, 5000);
+    } else {
+      const shadow = el.shadowRoot;
+      if (shadow) setupShadow(shadow);
     }
-  }, [ready, dimsReady, src, setDimensions]);
+
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+      mo?.disconnect();
+    };
+  }, [ready, dimsReady, src, setDimensions, lynxViewRef]);
+
+  return { ready, dimsReady, rendered, error };
+}
+
+export const WebIframe = ({ show, src }: WebIframeProps) => {
+  const lynxViewRef = useRef<LynxView>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { ready, rendered, error } = useWebIframeController({
+    src,
+    lynxViewRef,
+    containerRef,
+  });
 
   // Only show loading state when the view is actually visible
   const loading = show && (!ready || !rendered || !!error);
@@ -379,14 +323,16 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       <div style={show ? INNER_VISIBLE : INNER_HIDDEN}>
         <LoadingOverlay visible={loading} error={error} />
         {src && (
-          <lynx-view
-            key={src}
-            ref={lynxViewRef}
-            style={LYNX_VIEW_STYLE}
-            lynx-group-id={LYNX_GROUP_ID}
-            transform-vh={true}
-            transform-vw={true}
-          />
+          <div style={STAGE}>
+            <lynx-view
+              key={src}
+              ref={lynxViewRef}
+              style={LYNX_VIEW_STYLE}
+              lynx-group-id={LYNX_GROUP_ID}
+              transform-vh={true}
+              transform-vw={true}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/example-preview/hooks/use-container-resize.ts
+++ b/src/example-preview/hooks/use-container-resize.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+
+import { useEffectEvent } from './use-effect-event';
+
+type Size = {
+  width?: number;
+  height?: number;
+};
+
+type ResizeObserverCtor = new (
+  callback: ResizeObserverCallback,
+) => ResizeObserver;
+
+type useContainerResizeOptions<T> = {
+  ref: MutableRefObject<T | null>;
+  ResizeObserverImpl?: ResizeObserverCtor;
+  onResize?: (size: Size) => void;
+};
+
+function useContainerResize<T extends HTMLElement = HTMLElement>({
+  ref,
+  ResizeObserverImpl,
+  onResize: onResizeProp,
+}: useContainerResizeOptions<T>): Size {
+  const [size, setSize] = useState<Size>({});
+  const prev = useRef<Size>({});
+  const onResize = useEffectEvent(onResizeProp);
+  const hasOnResize = onResizeProp !== undefined;
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const RO: ResizeObserverCtor | undefined =
+      ResizeObserverImpl ??
+      (typeof window !== 'undefined' && 'ResizeObserver' in window
+        ? window.ResizeObserver
+        : undefined);
+
+    if (!RO) return;
+
+    const observer: ResizeObserver = new RO((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      let width = 0;
+      let height = 0;
+
+      const cbsUnknown = entry.contentBoxSize as unknown;
+
+      if (Array.isArray(cbsUnknown)) {
+        const first = entry.contentBoxSize[0];
+        if (first) {
+          width = first.inlineSize;
+          height = first.blockSize;
+        }
+      } else if (isContentBoxSizeSingleItem(cbsUnknown)) {
+        width = cbsUnknown.inlineSize;
+        height = cbsUnknown.blockSize;
+      } else {
+        width = entry.contentRect.width;
+        height = entry.contentRect.height;
+      }
+
+      const changed =
+        width !== prev.current.width || height !== prev.current.height;
+
+      if (!changed) return;
+
+      const next: Size = { width, height };
+      prev.current = next;
+      if (hasOnResize) {
+        onResize(next);
+      } else if (ref.current) {
+        setSize(next);
+      }
+    });
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, ResizeObserverImpl, hasOnResize]);
+
+  return size;
+}
+
+export { useContainerResize };
+
+function isContentBoxSizeSingleItem(
+  v: unknown,
+): v is { inlineSize: number; blockSize: number } {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as { inlineSize?: unknown }).inlineSize === 'number' &&
+    typeof (v as { blockSize?: unknown }).blockSize === 'number'
+  );
+}

--- a/src/example-preview/hooks/use-container-resize.ts
+++ b/src/example-preview/hooks/use-container-resize.ts
@@ -12,7 +12,7 @@ type ResizeObserverCtor = new (
   callback: ResizeObserverCallback,
 ) => ResizeObserver;
 
-type useContainerResizeOptions<T> = {
+type UseContainerResizeOptions<T> = {
   ref: MutableRefObject<T | null>;
   ResizeObserverImpl?: ResizeObserverCtor;
   onResize?: (size: Size) => void;
@@ -22,7 +22,7 @@ function useContainerResize<T extends HTMLElement = HTMLElement>({
   ref,
   ResizeObserverImpl,
   onResize: onResizeProp,
-}: useContainerResizeOptions<T>): Size {
+}: UseContainerResizeOptions<T>): Size {
   const [size, setSize] = useState<Size>({});
   const prev = useRef<Size>({});
   const onResize = useEffectEvent(onResizeProp);

--- a/src/example-preview/hooks/use-effect-event.ts
+++ b/src/example-preview/hooks/use-effect-event.ts
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+function useEffectEvent<TArgs extends unknown[]>(
+  fn: ((...args: TArgs) => void) | undefined,
+): (...args: TArgs) => void;
+
+function useEffectEvent<TArgs extends unknown[], TResult>(
+  fn: ((...args: TArgs) => TResult) | undefined,
+  options: { fallbackResult: TResult },
+): (...args: TArgs) => TResult;
+
+function useEffectEvent<TArgs extends unknown[], TResult>(
+  fn: ((...args: TArgs) => TResult) | undefined,
+  options?: { fallbackResult: TResult },
+): (...args: TArgs) => TResult {
+  const ref = useRef(fn);
+
+  useEffect(() => {
+    ref.current = fn;
+  }, [fn]);
+
+  return useMemo(() => {
+    const proxy = (...args: TArgs) => {
+      const f = ref.current;
+      if (f) {
+        return f(...args);
+      }
+      if (options) {
+        return options.fallbackResult;
+      }
+      return undefined as unknown as TResult;
+    };
+    return proxy;
+  }, [options]);
+}
+
+export { useEffectEvent };

--- a/src/example-preview/hooks/use-is-client.ts
+++ b/src/example-preview/hooks/use-is-client.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from 'react';
+
+function subscribe(): () => void {
+  return () => {
+    /* no-op */
+  };
+}
+
+function getClientSnapshot(): boolean {
+  return true;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useIsClient(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
- Extract WebIframe runtime/resize/url/rendered/error logic into an internal controller hook, keeping default responsive behavior unchanged
- Introduce a 3-layer structure (MeasureContainer / Stage / lynx-view) so future fit/auto transform work is isolated to the Stage wrapper
- Port useContainerResize, useEffectEvent, useIsClient from luna-stage (inlined to avoid cross-package dependency in go-web)
- Remove customTemplateLoader, template rewrite logic, and simulateError=template dev path — no longer applicable with WASM-based web-core (v0.20.0+)

### Related: 
- Implementing #42