### PR TITLE
feat: add WebIframe viewport modes and expose via Go props

### DIFF
--- a/.changeset/fiery-cameras-try.md
+++ b/.changeset/fiery-cameras-try.md
@@ -1,0 +1,11 @@
+---
+'@lynx-js/go-web': minor
+---
+
+Add `webPreviewMode` to `ExamplePreview` / `Go` to control how the web preview renders `<lynx-view>`:
+
+- `responsive`: current behavior, `<lynx-view>` fills the container
+- `fit`: fixed design canvas (`designWidth`/`designHeight`) scaled into the container via CSS transform
+- `auto`: switches between `fit` and `responsive` based on container size (`fitThresholdScale` / `fitMinScale`)
+
+Also adds optional `designWidth`, `designHeight`, `fitThresholdScale`, and `fitMinScale` props (and embed options) to configure the viewport behavior.

--- a/example/src/embed-entry.tsx
+++ b/example/src/embed-entry.tsx
@@ -107,6 +107,11 @@ type EmbedOptions = {
   entry?: string | string[];
   seamless?: boolean;
   exampleBasePath?: string;
+  webPreviewMode?: 'fit' | 'responsive' | 'auto';
+  designWidth?: number;
+  designHeight?: number;
+  fitThresholdScale?: number;
+  fitMinScale?: number;
 };
 
 // ---------------------------------------------------------------------------
