### PR TITLE
feat(example-preview): add WebIframe viewport modes (fit/responsive/auto)

### DIFF
--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,7 +1,15 @@
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { useContainerResize } from '../hooks/use-container-resize';
+import {
+  computeFrameOffset,
+  computeScaleRange,
+  lerpFitScale,
+} from '../utils/fit-scale';
+import { resolveWebPreviewMode } from '../utils/resolve-web-preview';
+import type { WebPreviewMode } from '../utils/resolve-web-preview';
 import { LoadingOverlay } from './loading-overlay';
 
 declare global {
@@ -18,22 +26,45 @@ type LynxViewAttributes = React.HTMLAttributes<HTMLElement> & {
   'transform-vw'?: boolean;
 };
 
-interface WebIframeProps {
+type CSSVarProperties = { [key: `--${string}`]: string | number };
+
+type WebIframeProps = {
   show: boolean;
   src: string;
-}
-
-type CSSVarProperties = {
-  [key: `--${string}`]: string | number;
+  webPreviewMode?: WebPreviewMode;
+  designWidth?: number;
+  designHeight?: number;
+  fitThresholdScale?: number;
+  fitMinScale?: number;
 };
 
+type UseWebIframeControllerArgs = {
+  src: string;
+  lynxViewRef: React.RefObject<LynxView>;
+  dimsReady: boolean;
+  containerSizeRef: React.MutableRefObject<{ width: number; height: number }>;
+  /**
+   * Override the pixel dimensions written to `browserConfig`.
+   * In `fit` mode this should be the design canvas size × pixelRatio,
+   * not the container size. Omit to use the container size (responsive mode).
+   */
+  browserConfigSize?: { width: number; height: number };
+};
+
+type UseWebIframeControllerResult = {
+  ready: boolean;
+  rendered: boolean;
+  error: string | null;
+};
+
+// Responsive mode: lynx-view fills the container, units track container size.
 // Container-relative unit hooks for Lynx runtime:
 // - `containerType: 'size'` enables `cqw/cqh` units based on the host element box.
 // - `--vh-unit/--vw-unit` make `vh/vw` behave like "container viewport" inside `<lynx-view>`.
 // - `--rpx-unit` aligns `rpx` scaling with a 750-wide design baseline (mobile-like behavior).
 // Note: web-core already applies `contain: content` internally; combined with `containerType: 'size'`
 // this effectively behaves like `contain: strict` without us overriding containment explicitly.
-const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
+const LYNX_VIEW_STYLE_RESPONSIVE: React.CSSProperties & CSSVarProperties = {
   width: '100%',
   height: '100%',
   containerType: 'size',
@@ -56,28 +87,33 @@ const INNER_VISIBLE: React.CSSProperties = {
   justifyContent: 'center',
 };
 
-const INNER_HIDDEN: React.CSSProperties = {
-  display: 'none',
-};
+const INNER_HIDDEN: React.CSSProperties = { display: 'none' };
 
-const STAGE: React.CSSProperties = {
+// Responsive stage: fills parent.
+const STAGE_RESPONSIVE: React.CSSProperties = {
   position: 'relative',
   width: '100%',
   height: '100%',
 };
 
-// Use a shared group so multiple Lynx views can reuse web workers.
+const STAGE_FIT_ANCHOR: React.CSSProperties = {
+  position: 'relative',
+  width: 0,
+  height: 0,
+  overflow: 'visible',
+};
+
+const FRAME_RESPONSIVE: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
 const LYNX_GROUP_ID = 42;
 
-// Shared promise so multiple WebIframe instances don't duplicate the dynamic import
 let runtimeReady: Promise<void> | null = null;
 function ensureRuntime() {
-  if (!runtimeReady) {
-    runtimeReady = import('@lynx-js/web-core/client').then(() => {
-      /* runtime loaded */
-    });
-  }
-  return runtimeReady;
+  return (runtimeReady ??= import('@lynx-js/web-core/client').then(() => {}));
 }
 
 // DEV: ?simulateError=runtime|shadow|render
@@ -86,32 +122,27 @@ const simulateError =
     ? new URLSearchParams(window.location.search).get('simulateError')
     : null;
 
-type UseWebIframeControllerArgs = {
-  src: string;
-  lynxViewRef: React.RefObject<LynxView>;
-  containerRef: React.RefObject<HTMLDivElement>;
-};
-
 function useWebIframeController({
   src,
   lynxViewRef,
-  containerRef,
-}: UseWebIframeControllerArgs) {
+  dimsReady,
+  containerSizeRef,
+  browserConfigSize,
+}: UseWebIframeControllerArgs): UseWebIframeControllerResult {
   const [ready, setReady] = useState(false);
-  const [dimsReady, setDimsReady] = useState(false);
   const [rendered, setRendered] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const renderedRef = useRef(false);
+  const browserConfigInitializedRef = useRef(false);
   const lastUrlRef = useRef<string>('');
-  const containerSizeRef = useRef({ width: 0, height: 0 });
-  const dimsReadyRef = useRef(false);
 
   // Reset state when src changes
   useEffect(() => {
     setRendered(false);
     setError(null);
     renderedRef.current = false;
+    browserConfigInitializedRef.current = false;
     lastUrlRef.current = '';
   }, [src]);
 
@@ -138,50 +169,23 @@ function useWebIframeController({
       });
   }, []);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const width = el.clientWidth;
-    const height = el.clientHeight;
-    containerSizeRef.current = { width, height };
-    const nextDimsReady = width > 0 && height > 0;
-    dimsReadyRef.current = nextDimsReady;
-    setDimsReady(nextDimsReady);
-  }, []);
-
-  useContainerResize({
-    ref: containerRef,
-    onResize: ({ width, height }) => {
-      const w = width ?? 0;
-      const h = height ?? 0;
-      containerSizeRef.current = { width: w, height: h };
-      const nextDimsReady = w > 0 && h > 0;
-      if (nextDimsReady !== dimsReadyRef.current) {
-        dimsReadyRef.current = nextDimsReady;
-        setDimsReady(nextDimsReady);
-      }
-    },
-  });
-
   // Set lynx-view dimensions to match the container.
   // Called on initial setup, SystemInfo cannot be updated after that.
   const setDimensions = useCallback((): boolean => {
     if (!lynxViewRef.current) return false;
-
-    const { width, height } = containerSizeRef.current;
+    if (browserConfigInitializedRef.current) return true;
+    // Use override size (fit mode: design canvas) or container size (responsive).
+    const { width, height } = browserConfigSize ?? containerSizeRef.current;
     if (width === 0 || height === 0) return false;
-
     const pixelRatio = window.devicePixelRatio;
-    const pixelWidth = Math.round(width * pixelRatio);
-    const pixelHeight = Math.round(height * pixelRatio);
-
     lynxViewRef.current.browserConfig = {
-      pixelWidth,
-      pixelHeight,
+      pixelWidth: Math.round(width * pixelRatio),
+      pixelHeight: Math.round(height * pixelRatio),
       pixelRatio,
     };
+    browserConfigInitializedRef.current = true;
     return true;
-  }, [lynxViewRef]);
+  }, [lynxViewRef, browserConfigSize, containerSizeRef]);
 
   // Set URL eagerly once runtime is ready and element is mounted.
   // No longer gates on `show` — content is preloaded so tab switches are instant.
