### PR TITLE
feat(go): add `webPreview` prop to disable web tab

### DIFF
--- a/.changeset/pretty-dogs-join.md
+++ b/.changeset/pretty-dogs-join.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': minor
+---
+
+Add `webPreview` prop to disable the Web preview tab.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Web preview bundle resolution is driven by `example-metadata.json` (`templateFil
 
 | Option              | Type                              | Default  | Description                                                                      |
 | ------------------- | --------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `webPreview`        | `boolean`                         | `true`   | Enable/disable the web preview tab even if `templateFiles[].webFile` exists      |
 | `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'auto'` | Viewport rendering mode                                                          |
 | `designWidth`       | `number`                          | `375`    | Design canvas width in pixels. Used in `fit` mode.                               |
 | `designHeight`      | `number`                          | `812`    | Design canvas height in pixels. Used in `fit` mode.                              |

--- a/example/src/embed-entry.tsx
+++ b/example/src/embed-entry.tsx
@@ -4,7 +4,7 @@
  * Listens for postMessage from the parent to receive example configuration,
  * then renders a Go component with GoConfigProvider.
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@douyinfe/semi-ui/dist/css/semi.min.css';
 import { GoConfigProvider, Go } from '../../src/index';
@@ -108,6 +108,7 @@ type EmbedOptions = {
   entry?: string | string[];
   seamless?: boolean;
   exampleBasePath?: string;
+  webPreview?: boolean;
   webPreviewMode?: 'fit' | 'responsive' | 'auto';
   designWidth?: number;
   designHeight?: number;
@@ -183,6 +184,7 @@ function EmbedApp() {
           defaultEntryName={options.defaultEntryName}
           highlight={options.highlight}
           entry={options.entry}
+          webPreview={options.webPreview}
           webPreviewMode={options.webPreviewMode}
           designWidth={options.designWidth}
           designHeight={options.designHeight}

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -39,6 +39,8 @@ export type EmbedOptions = {
   entry?: string | string[];
   /** Hide the header bar for minimal embeds */
   seamless?: boolean;
+  /** Enable/disable the web preview tab even if templateFiles[].webFile exists */
+  webPreview?: boolean;
   /** Web preview viewport mode */
   webPreviewMode?: 'fit' | 'responsive' | 'auto';
   /** Design canvas width for fit mode */

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -55,6 +55,7 @@ export interface ExamplePreviewProps {
   langAlias?: Record<string, string>;
   mode?: ExamplePreviewMode;
   webPreviewMode?: WebPreviewMode;
+  webPreview?: boolean;
   designWidth?: number;
   designHeight?: number;
   fitThresholdScale?: number;
@@ -111,6 +112,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     defaultTab: propsDefaultTab,
     mode = 'linked',
     webPreviewMode = 'auto',
+    webPreview = true,
     designWidth = 375,
     designHeight = 812,
     fitThresholdScale = 1.0,
@@ -119,6 +121,8 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
 
   // Instance prop > config provider > undefined (let ExampleContent decide)
   const defaultTab = propsDefaultTab ?? configDefaultTab;
+  const resolvedDefaultTab =
+    webPreview === false && defaultTab === 'web' ? undefined : defaultTab;
 
   const [currentName, setCurrentName] = useState(defaultFile);
   const [currentFile, setCurrentFile] = useState('');
@@ -218,9 +222,11 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
         tmpEntry = exampleData?.templateFiles[0];
       }
       if (tmpEntry) {
-        if (tmpEntry.webFile) {
+        if (tmpEntry.webFile && webPreview !== false) {
           const fullWebFile = `${window.location.origin}${EXAMPLE_BASE_URL}/${example}/${tmpEntry.webFile}`;
           setDefaultWebPreviewFile(fullWebFile);
+        } else {
+          setDefaultWebPreviewFile('');
         }
         setCurrentEntry(tmpEntry.name);
       } else {
@@ -230,7 +236,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       }
       setInitState(true);
     }
-  }, [exampleData, defaultEntryFile, defaultEntryName]);
+  }, [exampleData, defaultEntryFile, defaultEntryName, webPreview]);
 
   if (error) {
     const ErrorComp = ErrorComponent || DefaultErrorWrap;
@@ -264,7 +270,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       rightFooter={rightFooter}
       schemaOptions={schema ? undefined : schemaOptions}
       exampleGitBaseUrl={exampleData?.exampleGitBaseUrl}
-      defaultTab={defaultTab}
+      defaultTab={resolvedDefaultTab}
       mode={mode}
       webPreviewMode={webPreviewMode}
       designWidth={designWidth}


### PR DESCRIPTION
Add an optional `webPreview?: boolean` prop (default: true) to allow hiding the Web preview tab even when `templateFiles[].webFile` is present. When `webPreview` is false and `defaultTab` is `web`, the default tab falls back to automatic selection.

Also mirror the option in the iframe embed API types and forward it in the embed entry, and document it in README.