@@ -176,6 +181,11 @@ function EmbedApp() {
           defaultEntryFile={options.defaultEntryFile}
           highlight={options.highlight}
           entry={options.entry}
+          webPreviewMode={options.webPreviewMode}
+          designWidth={options.designWidth}
+          designHeight={options.designHeight}
+          fitThresholdScale={options.fitThresholdScale}
+          fitMinScale={options.fitMinScale}
         />
       </div>
     </GoConfigProvider>

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -34,6 +34,16 @@ export type EmbedOptions = {
   entry?: string | string[];
   /** Hide the header bar for minimal embeds */
   seamless?: boolean;
+  /** Web preview viewport mode */
+  webPreviewMode?: 'fit' | 'responsive' | 'auto';
+  /** Design canvas width for fit mode */
+  designWidth?: number;
+  /** Design canvas height for fit mode */
+  designHeight?: number;
+  /** Auto mode width threshold multiplier */
+  fitThresholdScale?: number;
+  /** Auto mode height lower-bound multiplier */
+  fitMinScale?: number;
   /**
    * Base path (or full URL) for example assets.
    * Defaults to '/lynx-examples'. Use a full URL for cross-origin data,

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -31,6 +31,7 @@ import {
   IconFullscreen,
   IconGithub,
 } from '../utils/icon';
+import type { WebPreviewMode } from '../utils/resolve-web-preview';
 import { tabScrollToTop } from '../utils/tool';
 
 const WebIframe = React.lazy(() =>
@@ -76,6 +77,11 @@ interface ExampleContentProps {
   langAlias?: Record<string, string>;
   defaultTab?: PreviewTab;
   mode?: ExamplePreviewMode;
+  webPreviewMode?: WebPreviewMode;
+  designWidth?: number;
+  designHeight?: number;
+  fitThresholdScale?: number;
+  fitMinScale?: number;
 }
 
 export function ExampleContent({
@@ -101,6 +107,11 @@ export function ExampleContent({
   langAlias,
   defaultTab,
   mode = 'linked',
+  webPreviewMode = 'auto',
+  designWidth = 375,
+  designHeight = 812,
+  fitThresholdScale = 1.5,
+  fitMinScale = 0.6,
 }: ExampleContentProps) {
   const {
     explorerUrl,
@@ -421,6 +432,11 @@ export function ExampleContent({
                   <WebIframe
                     show={previewType === PreviewType.Web}
                     src={defaultWebPreviewFile || ''}
+                    webPreviewMode={webPreviewMode}
+                    designWidth={designWidth}
+                    designHeight={designHeight}
+                    fitThresholdScale={fitThresholdScale}
+                    fitMinScale={fitMinScale}
                   />
                 </Suspense>
               </NoSSRComponent>

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,7 +1,15 @@
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { useContainerResize } from '../hooks/use-container-resize';
+import {
+  computeFrameOffset,
+  computeScaleRange,
+  lerpFitScale,
+} from '../utils/fit-scale';
+import { resolveWebPreviewMode } from '../utils/resolve-web-preview';
+import type { WebPreviewMode } from '../utils/resolve-web-preview';
 import { LoadingOverlay } from './loading-overlay';
 
 declare global {
@@ -18,22 +26,45 @@ type LynxViewAttributes = React.HTMLAttributes<HTMLElement> & {
   'transform-vw'?: boolean;
 };
 
-interface WebIframeProps {
+type CSSVarProperties = { [key: `--${string}`]: string | number };
+
+type WebIframeProps = {
   show: boolean;
   src: string;
-}
-
-type CSSVarProperties = {
-  [key: `--${string}`]: string | number;
+  webPreviewMode?: WebPreviewMode;
+  designWidth?: number;
+  designHeight?: number;
+  fitThresholdScale?: number;
+  fitMinScale?: number;
 };
 
+type UseWebIframeControllerArgs = {
+  src: string;
+  lynxViewRef: React.RefObject<LynxView>;
+  dimsReady: boolean;
+  containerSizeRef: React.MutableRefObject<{ width: number; height: number }>;
+  /**
+   * Override the pixel dimensions written to `browserConfig`.
+   * In `fit` mode this should be the design canvas size × pixelRatio,
+   * not the container size. Omit to use the container size (responsive mode).
+   */
+  browserConfigSize?: { width: number; height: number };
+};
+
+type UseWebIframeControllerResult = {
+  ready: boolean;
+  rendered: boolean;
+  error: string | null;
+};
+
+// Responsive mode: lynx-view fills the container, units track container size.
 // Container-relative unit hooks for Lynx runtime:
 // - `containerType: 'size'` enables `cqw/cqh` units based on the host element box.
 // - `--vh-unit/--vw-unit` make `vh/vw` behave like "container viewport" inside `<lynx-view>`.
 // - `--rpx-unit` aligns `rpx` scaling with a 750-wide design baseline (mobile-like behavior).
 // Note: web-core already applies `contain: content` internally; combined with `containerType: 'size'`
 // this effectively behaves like `contain: strict` without us overriding containment explicitly.
-const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
+const LYNX_VIEW_STYLE_RESPONSIVE: React.CSSProperties & CSSVarProperties = {
   width: '100%',
   height: '100%',
   containerType: 'size',
@@ -56,28 +87,33 @@ const INNER_VISIBLE: React.CSSProperties = {
   justifyContent: 'center',
 };
 
-const INNER_HIDDEN: React.CSSProperties = {
-  display: 'none',
-};
+const INNER_HIDDEN: React.CSSProperties = { display: 'none' };
 
-const STAGE: React.CSSProperties = {
+// Responsive stage: fills parent.
+const STAGE_RESPONSIVE: React.CSSProperties = {
   position: 'relative',
   width: '100%',
   height: '100%',
 };
 
-// Use a shared group so multiple Lynx views can reuse web workers.
+const STAGE_FIT_ANCHOR: React.CSSProperties = {
+  position: 'relative',
+  width: 0,
+  height: 0,
+  overflow: 'visible',
+};
+
+const FRAME_RESPONSIVE: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
 const LYNX_GROUP_ID = 42;
 
-// Shared promise so multiple WebIframe instances don't duplicate the dynamic import
 let runtimeReady: Promise<void> | null = null;
 function ensureRuntime() {
-  if (!runtimeReady) {
-    runtimeReady = import('@lynx-js/web-core/client').then(() => {
-      /* runtime loaded */
-    });
-  }
-  return runtimeReady;
+  return (runtimeReady ??= import('@lynx-js/web-core/client').then(() => {}));
 }
 
 // DEV: ?simulateError=runtime|shadow|render
@@ -86,32 +122,27 @@ const simulateError =
     ? new URLSearchParams(window.location.search).get('simulateError')
     : null;
 
-type UseWebIframeControllerArgs = {
-  src: string;
-  lynxViewRef: React.RefObject<LynxView>;
-  containerRef: React.RefObject<HTMLDivElement>;
-};
-
 function useWebIframeController({
   src,
   lynxViewRef,
-  containerRef,
-}: UseWebIframeControllerArgs) {
+  dimsReady,
+  containerSizeRef,
+  browserConfigSize,
+}: UseWebIframeControllerArgs): UseWebIframeControllerResult {
   const [ready, setReady] = useState(false);
-  const [dimsReady, setDimsReady] = useState(false);
   const [rendered, setRendered] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const renderedRef = useRef(false);
+  const browserConfigInitializedRef = useRef(false);
   const lastUrlRef = useRef<string>('');
-  const containerSizeRef = useRef({ width: 0, height: 0 });
-  const dimsReadyRef = useRef(false);
 
   // Reset state when src changes
   useEffect(() => {
     setRendered(false);
     setError(null);
     renderedRef.current = false;
+    browserConfigInitializedRef.current = false;
     lastUrlRef.current = '';
   }, [src]);
 
@@ -138,50 +169,23 @@ function useWebIframeController({
       });
   }, []);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const width = el.clientWidth;
-    const height = el.clientHeight;
-    containerSizeRef.current = { width, height };
-    const nextDimsReady = width > 0 && height > 0;
-    dimsReadyRef.current = nextDimsReady;
-    setDimsReady(nextDimsReady);
-  }, []);
-
-  useContainerResize({
-    ref: containerRef,
-    onResize: ({ width, height }) => {
-      const w = width ?? 0;
-      const h = height ?? 0;
-      containerSizeRef.current = { width: w, height: h };
-      const nextDimsReady = w > 0 && h > 0;
-      if (nextDimsReady !== dimsReadyRef.current) {
-        dimsReadyRef.current = nextDimsReady;
-        setDimsReady(nextDimsReady);
-      }
-    },
-  });
-
   // Set lynx-view dimensions to match the container.
   // Called on initial setup, SystemInfo cannot be updated after that.
   const setDimensions = useCallback((): boolean => {
     if (!lynxViewRef.current) return false;
-
-    const { width, height } = containerSizeRef.current;
+    if (browserConfigInitializedRef.current) return true;
+    // Use override size (fit mode: design canvas) or container size (responsive).
+    const { width, height } = browserConfigSize ?? containerSizeRef.current;
     if (width === 0 || height === 0) return false;
-
     const pixelRatio = window.devicePixelRatio;
-    const pixelWidth = Math.round(width * pixelRatio);
-    const pixelHeight = Math.round(height * pixelRatio);
-
     lynxViewRef.current.browserConfig = {
-      pixelWidth,
-      pixelHeight,
+      pixelWidth: Math.round(width * pixelRatio),
+      pixelHeight: Math.round(height * pixelRatio),
       pixelRatio,
     };
+    browserConfigInitializedRef.current = true;
     return true;
-  }, [lynxViewRef]);
+  }, [lynxViewRef, browserConfigSize, containerSizeRef]);
 
   // Set URL eagerly once runtime is ready and element is mounted.
   // No longer gates on `show` — content is preloaded so tab switches are instant.