@@ -219,6 +223,7 @@ function useWebIframeController({
       );
       renderedRef.current = true;
       setRendered(true);
+      console.log(`[WebIframe] rendered (${source})`);
     };
 
     const setupShadow = (shadow: ShadowRoot) => {
@@ -245,13 +250,15 @@ function useWebIframeController({
     };
 
     if (simulateError === 'shadow') {
-      const shadowErrorTimer = setTimeout(() => {
-        if (disposed) return;
-        setError('Preview timed out: shadow root was not created (simulated)');
+      const t = setTimeout(() => {
+        if (!disposed)
+          setError(
+            'Preview timed out: shadow root was not created (simulated)',
+          );
       }, 500);
       return () => {
         disposed = true;
-        clearTimeout(shadowErrorTimer);
+        clearTimeout(t);
       };
     }
 
@@ -298,21 +305,146 @@ function useWebIframeController({
     };
   }, [ready, dimsReady, src, setDimensions, lynxViewRef]);
 
-  return { ready, dimsReady, rendered, error };
+  return { ready, rendered, error };
 }
 
-export const WebIframe = ({ show, src }: WebIframeProps) => {
+function deriveFitStyles(
+  containerWidth: number,
+  containerHeight: number,
+  designWidth: number,
+  designHeight: number,
+  enableTransition: boolean,
+): {
+  frame: React.CSSProperties;
+  lynxView: React.CSSProperties & CSSVarProperties;
+} {
+  const scaleRange = computeScaleRange({
+    containerWidth,
+    containerHeight,
+    baseWidth: designWidth,
+    baseHeight: designHeight,
+  });
+  const scale = lerpFitScale(scaleRange, 0); // always contain
+  const { offsetX, offsetY } = computeFrameOffset({
+    baseWidth: designWidth,
+    baseHeight: designHeight,
+    scale,
+    ax: 0.5,
+    ay: 0.5,
+  });
+
+  return {
+    frame: {
+      position: 'absolute',
+      transformOrigin: 'top left',
+      width: designWidth,
+      height: designHeight,
+      transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+      // Smooth transition for fit→fit scale changes (container resize).
+      // Disabled for fit↔responsive mode switches (hard cut).
+      transition: enableTransition ? 'transform 0.2s ease' : undefined,
+    },
+    lynxView: {
+      width: designWidth,
+      height: designHeight,
+      containerType: 'size',
+      '--rpx-unit': `${designWidth / 750}px`,
+      '--vh-unit': `${designHeight / 100}px`,
+      '--vw-unit': `${designWidth / 100}px`,
+    },
+  };
+}
+
+export const WebIframe = ({
+  show,
+  src,
+  webPreviewMode = 'auto',
+  designWidth = 375,
+  designHeight = 812,
+  fitThresholdScale = 1.5,
+  fitMinScale = 0.6,
+}: WebIframeProps) => {
   const lynxViewRef = useRef<LynxView>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerSizeRef = useRef({ width: 0, height: 0 });
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const width = el.clientWidth;
+    const height = el.clientHeight;
+    containerSizeRef.current = { width, height };
+    setContainerWidth(width);
+    setContainerHeight(height);
+  }, []);
+
+  useContainerResize({
+    ref: containerRef,
+    onResize: ({ width, height }) => {
+      containerSizeRef.current = { width: width ?? 0, height: height ?? 0 };
+      setContainerWidth(width ?? 0);
+      setContainerHeight(height ?? 0);
+    },
+  });
+
+  const dimsReady = containerWidth > 0 && containerHeight > 0;
+
+  const mode = resolveWebPreviewMode({
+    webPreviewMode,
+    designWidth,
+    designHeight,
+    fitThresholdScale,
+    fitMinScale,
+    containerWidth,
+    containerHeight,
+  });
+
+  const browserConfigSize =
+    mode === 'fit' ? { width: designWidth, height: designHeight } : undefined;
+
+  const prevModeRef = useRef(mode);
+  const enableFitTransition = prevModeRef.current === 'fit' && mode === 'fit';
+  useEffect(() => {
+    prevModeRef.current = mode;
+  }, [mode]);
+
   const { ready, rendered, error } = useWebIframeController({
     src,
     lynxViewRef,
-    containerRef,
+    dimsReady,
+    containerSizeRef,
+    browserConfigSize,
   });
 
-  // Only show loading state when the view is actually visible
+  const { frame: fitFrameStyle, lynxView: fitLynxViewStyle } = deriveFitStyles(
+    containerWidth,
+    containerHeight,
+    designWidth,
+    designHeight,
+    enableFitTransition,
+  );
+
+  const { stage: stageStyle, lynxView: lynxViewStyle } =
+    mode === 'fit'
+      ? { stage: STAGE_FIT_ANCHOR, lynxView: fitLynxViewStyle }
+      : { stage: STAGE_RESPONSIVE, lynxView: LYNX_VIEW_STYLE_RESPONSIVE };
+
   const loading = show && (!ready || !rendered || !!error);
 
+  const lynxViewEl = src && (
+    <lynx-view
+      key={src}
+      ref={lynxViewRef}
+      style={lynxViewStyle}
+      lynx-group-id={LYNX_GROUP_ID}
+      transform-vh={true}
+      transform-vw={true}
+    />
+  );
+
+  const frameStyle = mode === 'fit' ? fitFrameStyle : FRAME_RESPONSIVE;
   // Always mount <lynx-view> when src exists so the ref
   // is always populated and shadow DOM persists
   // across tab switches.
@@ -322,18 +454,9 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
     <div style={MEASURE_CONTAINER} ref={containerRef}>
       <div style={show ? INNER_VISIBLE : INNER_HIDDEN}>
         <LoadingOverlay visible={loading} error={error} />
-        {src && (
-          <div style={STAGE}>
-            <lynx-view
-              key={src}
-              ref={lynxViewRef}
-              style={LYNX_VIEW_STYLE}
-              lynx-group-id={LYNX_GROUP_ID}
-              transform-vh={true}
-              transform-vw={true}
-            />
-          </div>
-        )}
+        <div style={stageStyle}>
+          <div style={frameStyle}>{lynxViewEl}</div>
+        </div>
       </div>
     </div>
   );

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -223,7 +223,6 @@ function useWebIframeController({
       );
       renderedRef.current = true;
       setRendered(true);
-      console.log(`[WebIframe] rendered (${source})`);
     };
 
     const setupShadow = (shadow: ShadowRoot) => {
@@ -418,17 +417,20 @@ export const WebIframe = ({
     browserConfigSize,
   });
 
-  const { frame: fitFrameStyle, lynxView: fitLynxViewStyle } = deriveFitStyles(
-    containerWidth,
-    containerHeight,
-    designWidth,
-    designHeight,
-    enableFitTransition,
-  );
+  const fitStyles =
+    mode === 'fit'
+      ? deriveFitStyles(
+          containerWidth,
+          containerHeight,
+          designWidth,
+          designHeight,
+          enableFitTransition,
+        )
+      : null;
 
   const { stage: stageStyle, lynxView: lynxViewStyle } =
-    mode === 'fit'
-      ? { stage: STAGE_FIT_ANCHOR, lynxView: fitLynxViewStyle }
+    mode === 'fit' && fitStyles
+      ? { stage: STAGE_FIT_ANCHOR, lynxView: fitStyles.lynxView }
       : { stage: STAGE_RESPONSIVE, lynxView: LYNX_VIEW_STYLE_RESPONSIVE };
 
   const loading = show && (!ready || !rendered || !!error);
@@ -444,7 +446,8 @@ export const WebIframe = ({
     />
   );
 
-  const frameStyle = mode === 'fit' ? fitFrameStyle : FRAME_RESPONSIVE;
+  const frameStyle =
+    mode === 'fit' && fitStyles ? fitStyles.frame : FRAME_RESPONSIVE;
   // Always mount <lynx-view> when src exists so the ref
   // is always populated and shadow DOM persists
   // across tab switches.

--- a/src/example-preview/utils/fit-scale.ts
+++ b/src/example-preview/utils/fit-scale.ts
@@ -1,0 +1,100 @@
+/**
+ * Dimensions of the container and the base frame.
+ */
+export type FitInput = {
+  /** Container width in pixels */
+  containerWidth: number;
+  /** Container height in pixels */
+  containerHeight: number;
+  /** Base frame width in pixels */
+  baseWidth: number;
+  /** Base frame height in pixels */
+  baseHeight: number;
+};
+
+/**
+ * Contain and cover scale factors for a base frame fitted into a container.
+ * The two values bracket the valid scale range.
+ *
+ * - `contain`: the base frame is fully visible inside the container
+ * - `cover`: the container is fully filled, base frame may be cropped
+ */
+export type ScaleRange = {
+  contain: number;
+  cover: number;
+};
+
+/**
+ * Pre-computed alignment factors along each axis.
+ * Each value is in [0, 1]: 0 = start, 0.5 = center, 1 = end.
+ */
+export type AlignFactors = {
+  ax: number;
+  ay: number;
+};
+
+/**
+ * Input for computing the frame's transform offset.
+ */
+export type FrameOffsetInput = {
+  baseWidth: number;
+  baseHeight: number;
+  scale: number;
+} & AlignFactors;
+
+/**
+ * 2D translation offset for a frame transform.
+ */
+export type FrameOffset = {
+  offsetX: number;
+  offsetY: number;
+};
+
+/**
+ * Compute the contain and cover scale factors for a base frame
+ * fitted into a container.
+ */
+export function computeScaleRange(input: FitInput): ScaleRange {
+  const { containerWidth, containerHeight, baseWidth, baseHeight } = input;
+  if (
+    !Number.isFinite(baseWidth) ||
+    baseWidth <= 0 ||
+    !Number.isFinite(baseHeight) ||
+    baseHeight <= 0
+  ) {
+    throw new RangeError(
+      `computeScaleRange: baseWidth and baseHeight must be finite and > 0, got ${baseWidth}x${baseHeight}`,
+    );
+  }
+  const ratioW = containerWidth / baseWidth;
+  const ratioH = containerHeight / baseHeight;
+  return {
+    contain: Math.min(ratioW, ratioH),
+    cover: Math.max(ratioW, ratioH),
+  };
+}
+
+/**
+ * Interpolate between contain and cover scale using a 0–1 progress value.
+ *
+ * - `t = 0`: behaves like contain
+ * - `t = 1`: behaves like cover
+ */
+export function lerpFitScale(
+  { contain, cover }: ScaleRange,
+  t: number,
+): number {
+  return contain + (cover - contain) * t;
+}
+
+/**
+ * Compute the transform offset for a scaled frame,
+ * given pre-computed scale and alignment factors.
+ */
+export function computeFrameOffset(input: FrameOffsetInput): FrameOffset {
+  const { baseWidth, baseHeight, scale, ax, ay } = input;
+  return {
+    offsetX: -(baseWidth * scale) * ax,
+    offsetY: -(baseHeight * scale) * ay,
+  };
+}

--- a/src/example-preview/utils/resolve-web-preview.ts
+++ b/src/example-preview/utils/resolve-web-preview.ts
@@ -1,0 +1,33 @@
+export type WebPreviewMode = 'fit' | 'responsive' | 'auto';
+export type ResolvedWebPreviewMode = Exclude<WebPreviewMode, 'auto'>;
+
+export type ResolveWebPreviewModeArgs = {
+  webPreviewMode: WebPreviewMode;
+  designWidth: number;
+  designHeight: number;
+  fitThresholdScale: number;
+  fitMinScale: number;
+  containerWidth: number;
+  containerHeight: number;
+};
+
+export function resolveWebPreviewMode({
+  webPreviewMode,
+  designWidth,
+  designHeight,
+  fitThresholdScale,
+  fitMinScale,
+  containerWidth,
+  containerHeight,
+}: ResolveWebPreviewModeArgs): ResolvedWebPreviewMode {
+  if (webPreviewMode === 'fit') return 'fit';
+  if (webPreviewMode === 'responsive') return 'responsive';
+
+  if (containerWidth <= 0 || containerHeight <= 0) return 'responsive';
+
+  const shouldUseFit =
+    containerWidth < designWidth * fitThresholdScale ||
+    containerHeight < designHeight * fitMinScale;
+
+  return shouldUseFit ? 'fit' : 'responsive';
+}


### PR DESCRIPTION
- Add viewport mode props: webPreviewMode (default: auto), designWidth/designHeight, fitThresholdScale, fitMinScale
- Implement auto mode resolution via resolveWebPreviewMode and keep browserConfig initialization explicit and one-time (browserConfigInitializedRef)
- Implement fit rendering: fixed design canvas size, translate+scale fit math (fit-scale utils), and fixed CSS vars for rpx/vh/vw units
- Implement switch behavior: fit→fit uses transform transition; fit↔responsive is a hard cut (transition disabled on mode changes)

## Related
- Implementing #42 