@@ -245,13 +249,15 @@ function useWebIframeController({
     };
 
     if (simulateError === 'shadow') {
-      const shadowErrorTimer = setTimeout(() => {
-        if (disposed) return;
-        setError('Preview timed out: shadow root was not created (simulated)');
+      const t = setTimeout(() => {
+        if (!disposed)
+          setError(
+            'Preview timed out: shadow root was not created (simulated)',
+          );
       }, 500);
       return () => {
         disposed = true;
-        clearTimeout(shadowErrorTimer);
+        clearTimeout(t);
       };
     }
 
@@ -298,21 +304,150 @@ function useWebIframeController({
     };
   }, [ready, dimsReady, src, setDimensions, lynxViewRef]);
 
-  return { ready, dimsReady, rendered, error };
+  return { ready, rendered, error };
 }
 
-export const WebIframe = ({ show, src }: WebIframeProps) => {
+function deriveFitStyles(
+  containerWidth: number,
+  containerHeight: number,
+  designWidth: number,
+  designHeight: number,
+  enableTransition: boolean,
+): {
+  frame: React.CSSProperties;
+  lynxView: React.CSSProperties & CSSVarProperties;
+} {
+  const scaleRange = computeScaleRange({
+    containerWidth,
+    containerHeight,
+    baseWidth: designWidth,
+    baseHeight: designHeight,
+  });
+  const scale = lerpFitScale(scaleRange, 0); // always contain
+  const { offsetX, offsetY } = computeFrameOffset({
+    baseWidth: designWidth,
+    baseHeight: designHeight,
+    scale,
+    ax: 0.5,
+    ay: 0.5,
+  });
+
+  return {
+    frame: {
+      position: 'absolute',
+      transformOrigin: 'top left',
+      width: designWidth,
+      height: designHeight,
+      transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+      // Smooth transition for fit→fit scale changes (container resize).
+      // Disabled for fit↔responsive mode switches (hard cut).
+      transition: enableTransition ? 'transform 0.2s ease' : undefined,
+    },
+    lynxView: {
+      width: designWidth,
+      height: designHeight,
+      containerType: 'size',
+      '--rpx-unit': `${designWidth / 750}px`,
+      '--vh-unit': `${designHeight / 100}px`,
+      '--vw-unit': `${designWidth / 100}px`,
+    },
+  };
+}
+
+export const WebIframe = ({
+  show,
+  src,
+  webPreviewMode = 'auto',
+  designWidth = 375,
+  designHeight = 812,
+  fitThresholdScale = 1.5,
+  fitMinScale = 0.6,
+}: WebIframeProps) => {
   const lynxViewRef = useRef<LynxView>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerSizeRef = useRef({ width: 0, height: 0 });
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const width = el.clientWidth;
+    const height = el.clientHeight;
+    containerSizeRef.current = { width, height };
+    setContainerWidth(width);
+    setContainerHeight(height);
+  }, []);
+
+  useContainerResize({
+    ref: containerRef,
+    onResize: ({ width, height }) => {
+      containerSizeRef.current = { width: width ?? 0, height: height ?? 0 };
+      setContainerWidth(width ?? 0);
+      setContainerHeight(height ?? 0);
+    },
+  });
+
+  const dimsReady = containerWidth > 0 && containerHeight > 0;
+
+  const mode = resolveWebPreviewMode({
+    webPreviewMode,
+    designWidth,
+    designHeight,
+    fitThresholdScale,
+    fitMinScale,
+    containerWidth,
+    containerHeight,
+  });
+
+  const browserConfigSize =
+    mode === 'fit' ? { width: designWidth, height: designHeight } : undefined;
+
+  const prevModeRef = useRef(mode);
+  const enableFitTransition = prevModeRef.current === 'fit' && mode === 'fit';
+  useEffect(() => {
+    prevModeRef.current = mode;
+  }, [mode]);
+
   const { ready, rendered, error } = useWebIframeController({
     src,
     lynxViewRef,
-    containerRef,
+    dimsReady,
+    containerSizeRef,
+    browserConfigSize,
   });
 
-  // Only show loading state when the view is actually visible
+  const fitStyles =
+    mode === 'fit'
+      ? deriveFitStyles(
+          containerWidth,
+          containerHeight,
+          designWidth,
+          designHeight,
+          enableFitTransition,
+        )
+      : null;
+
+  const { stage: stageStyle, lynxView: lynxViewStyle } =
+    mode === 'fit' && fitStyles
+      ? { stage: STAGE_FIT_ANCHOR, lynxView: fitStyles.lynxView }
+      : { stage: STAGE_RESPONSIVE, lynxView: LYNX_VIEW_STYLE_RESPONSIVE };
+
   const loading = show && (!ready || !rendered || !!error);
 
+  const lynxViewEl = src && (
+    <lynx-view
+      key={src}
+      ref={lynxViewRef}
+      style={lynxViewStyle}
+      lynx-group-id={LYNX_GROUP_ID}
+      transform-vh={true}
+      transform-vw={true}
+    />
+  );
+
+  const frameStyle =
+    mode === 'fit' && fitStyles ? fitStyles.frame : FRAME_RESPONSIVE;
   // Always mount <lynx-view> when src exists so the ref
   // is always populated and shadow DOM persists
   // across tab switches.
@@ -322,18 +457,9 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
     <div style={MEASURE_CONTAINER} ref={containerRef}>
       <div style={show ? INNER_VISIBLE : INNER_HIDDEN}>
         <LoadingOverlay visible={loading} error={error} />
-        {src && (
-          <div style={STAGE}>
-            <lynx-view
-              key={src}
-              ref={lynxViewRef}
-              style={LYNX_VIEW_STYLE}
-              lynx-group-id={LYNX_GROUP_ID}
-              transform-vh={true}
-              transform-vw={true}
-            />
-          </div>
-        )}
+        <div style={stageStyle}>
+          <div style={frameStyle}>{lynxViewEl}</div>
+        </div>
       </div>
     </div>
   );

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,6 +1,7 @@
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useContainerResize } from '../hooks/use-container-resize';
 import { LoadingOverlay } from './loading-overlay';
 
 declare global {
@@ -59,6 +60,12 @@ const INNER_HIDDEN: React.CSSProperties = {
   display: 'none',
 };
 
+const STAGE: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
 // Use a shared group so multiple Lynx views can reuse web workers.
 const LYNX_GROUP_ID = 42;
 
@@ -73,25 +80,32 @@ function ensureRuntime() {
   return runtimeReady;
 }
 
-// Pre-compiled regex for webpack public path rewriting in customTemplateLoader
-// Matches .p=\"<anything>\" — handles empty, single-char, and multi-char paths
-const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
-
-// DEV: ?simulateError=runtime|template|shadow|render
+// DEV: ?simulateError=runtime|shadow|render
 const simulateError =
   typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('simulateError')
     : null;
 
-export const WebIframe = ({ show, src }: WebIframeProps) => {
-  const lynxViewRef = useRef<LynxView>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+type UseWebIframeControllerArgs = {
+  src: string;
+  lynxViewRef: React.RefObject<LynxView>;
+  containerRef: React.RefObject<HTMLDivElement>;
+};
+
+function useWebIframeController({
+  src,
+  lynxViewRef,
+  containerRef,
+}: UseWebIframeControllerArgs) {
   const [ready, setReady] = useState(false);
   const [dimsReady, setDimsReady] = useState(false);
   const [rendered, setRendered] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
   const renderedRef = useRef(false);
   const lastUrlRef = useRef<string>('');
+  const containerSizeRef = useRef({ width: 0, height: 0 });
+  const dimsReadyRef = useRef(false);
 
   // Reset state when src changes
   useEffect(() => {
@@ -124,247 +138,177 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       });
   }, []);
 
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const width = el.clientWidth;
+    const height = el.clientHeight;
+    containerSizeRef.current = { width, height };
+    const nextDimsReady = width > 0 && height > 0;
+    dimsReadyRef.current = nextDimsReady;
+    setDimsReady(nextDimsReady);
+  }, []);
+
+  useContainerResize({
+    ref: containerRef,
+    onResize: ({ width, height }) => {
+      const w = width ?? 0;
+      const h = height ?? 0;
+      containerSizeRef.current = { width: w, height: h };
+      const nextDimsReady = w > 0 && h > 0;
+      if (nextDimsReady !== dimsReadyRef.current) {
+        dimsReadyRef.current = nextDimsReady;
+        setDimsReady(nextDimsReady);
+      }
+    },
+  });
+
   // Set lynx-view dimensions to match the container.
   // Called on initial setup, SystemInfo cannot be updated after that.
   const setDimensions = useCallback((): boolean => {
-    if (!lynxViewRef.current || !containerRef.current) return false;
+    if (!lynxViewRef.current) return false;
 
-    const width = containerRef.current.clientWidth;
-    const height = containerRef.current.clientHeight;
+    const { width, height } = containerSizeRef.current;
     if (width === 0 || height === 0) return false;
 
     const pixelRatio = window.devicePixelRatio;
     const pixelWidth = Math.round(width * pixelRatio);
     const pixelHeight = Math.round(height * pixelRatio);
 
-    // @ts-ignore
     lynxViewRef.current.browserConfig = {
       pixelWidth,
       pixelHeight,
       pixelRatio,
     };
     return true;
-  }, []);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    const update = () => {
-      setDimsReady(el.clientWidth > 0 && el.clientHeight > 0);
-    };
-    update();
-
-    const ro = new ResizeObserver(() => update());
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+  }, [lynxViewRef]);
 
   // Set URL eagerly once runtime is ready and element is mounted.
   // No longer gates on `show` — content is preloaded so tab switches are instant.
   // `lastUrlRef` prevents redundant url assignments that could trigger reloads.
   useEffect(() => {
-    if (
-      ready &&
-      dimsReady &&
-      src &&
-      lynxViewRef.current &&
-      containerRef.current
-    ) {
-      // Skip URL assignment only, not the rest of initialization
-      const urlAlreadySet = lastUrlRef.current === src;
+    const lynxView = lynxViewRef.current;
+    if (!ready || !dimsReady || !src || !lynxView) return;
 
-      const t0 = performance.now();
-      const tag = `[WebIframe ${src.split('/').pop()}]`;
-      console.log(tag, 'effect start', { ready, src, urlAlreadySet });
+    const urlAlreadySet = lastUrlRef.current === src;
 
-      const initialized = setDimensions();
-      if (!initialized) return;
+    const t0 = performance.now();
+    const tag = `[WebIframe ${src.split('/').pop()}]`;
+    console.log(tag, 'effect start', { ready, src, urlAlreadySet });
 
-      if (!urlAlreadySet) {
-        // @ts-ignore
-        lynxViewRef.current.customTemplateLoader = async (url: string) => {
-          try {
-            if (simulateError === 'template') {
-              throw new Error('simulated template load error');
-            }
-            const res = await fetch(url);
-            if (!res.ok) {
-              throw new Error(`HTTP ${res.status} loading ${url}`);
-            }
-            const text = await res.text();
+    const initialized = setDimensions();
+    if (!initialized) return;
 
-            // Rewrite webpack's public path in the bundle JS so that asset
-            // URLs (images etc.) resolve relative to the bundle location,
-            // not the page URL.
-            const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
-            const rewritten = text.replace(
-              WEBPACK_PUBLIC_PATH_RE,
-              `.p=\\"${baseUrl}\\"`,
-            );
-            const template = JSON.parse(rewritten);
+    if (!urlAlreadySet) {
+      console.log(tag, 'url set', `+${(performance.now() - t0).toFixed(0)}ms`);
+      lynxView.url = src;
+      lastUrlRef.current = src;
+    }
 
-            // Workaround: when no template modules reference publicPath (no asset
-            // imports), rspack omits the local webpack runtime from lepusCode and
-            // emits a bare `__webpack_require__` reference. Inject a minimal shim
-            // so the entry-point executor (`__webpack_require__.x`) can run.
-            if (template.lepusCode?.root) {
-              const root = template.lepusCode.root;
-              if (
-                typeof root === 'string' &&
-                root.includes('__webpack_require__') &&
-                !root.includes('function __webpack_require__')
-              ) {
-                template.lepusCode.root =
-                  `var __webpack_require__={p:"${baseUrl}"};` + root;
-              }
-            }
+    const el = lynxView as unknown as HTMLElement;
+    let disposed = false;
+    let mo: MutationObserver | undefined;
 
-            return template;
-          } catch (err) {
-            console.error(tag, 'template load failed', err);
-            setError(
-              `Failed to load template: ${err instanceof Error ? err.message : String(err)}`,
-            );
-            throw err;
-          }
-        };
+    const markRendered = (source: string) => {
+      if (renderedRef.current) return;
+      if (simulateError === 'render') return;
+      console.log(
+        tag,
+        `rendered (${source})`,
+        `+${(performance.now() - t0).toFixed(0)}ms`,
+      );
+      renderedRef.current = true;
+      setRendered(true);
+    };
 
-        console.log(
-          tag,
-          'url set',
-          `+${(performance.now() - t0).toFixed(0)}ms`,
-        );
-        lynxViewRef.current.url = src;
-        lastUrlRef.current = src;
-      }
+    const setupShadow = (shadow: ShadowRoot) => {
+      console.log(
+        tag,
+        'shadow found',
+        `+${(performance.now() - t0).toFixed(0)}ms`,
+        {
+          childElementCount: shadow.childElementCount,
+        },
+      );
 
-      // Workaround: web-core reads MouseEvent.x/.y (viewport-relative) for
-      // tap event detail.x/.y. When the <lynx-view> is embedded at a non-zero
-      // offset, coordinates are wrong. Override the coordinate getters on the
-      // original event in a capture-phase listener (before web-core reads
-      // them on the element's bubbling handler).
-      const el = lynxViewRef.current as unknown as HTMLElement;
-      let disposed = false;
-      let mo: MutationObserver | undefined;
-      let removeClickFix: (() => void) | undefined;
-
-      const adjustClickCoords = (e: Event) => {
-        const me = e as MouseEvent;
-        const rect = el.getBoundingClientRect();
-        const adjustedX = me.clientX - rect.left;
-        const adjustedY = me.clientY - rect.top;
-        Object.defineProperties(me, {
-          clientX: { get: () => adjustedX },
-          clientY: { get: () => adjustedY },
-          x: { get: () => adjustedX },
-          y: { get: () => adjustedY },
-          pageX: { get: () => adjustedX },
-          pageY: { get: () => adjustedY },
-        });
-      };
-
-      // The shadow root is created asynchronously by web-core after url is
-      // set, so we poll until it becomes available before attaching observers.
-      const markRendered = (source: string) => {
-        if (renderedRef.current) return;
-        if (simulateError === 'render') return; // simulate render timeout
-        console.log(
-          tag,
-          `rendered (${source})`,
-          `+${(performance.now() - t0).toFixed(0)}ms`,
-        );
-        renderedRef.current = true;
-        setRendered(true);
-      };
-
-      const setupShadow = (shadow: ShadowRoot) => {
-        console.log(
-          tag,
-          'shadow found',
-          `+${(performance.now() - t0).toFixed(0)}ms`,
-          {
-            childElementCount: shadow.childElementCount,
-          },
-        );
-
-        // If shadow already has children when we attach, we missed the mutation
-        if (shadow.childElementCount > 0) {
-          markRendered('immediate');
-        } else {
-          mo = new MutationObserver(() => {
-            if (shadow.childElementCount > 0) {
-              markRendered('observer');
-              mo!.disconnect();
-            }
-          });
-          mo.observe(shadow, { childList: true, subtree: true });
-        }
-
-        shadow.addEventListener('click', adjustClickCoords, true);
-        removeClickFix = () =>
-          shadow.removeEventListener('click', adjustClickCoords, true);
-      };
-
-      if (simulateError === 'shadow') {
-        setTimeout(
-          () =>
-            setError(
-              'Preview timed out: shadow root was not created (simulated)',
-            ),
-          500,
-        );
-        return () => {};
-      }
-
-      let timer: ReturnType<typeof setTimeout> | undefined;
-
-      if (!renderedRef.current) {
-        const pollStart = performance.now();
-        const pollShadow = () => {
-          if (disposed) return;
-          if (performance.now() - pollStart > 3000) {
-            console.error(tag, 'shadow root timeout');
-            setError('Preview timed out: shadow root was not created');
-            return;
-          }
-          const shadow = el.shadowRoot;
-          if (shadow) {
-            setupShadow(shadow);
-          } else {
-            requestAnimationFrame(pollShadow);
-          }
-        };
-        pollShadow();
-
-        // Fallback: error if rendering doesn't complete within 5s
-        timer = setTimeout(() => {
-          if (!renderedRef.current) {
-            console.error(
-              tag,
-              'render timeout',
-              `+${(performance.now() - t0).toFixed(0)}ms`,
-            );
-            setError('Preview timed out: rendering did not complete within 5s');
-          }
-        }, 5000);
+      if (shadow.childElementCount > 0) {
+        markRendered('immediate');
       } else {
-        const shadow = el.shadowRoot;
-        if (shadow) {
-          shadow.addEventListener('click', adjustClickCoords, true);
-          removeClickFix = () =>
-            shadow.removeEventListener('click', adjustClickCoords, true);
-        }
+        mo = new MutationObserver(() => {
+          if (shadow.childElementCount > 0) {
+            markRendered('observer');
+            mo!.disconnect();
+          }
+        });
+        mo.observe(shadow, { childList: true, subtree: true });
       }
+    };
 
+    if (simulateError === 'shadow') {
+      const shadowErrorTimer = setTimeout(() => {
+        if (disposed) return;
+        setError('Preview timed out: shadow root was not created (simulated)');
+      }, 500);
       return () => {
         disposed = true;
-        if (timer) clearTimeout(timer);
-        mo?.disconnect();
-        removeClickFix?.();
+        clearTimeout(shadowErrorTimer);
       };
     }
-  }, [ready, dimsReady, src, setDimensions]);
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (!renderedRef.current) {
+      const pollStart = performance.now();
+      const pollShadow = () => {
+        if (disposed) return;
+        if (performance.now() - pollStart > 3000) {
+          if (timer) clearTimeout(timer);
+          console.error(tag, 'shadow root timeout');
+          setError('Preview timed out: shadow root was not created');
+          return;
+        }
+        const shadow = el.shadowRoot;
+        if (shadow) {
+          setupShadow(shadow);
+        } else {
+          requestAnimationFrame(pollShadow);
+        }
+      };
+      pollShadow();
+
+      timer = setTimeout(() => {
+        if (!renderedRef.current) {
+          console.error(
+            tag,
+            'render timeout',
+            `+${(performance.now() - t0).toFixed(0)}ms`,
+          );
+          setError('Preview timed out: rendering did not complete within 5s');
+        }
+      }, 5000);
+    } else {
+      const shadow = el.shadowRoot;
+      if (shadow) setupShadow(shadow);
+    }
+
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+      mo?.disconnect();
+    };
+  }, [ready, dimsReady, src, setDimensions, lynxViewRef]);
+
+  return { ready, dimsReady, rendered, error };
+}
+
+export const WebIframe = ({ show, src }: WebIframeProps) => {
+  const lynxViewRef = useRef<LynxView>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { ready, rendered, error } = useWebIframeController({
+    src,
+    lynxViewRef,
+    containerRef,
+  });
 
   // Only show loading state when the view is actually visible
   const loading = show && (!ready || !rendered || !!error);
@@ -379,14 +323,16 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       <div style={show ? INNER_VISIBLE : INNER_HIDDEN}>
         <LoadingOverlay visible={loading} error={error} />
         {src && (
-          <lynx-view
-            key={src}
-            ref={lynxViewRef}
-            style={LYNX_VIEW_STYLE}
-            lynx-group-id={LYNX_GROUP_ID}
-            transform-vh={true}
-            transform-vw={true}
-          />
+          <div style={STAGE}>
+            <lynx-view
+              key={src}
+              ref={lynxViewRef}
+              style={LYNX_VIEW_STYLE}
+              lynx-group-id={LYNX_GROUP_ID}
+              transform-vh={true}
+              transform-vw={true}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/src/example-preview/hooks/use-container-resize.ts
+++ b/src/example-preview/hooks/use-container-resize.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+
+import { useEffectEvent } from './use-effect-event';
+
+type Size = {
+  width?: number;
+  height?: number;
+};
+
+type ResizeObserverCtor = new (
+  callback: ResizeObserverCallback,
+) => ResizeObserver;
+
+type UseContainerResizeOptions<T> = {
+  ref: MutableRefObject<T | null>;
+  ResizeObserverImpl?: ResizeObserverCtor;
+  onResize?: (size: Size) => void;
+};
+
+function useContainerResize<T extends HTMLElement = HTMLElement>({
+  ref,
+  ResizeObserverImpl,
+  onResize: onResizeProp,
+}: UseContainerResizeOptions<T>): Size {
+  const [size, setSize] = useState<Size>({});
+  const prev = useRef<Size>({});
+  const onResize = useEffectEvent(onResizeProp);
+  const hasOnResize = onResizeProp !== undefined;
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const RO: ResizeObserverCtor | undefined =
+      ResizeObserverImpl ??
+      (typeof window !== 'undefined' && 'ResizeObserver' in window
+        ? window.ResizeObserver
+        : undefined);
+
+    if (!RO) return;
+
+    const observer: ResizeObserver = new RO((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      let width = 0;
+      let height = 0;
+
+      const cbsUnknown = entry.contentBoxSize as unknown;
+
+      if (Array.isArray(cbsUnknown)) {
+        const first = entry.contentBoxSize[0];
+        if (first) {
+          width = first.inlineSize;
+          height = first.blockSize;
+        }
+      } else if (isContentBoxSizeSingleItem(cbsUnknown)) {
+        width = cbsUnknown.inlineSize;
+        height = cbsUnknown.blockSize;
+      } else {
+        width = entry.contentRect.width;
+        height = entry.contentRect.height;
+      }
+
+      const changed =
+        width !== prev.current.width || height !== prev.current.height;
+
+      if (!changed) return;
+
+      const next: Size = { width, height };
+      prev.current = next;
+      if (hasOnResize) {
+        onResize(next);
+      } else if (ref.current) {
+        setSize(next);
+      }
+    });
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, ResizeObserverImpl, hasOnResize]);
+
+  return size;
+}
+
+export { useContainerResize };
+
+function isContentBoxSizeSingleItem(
+  v: unknown,
+): v is { inlineSize: number; blockSize: number } {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as { inlineSize?: unknown }).inlineSize === 'number' &&
+    typeof (v as { blockSize?: unknown }).blockSize === 'number'
+  );
+}

--- a/src/example-preview/hooks/use-effect-event.ts
+++ b/src/example-preview/hooks/use-effect-event.ts
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+function useEffectEvent<TArgs extends unknown[]>(
+  fn: ((...args: TArgs) => void) | undefined,
+): (...args: TArgs) => void;
+
+function useEffectEvent<TArgs extends unknown[], TResult>(
+  fn: ((...args: TArgs) => TResult) | undefined,
+  options: { fallbackResult: TResult },
+): (...args: TArgs) => TResult;
+
+function useEffectEvent<TArgs extends unknown[], TResult>(
+  fn: ((...args: TArgs) => TResult) | undefined,
+  options?: { fallbackResult: TResult },
+): (...args: TArgs) => TResult {
+  const ref = useRef(fn);
+
+  useEffect(() => {
+    ref.current = fn;
+  }, [fn]);
+
+  return useMemo(() => {
+    const proxy = (...args: TArgs) => {
+      const f = ref.current;
+      if (f) {
+        return f(...args);
+      }
+      if (options) {
+        return options.fallbackResult;
+      }
+      return undefined as unknown as TResult;
+    };
+    return proxy;
+  }, [options]);
+}
+
+export { useEffectEvent };

--- a/src/example-preview/hooks/use-is-client.ts
+++ b/src/example-preview/hooks/use-is-client.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from 'react';
+
+function subscribe(): () => void {
+  return () => {
+    /* no-op */
+  };
+}
+
+function getClientSnapshot(): boolean {
+  return true;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useIsClient(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+}

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -7,6 +7,7 @@ import { useGoConfig } from '../config';
 import { ExampleContent } from './components';
 import type { SchemaOptionsData } from './hooks/use-switch-schema';
 import { isAssetFileType } from './utils/example-data';
+import type { WebPreviewMode } from './utils/resolve-web-preview';
 
 const DefaultErrorWrap = ({
   example,
@@ -53,6 +54,11 @@ export interface ExamplePreviewProps {
   schemaOptions?: SchemaOptionsData;
   langAlias?: Record<string, string>;
   mode?: ExamplePreviewMode;
+  webPreviewMode?: WebPreviewMode;
+  designWidth?: number;
+  designHeight?: number;
+  fitThresholdScale?: number;
+  fitMinScale?: number;
   /**
    * Override the default preview tab for this instance.
    * Takes precedence over the site-level `GoConfig.defaultTab`.
@@ -104,6 +110,11 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     langAlias,
     defaultTab: propsDefaultTab,
     mode = 'linked',
+    webPreviewMode = 'auto',
+    designWidth = 375,
+    designHeight = 812,
+    fitThresholdScale = 1.5,
+    fitMinScale = 0.6,
   } = props;
 
   // Instance prop > config provider > undefined (let ExampleContent decide)
@@ -255,6 +266,11 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       exampleGitBaseUrl={exampleData?.exampleGitBaseUrl}
       defaultTab={defaultTab}
       mode={mode}
+      webPreviewMode={webPreviewMode}
+      designWidth={designWidth}
+      designHeight={designHeight}
+      fitThresholdScale={fitThresholdScale}
+      fitMinScale={fitMinScale}
     />
   );
 };

--- a/src/example-preview/utils/fit-scale.ts
+++ b/src/example-preview/utils/fit-scale.ts
@@ -1,0 +1,100 @@
+/**
+ * Dimensions of the container and the base frame.
+ */
+export type FitInput = {
+  /** Container width in pixels */
+  containerWidth: number;
+  /** Container height in pixels */
+  containerHeight: number;
+  /** Base frame width in pixels */
+  baseWidth: number;
+  /** Base frame height in pixels */
+  baseHeight: number;
+};
+
+/**
+ * Contain and cover scale factors for a base frame fitted into a container.
+ * The two values bracket the valid scale range.
+ *
+ * - `contain`: the base frame is fully visible inside the container
+ * - `cover`: the container is fully filled, base frame may be cropped
+ */
+export type ScaleRange = {
+  contain: number;
+  cover: number;
+};
+
+/**
+ * Pre-computed alignment factors along each axis.
+ * Each value is in [0, 1]: 0 = start, 0.5 = center, 1 = end.
+ */
+export type AlignFactors = {
+  ax: number;
+  ay: number;
+};
+
+/**
+ * Input for computing the frame's transform offset.
+ */
+export type FrameOffsetInput = {
+  baseWidth: number;
+  baseHeight: number;
+  scale: number;
+} & AlignFactors;
+
+/**
+ * 2D translation offset for a frame transform.
+ */
+export type FrameOffset = {
+  offsetX: number;
+  offsetY: number;
+};
+
+/**
+ * Compute the contain and cover scale factors for a base frame
+ * fitted into a container.
+ */
+export function computeScaleRange(input: FitInput): ScaleRange {
+  const { containerWidth, containerHeight, baseWidth, baseHeight } = input;
+  if (
+    !Number.isFinite(baseWidth) ||
+    baseWidth <= 0 ||
+    !Number.isFinite(baseHeight) ||
+    baseHeight <= 0
+  ) {
+    throw new RangeError(
+      `computeScaleRange: baseWidth and baseHeight must be finite and > 0, got ${baseWidth}x${baseHeight}`,
+    );
+  }
+  const ratioW = containerWidth / baseWidth;
+  const ratioH = containerHeight / baseHeight;
+  return {
+    contain: Math.min(ratioW, ratioH),
+    cover: Math.max(ratioW, ratioH),
+  };
+}
+
+/**
+ * Interpolate between contain and cover scale using a 0–1 progress value.
+ *
+ * - `t = 0`: behaves like contain
+ * - `t = 1`: behaves like cover
+ */
+export function lerpFitScale(
+  { contain, cover }: ScaleRange,
+  t: number,
+): number {
+  return contain + (cover - contain) * t;
+}
+
+/**
+ * Compute the transform offset for a scaled frame,
+ * given pre-computed scale and alignment factors.
+ */
+export function computeFrameOffset(input: FrameOffsetInput): FrameOffset {
+  const { baseWidth, baseHeight, scale, ax, ay } = input;
+  return {
+    offsetX: -(baseWidth * scale) * ax,
+    offsetY: -(baseHeight * scale) * ay,
+  };
+}

--- a/src/example-preview/utils/resolve-web-preview.ts
+++ b/src/example-preview/utils/resolve-web-preview.ts
@@ -1,0 +1,33 @@
+export type WebPreviewMode = 'fit' | 'responsive' | 'auto';
+export type ResolvedWebPreviewMode = Exclude<WebPreviewMode, 'auto'>;
+
+export type ResolveWebPreviewModeArgs = {
+  webPreviewMode: WebPreviewMode;
+  designWidth: number;
+  designHeight: number;
+  fitThresholdScale: number;
+  fitMinScale: number;
+  containerWidth: number;
+  containerHeight: number;
+};
+
+export function resolveWebPreviewMode({
+  webPreviewMode,
+  designWidth,
+  designHeight,
+  fitThresholdScale,
+  fitMinScale,
+  containerWidth,
+  containerHeight,
+}: ResolveWebPreviewModeArgs): ResolvedWebPreviewMode {
+  if (webPreviewMode === 'fit') return 'fit';
+  if (webPreviewMode === 'responsive') return 'responsive';
+
+  if (containerWidth <= 0 || containerHeight <= 0) return 'responsive';
+
+  const shouldUseFit =
+    containerWidth < designWidth * fitThresholdScale ||
+    containerHeight < designHeight * fitMinScale;
+
+  return shouldUseFit ? 'fit' : 'responsive';
+}


### PR DESCRIPTION
## What

Add viewport mode props to `ExamplePreview` and plumb them through `ExampleContent` → `WebIframe`:

- `webPreviewMode` (default: `'auto'`)
- `designWidth` / `designHeight`
- `fitThresholdScale` / `fitMinScale`

Implement fit rendering strategy for `lynx-view`:

- Fixed design canvas size with CSS `transform: translate + scale` to fit into container
- Fixed CSS vars for `rpx/vh/vw` units in fit mode

Implement auto mode selection and switching behavior:

- `fit → fit`: smooth `transform` transition on container resize
- `fit ↔ responsive`: hard cut, transition disabled on mode change

## Related

- Closes #42
