### PR TITLE
feat: smooth WebIframe auto fit and mode transitions

### DIFF
--- a/.changeset/metal-breads-check.md
+++ b/.changeset/metal-breads-check.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': minor
+---
+
+Improve web preview fit behavior and default `webPreviewMode` to `responsive`.

--- a/README.md
+++ b/README.md
@@ -102,17 +102,19 @@ For non-React sites (Hugo, Jekyll, plain HTML, etc.), use the iframe embed API. 
 
 Options:
 
-| Option             | Type                               | Description                                                                                                                                                                                                   |
-| ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `example`          | `string`                           | **Required.** Example folder name, e.g. `'hello-world'`                                                                                                                                                       |
-| `defaultFile`      | `string`                           | Initial file to display (default: `'src/App.tsx'`)                                                                                                                                                            |
-| `defaultTab`       | `'preview' \| 'web' \| 'qrcode'`   | Default preview tab                                                                                                                                                                                           |
-| `exampleBasePath`  | `string`                           | Base path or full URL for example data, e.g. `'/lynx-examples'`                                                                                                                                               |
-| `img`              | `string`                           | Static preview image URL                                                                                                                                                                                      |
-| `defaultEntryFile` | `string`                           | Default entry bundle file path (relative to the example folder), e.g. `'dist/main.lynx.bundle'`. Must match `example-metadata.json` (`templateFiles[].file`). Prefix match is supported (e.g. `'dist/main'`). |
-| `defaultEntryName` | `string`                           | Default entry name (from `templateFiles[].name`), e.g. `'main'`. Convenience alternative to `defaultEntryFile` and only used when `defaultEntryFile` is not provided.                                         |
-| `highlight`        | `string \| Record<string, string>` | Line highlight spec, e.g. `'{1,3-5}'`. When passing a map, the key is the file path and the value is that file’s highlight spec.                                                                              |
-| `entry`            | `string \| string[]`               | Filter entry files in tree, useful for example with multiple entries, e.g. `'src/basic'`                                                                                                                      |
+| Option             | Type                                | Description                                                                                                                                                                                                   |
+| ------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `example`          | `string`                            | **Required.** Example folder name, e.g. `'hello-world'`                                                                                                                                                       |
+| `defaultFile`      | `string`                            | Initial file to display (default: `'src/App.tsx'`)                                                                                                                                                            |
+| `mode`             | `'linked' \| 'preview' \| 'source'` | Overall layout mode (default: `'linked'`). `'linked'` shows code + preview together; `'preview'` shows preview only; `'source'` shows code only.                                                              |
+| `defaultTab`       | `'preview' \| 'web' \| 'qrcode'`    | Default preview tab                                                                                                                                                                                           |
+| `exampleBasePath`  | `string`                            | Base path or full URL for example data, e.g. `'/lynx-examples'`                                                                                                                                               |
+| `img`              | `string`                            | Static preview image URL                                                                                                                                                                                      |
+| `defaultEntryFile` | `string`                            | Default entry bundle file path (relative to the example folder), e.g. `'dist/main.lynx.bundle'`. Must match `example-metadata.json` (`templateFiles[].file`). Prefix match is supported (e.g. `'dist/main'`). |
+| `defaultEntryName` | `string`                            | Default entry name (from `templateFiles[].name`), e.g. `'main'`. Convenience alternative to `defaultEntryFile` and only used when `defaultEntryFile` is not provided.                                         |
+| `highlight`        | `string \| Record<string, string>`  | Line highlight spec, e.g. `'{1,3-5}'`. When passing a map, the key is the file path and the value is that file’s highlight spec.                                                                              |
+| `entry`            | `string \| string[]`                | Filter entry files in tree, useful for example with multiple entries, e.g. `'src/basic'`                                                                                                                      |
+| `schema`           | `string`                            | URL schema template for Lynx Explorer QR code. Use `{{{url}}}` as placeholder for the resolved entry URL, e.g. `{{{url}}}?bar_color=000000&back_button_style=dark`                                            |
 
 #### Viewport Mode (Web Preview)
 
@@ -120,14 +122,15 @@ These options control how `lynx-view` renders inside the web preview panel.
 
 Web preview bundle resolution is driven by `example-metadata.json` (`templateFiles[].webFile`) for the selected entry; it is not inferred from the Lynx bundle filename automatically.
 
-| Option              | Type                              | Default  | Description                                                                      |
-| ------------------- | --------------------------------- | -------- | -------------------------------------------------------------------------------- |
-| `webPreview`        | `boolean`                         | `true`   | Enable/disable the web preview tab even if `templateFiles[].webFile` exists      |
-| `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'auto'` | Viewport rendering mode                                                          |
-| `designWidth`       | `number`                          | `375`    | Design canvas width in pixels. Used in `fit` mode.                               |
-| `designHeight`      | `number`                          | `812`    | Design canvas height in pixels. Used in `fit` mode.                              |
-| `fitThresholdScale` | `number`                          | `1.0`    | Width upper bound for `auto` mode. Switches to `responsive` when wide enough     |
-| `fitMinScale`       | `number`                          | `0.6`    | Height lower bound for `auto` mode. Forces `fit` when the container is too short |
+| Option              | Type                              | Default   | Description                                                                        |
+| ------------------- | --------------------------------- | --------- | ---------------------------------------------------------------------------------- |
+| `webPreview`        | `boolean`                         | `true`    | Enable/disable the web preview tab even if `templateFiles[].webFile` exists        |
+| `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'auto'`  | Viewport rendering mode                                                            |
+| `designWidth`       | `number`                          | `375`     | Design canvas width in pixels. Used in `fit` mode.                                 |
+| `designHeight`      | `number`                          | `812`     | Design canvas height in pixels. Used in `fit` mode.                                |
+| `fitThresholdScale` | `number`                          | `1.0`     | Width upper bound for `auto` mode. Switches to `responsive` when wide enough       |
+| `fitMinScale`       | `number`                          | `0.5`     | Height lower bound for `auto` mode. Forces `fit` when the container is too short   |
+| `fit`               | `'contain' \| 'cover' \| 'auto'`  | `'cover'` | Fit strategy inside `fit` mode. `auto` uses built-in heuristics (not configurable) |
 
 Mode behavior:
 

--- a/README.md
+++ b/README.md
@@ -122,23 +122,23 @@ These options control how `lynx-view` renders inside the web preview panel.
 
 Web preview bundle resolution is driven by `example-metadata.json` (`templateFiles[].webFile`) for the selected entry; it is not inferred from the Lynx bundle filename automatically.
 
-| Option              | Type                              | Default        | Description                                                                        |
-| ------------------- | --------------------------------- | -------------- | ---------------------------------------------------------------------------------- |
-| `webPreview`        | `boolean`                         | `true`         | Enable/disable the web preview tab even if `templateFiles[].webFile` exists        |
-| `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'responsive'` | Viewport rendering mode                                                            |
-| `designWidth`       | `number`                          | `375`          | Design canvas width in pixels. Used in `fit` mode.                                 |
-| `designHeight`      | `number`                          | `812`          | Design canvas height in pixels. Used in `fit` mode.                                |
-| `fitThresholdScale` | `number`                          | `1.0`          | Width upper bound for `auto` mode. Switches to `responsive` when wide enough       |
-| `fitMinScale`       | `number`                          | `0.5`          | Height lower bound for `auto` mode. Forces `fit` when the container is too short   |
-| `fit`               | `'contain' \| 'cover' \| 'auto'`  | `'cover'`      | Fit strategy inside `fit` mode. `auto` uses built-in heuristics (not configurable) |
+| Option              | Type                              | Default        | Description                                                                                                     |
+| ------------------- | --------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------- |
+| `webPreview`        | `boolean`                         | `true`         | Enable/disable the web preview tab even if `templateFiles[].webFile` exists                                     |
+| `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'responsive'` | Viewport rendering mode                                                                                         |
+| `designWidth`       | `number`                          | `375`          | Design canvas width in pixels. Used in `fit` mode.                                                              |
+| `designHeight`      | `number`                          | `812`          | Design canvas height in pixels. Used in `fit` mode.                                                             |
+| `fitThresholdScale` | `number`                          | `1.0`          | Width enter threshold for `webPreviewMode='auto'`. Exit back to `responsive` uses a built-in hysteresis band.   |
+| `fitMinScale`       | `number`                          | `0.5`          | Height enter threshold for `webPreviewMode='auto'`. Exit back to `responsive` uses a built-in hysteresis band.  |
+| `fit`               | `'contain' \| 'cover' \| 'auto'`  | `'cover'`      | Fit strategy inside the fit path. `auto` uses built-in heuristics, including hysteresis-aware mode transitions. |
 
 Mode behavior:
 
-| Mode           | Behavior                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `'responsive'` | `lynx-view` fills the container. `browserConfig` uses measured container dimensions.                                                             |
-| `'fit'`        | `lynx-view` is fixed at `designWidth × designHeight`. CSS `transform: scale` fits it into the container. `browserConfig` uses design dimensions. |
-| `'auto'`       | Switches based on container size. Behaves like `fit` for small/narrow containers, `responsive` for wide ones.                                    |
+| Mode           | Behavior                                                                                                                                                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'responsive'` | `lynx-view` fills the container. `browserConfig` uses measured container dimensions.                                                                                       |
+| `'fit'`        | `lynx-view` is fixed at `designWidth × designHeight`. CSS `transform: scale` fits it into the container. `browserConfig` uses design dimensions.                           |
+| `'auto'`       | Switches based on container size. Behaves like `fit` for small/narrow containers and `responsive` for wide ones, with a built-in hysteresis band to reduce resize flicker. |
 
 Auto switching logic:
 
@@ -146,11 +146,14 @@ Auto switching logic:
 const ratioW = containerWidth / designWidth;
 const ratioH = containerHeight / designHeight;
 
-// Equivalent to:
+// Enter condition only:
 // - containerWidth < designWidth * fitThresholdScale
 // - containerHeight < designHeight * fitMinScale
 const shouldUseFit = ratioW < fitThresholdScale || ratioH < fitMinScale;
 ```
+
+Exit back to `responsive` uses slightly larger internal thresholds, so `auto`
+does not switch back and forth on every tiny resize near the boundary.
 
 Transition behavior:
 

--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ These options control how `lynx-view` renders inside the web preview panel.
 
 Web preview bundle resolution is driven by `example-metadata.json` (`templateFiles[].webFile`) for the selected entry; it is not inferred from the Lynx bundle filename automatically.
 
-| Option              | Type                              | Default   | Description                                                                        |
-| ------------------- | --------------------------------- | --------- | ---------------------------------------------------------------------------------- |
-| `webPreview`        | `boolean`                         | `true`    | Enable/disable the web preview tab even if `templateFiles[].webFile` exists        |
-| `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'auto'`  | Viewport rendering mode                                                            |
-| `designWidth`       | `number`                          | `375`     | Design canvas width in pixels. Used in `fit` mode.                                 |
-| `designHeight`      | `number`                          | `812`     | Design canvas height in pixels. Used in `fit` mode.                                |
-| `fitThresholdScale` | `number`                          | `1.0`     | Width upper bound for `auto` mode. Switches to `responsive` when wide enough       |
-| `fitMinScale`       | `number`                          | `0.5`     | Height lower bound for `auto` mode. Forces `fit` when the container is too short   |
-| `fit`               | `'contain' \| 'cover' \| 'auto'`  | `'cover'` | Fit strategy inside `fit` mode. `auto` uses built-in heuristics (not configurable) |
+| Option              | Type                              | Default        | Description                                                                        |
+| ------------------- | --------------------------------- | -------------- | ---------------------------------------------------------------------------------- |
+| `webPreview`        | `boolean`                         | `true`         | Enable/disable the web preview tab even if `templateFiles[].webFile` exists        |
+| `webPreviewMode`    | `'fit' \| 'responsive' \| 'auto'` | `'responsive'` | Viewport rendering mode                                                            |
+| `designWidth`       | `number`                          | `375`          | Design canvas width in pixels. Used in `fit` mode.                                 |
+| `designHeight`      | `number`                          | `812`          | Design canvas height in pixels. Used in `fit` mode.                                |
+| `fitThresholdScale` | `number`                          | `1.0`          | Width upper bound for `auto` mode. Switches to `responsive` when wide enough       |
+| `fitMinScale`       | `number`                          | `0.5`          | Height lower bound for `auto` mode. Forces `fit` when the container is too short   |
+| `fit`               | `'contain' \| 'cover' \| 'auto'`  | `'cover'`      | Fit strategy inside `fit` mode. `auto` uses built-in heuristics (not configurable) |
 
 Mode behavior:
 

--- a/example/src/embed-entry.tsx
+++ b/example/src/embed-entry.tsx
@@ -100,12 +100,14 @@ const StandaloneCodeBlock = ({
 type EmbedOptions = {
   example: string;
   defaultFile?: string;
+  mode?: 'linked' | 'preview' | 'source';
   defaultTab?: 'preview' | 'web' | 'qrcode';
   img?: string;
   defaultEntryFile?: string;
   defaultEntryName?: string;
   highlight?: string | Record<string, string>;
   entry?: string | string[];
+  schema?: string;
   seamless?: boolean;
   exampleBasePath?: string;
   webPreview?: boolean;
@@ -114,6 +116,7 @@ type EmbedOptions = {
   designHeight?: number;
   fitThresholdScale?: number;
   fitMinScale?: number;
+  fit?: 'contain' | 'cover' | 'auto';
 };
 
 // ---------------------------------------------------------------------------
@@ -178,18 +181,21 @@ function EmbedApp() {
             options.defaultFile ??
             (options.example.startsWith('vue-') ? 'src/App.vue' : 'src/App.tsx')
           }
+          mode={options.mode}
           defaultTab={options.defaultTab}
           img={options.img}
           defaultEntryFile={options.defaultEntryFile}
           defaultEntryName={options.defaultEntryName}
           highlight={options.highlight}
           entry={options.entry}
+          schema={options.schema}
           webPreview={options.webPreview}
           webPreviewMode={options.webPreviewMode}
           designWidth={options.designWidth}
           designHeight={options.designHeight}
           fitThresholdScale={options.fitThresholdScale}
           fitMinScale={options.fitMinScale}
+          fit={options.fit}
         />
       </div>
     </GoConfigProvider>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1297,7 +1297,7 @@ function App() {
                     mode={mode}
                   />
                 </div>
-                <div className="figure-caption">Mobile (320 × 660)</div>
+                <div className="figure-caption">Mobile (320 x 660)</div>
               </div>
             </div>
           </GoConfigProvider>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1264,6 +1264,9 @@ function App() {
                   img={img || undefined}
                   schema={schema || undefined}
                   mode={mode}
+                  webPreviewMode={
+                    example.startsWith('lynx-ui') ? 'auto' : 'responsive'
+                  }
                 />
                 <div className="figure-caption">Desktop</div>
               </div>
@@ -1295,6 +1298,9 @@ function App() {
                     img={img || undefined}
                     schema={schema || undefined}
                     mode={mode}
+                    webPreviewMode={
+                      example.startsWith('lynx-ui') ? 'auto' : 'responsive'
+                    }
                   />
                 </div>
                 <div className="figure-caption">Mobile (320 x 660)</div>

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -22,6 +22,8 @@ export type EmbedOptions = {
   example: string;
   /** Initial file to display */
   defaultFile?: string;
+  /** Overall layout mode */
+  mode?: 'linked' | 'preview' | 'source';
   /** Default preview tab */
   defaultTab?: 'preview' | 'web' | 'qrcode';
   /** Static preview image URL */
@@ -37,6 +39,11 @@ export type EmbedOptions = {
   highlight?: string | Record<string, string>;
   /** Filter entry files in tree */
   entry?: string | string[];
+  /**
+   * URL schema template for Lynx Explorer QR code generation.
+   * Use `{{{url}}}` as a placeholder for the resolved entry URL.
+   */
+  schema?: string;
   /** Hide the header bar for minimal embeds */
   seamless?: boolean;
   /** Enable/disable the web preview tab even if templateFiles[].webFile exists */
@@ -51,6 +58,7 @@ export type EmbedOptions = {
   fitThresholdScale?: number;
   /** Auto mode height lower-bound multiplier */
   fitMinScale?: number;
+  fit?: 'contain' | 'cover' | 'auto';
   /**
    * Base path (or full URL) for example assets.
    * Defaults to '/lynx-examples'. Use a full URL for cross-origin data,

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -82,6 +82,7 @@ interface ExampleContentProps {
   designHeight?: number;
   fitThresholdScale?: number;
   fitMinScale?: number;
+  fit?: 'contain' | 'cover' | 'auto';
 }
 
 export function ExampleContent({
@@ -111,7 +112,8 @@ export function ExampleContent({
   designWidth = 375,
   designHeight = 812,
   fitThresholdScale = 1.0,
-  fitMinScale = 0.6,
+  fitMinScale = 0.5,
+  fit = 'cover',
 }: ExampleContentProps) {
   const {
     explorerUrl,
@@ -437,6 +439,7 @@ export function ExampleContent({
                     designHeight={designHeight}
                     fitThresholdScale={fitThresholdScale}
                     fitMinScale={fitMinScale}
+                    fit={fit}
                   />
                 </Suspense>
               </NoSSRComponent>

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -108,7 +108,7 @@ export function ExampleContent({
   langAlias,
   defaultTab,
   mode = 'linked',
-  webPreviewMode = 'auto',
+  webPreviewMode = 'responsive',
   designWidth = 375,
   designHeight = 812,
   fitThresholdScale = 1.0,

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -8,8 +8,13 @@ import {
   computeScaleRange,
   lerpFitScale,
 } from '../utils/fit-scale';
-import { resolveWebPreviewMode } from '../utils/resolve-web-preview';
-import type { WebPreviewMode } from '../utils/resolve-web-preview';
+import { isFinitePositive } from '../utils/number';
+import { resolveWebPreviewModeWithHysteresis } from '../utils/resolve-web-preview';
+import type {
+  WebPreviewMode,
+  ResolvedWebPreviewMode,
+  WebPreviewResolveReason,
+} from '../utils/resolve-web-preview';
 import { LoadingOverlay } from './loading-overlay';
 
 declare global {
@@ -36,6 +41,7 @@ type WebIframeProps = {
   designHeight?: number;
   fitThresholdScale?: number;
   fitMinScale?: number;
+  fit?: 'contain' | 'cover' | 'auto';
 };
 
 type UseWebIframeControllerArgs = {
@@ -47,6 +53,7 @@ type UseWebIframeControllerArgs = {
    * Override the pixel dimensions written to `browserConfig`.
    * In `fit` mode this should be the design canvas size × pixelRatio,
    * not the container size. Omit to use the container size (responsive mode).
+   * Known limitation: `browserConfig` is only initialized once per `src`.
    */
   browserConfigSize?: { width: number; height: number };
 };
@@ -85,6 +92,7 @@ const INNER_VISIBLE: React.CSSProperties = {
   height: '100%',
   alignItems: 'center',
   justifyContent: 'center',
+  overflow: 'hidden',
 };
 
 const INNER_HIDDEN: React.CSSProperties = { display: 'none' };
@@ -312,18 +320,59 @@ function deriveFitStyles(
   containerHeight: number,
   designWidth: number,
   designHeight: number,
+  fit: 'contain' | 'cover' | 'auto',
+  autoCoverBias: number,
   enableTransition: boolean,
 ): {
   frame: React.CSSProperties;
   lynxView: React.CSSProperties & CSSVarProperties;
 } {
+  const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+
+  const FIT_AUTO_MAX_CROP_RATIO = 0.5;
+  const FIT_AUTO_COVER_BIAS_EXP = 2;
+  const FIT_AUTO_MIN_READABLE_WIDTH = Math.max(
+    200,
+    Math.round(designWidth * 0.64),
+  );
+  const FIT_AUTO_MIN_READABLE_HEIGHT = Math.max(
+    240,
+    Math.round(designHeight * 0.4),
+  );
+
   const scaleRange = computeScaleRange({
     containerWidth,
     containerHeight,
     baseWidth: designWidth,
     baseHeight: designHeight,
   });
-  const scale = lerpFitScale(scaleRange, 0); // always contain
+  let fitProgress: number;
+  if (fit === 'contain') {
+    fitProgress = 0;
+  } else if (fit === 'cover') {
+    fitProgress = 1;
+  } else {
+    const cropRatio = 1 - scaleRange.contain / scaleRange.cover;
+    const normalizedCrop = clamp01(cropRatio / FIT_AUTO_MAX_CROP_RATIO);
+    fitProgress = 1 - Math.pow(normalizedCrop, FIT_AUTO_COVER_BIAS_EXP);
+  }
+  if (fit === 'auto') {
+    const t = clamp01(autoCoverBias);
+    fitProgress = fitProgress + (1 - fitProgress) * t;
+  }
+  let scale = lerpFitScale(scaleRange, fitProgress);
+  if (fit === 'auto') {
+    const widthFloorScale = FIT_AUTO_MIN_READABLE_WIDTH / designWidth;
+    const heightFloorScale = FIT_AUTO_MIN_READABLE_HEIGHT / designHeight;
+    const autoScaleFloor = Math.max(widthFloorScale, heightFloorScale);
+    const shouldForceReadable =
+      containerWidth < FIT_AUTO_MIN_READABLE_WIDTH ||
+      containerHeight < FIT_AUTO_MIN_READABLE_HEIGHT;
+    if (shouldForceReadable && scale < autoScaleFloor) {
+      fitProgress = 1;
+      scale = Math.max(scaleRange.cover, autoScaleFloor);
+    }
+  }
   const { offsetX, offsetY } = computeFrameOffset({
     baseWidth: designWidth,
     baseHeight: designHeight,
@@ -354,6 +403,49 @@ function deriveFitStyles(
   };
 }
 
+function useAutoCoverBias(args: {
+  fit: 'contain' | 'cover' | 'auto';
+  webPreviewMode: WebPreviewMode;
+  mode: ResolvedWebPreviewMode;
+  prevMode: ResolvedWebPreviewMode;
+  reason: WebPreviewResolveReason;
+  inHysteresisHold: boolean;
+  hysteresisProgress: number;
+}): number {
+  type AutoFitKind = 'width' | 'height' | null;
+  const autoFitKindRef = useRef<AutoFitKind>(null);
+
+  const {
+    fit,
+    webPreviewMode,
+    mode,
+    prevMode,
+    reason,
+    inHysteresisHold,
+    hysteresisProgress,
+  } = args;
+
+  if (fit !== 'auto' || webPreviewMode !== 'auto') {
+    autoFitKindRef.current = null;
+  } else if (prevMode === 'fit' && mode === 'responsive') {
+    autoFitKindRef.current = null;
+  } else if (mode === 'fit') {
+    // Keep the previous bound only while we are inside the hysteresis band.
+    if (reason === 'width_bound') autoFitKindRef.current = 'width';
+    else if (reason === 'height_bound') autoFitKindRef.current = 'height';
+  }
+
+  if (mode !== 'fit' || webPreviewMode !== 'auto' || fit !== 'auto') return 0;
+
+  if (autoFitKindRef.current === 'width') return 1;
+
+  if (autoFitKindRef.current === 'height') {
+    return inHysteresisHold ? Math.pow(hysteresisProgress, 2) : 0;
+  }
+
+  return 0;
+}
+
 export const WebIframe = ({
   show,
   src,
@@ -361,7 +453,8 @@ export const WebIframe = ({
   designWidth = 375,
   designHeight = 812,
   fitThresholdScale = 1.0,
-  fitMinScale = 0.6,
+  fitMinScale = 0.5,
+  fit = 'cover',
 }: WebIframeProps) => {
   const lynxViewRef = useRef<LynxView>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -380,22 +473,25 @@ export const WebIframe = ({
 
   const dimsReady = containerWidth > 0 && containerHeight > 0;
 
-  const mode = resolveWebPreviewMode({
-    webPreviewMode,
-    designWidth,
-    designHeight,
-    fitThresholdScale,
-    fitMinScale,
-    containerWidth,
-    containerHeight,
-  });
+  const prevResolvedModeRef = useRef<ResolvedWebPreviewMode>('responsive');
+  const prevResolvedMode = prevResolvedModeRef.current;
+  const resolved = resolveWebPreviewModeWithHysteresis(
+    {
+      webPreviewMode,
+      designWidth,
+      designHeight,
+      fitThresholdScale,
+      fitMinScale,
+      containerWidth,
+      containerHeight,
+    },
+    prevResolvedMode,
+  );
+  const mode = resolved.mode;
 
   if (
     mode === 'fit' &&
-    (!Number.isFinite(designWidth) ||
-      designWidth <= 0 ||
-      !Number.isFinite(designHeight) ||
-      designHeight <= 0)
+    (!isFinitePositive(designWidth) || !isFinitePositive(designHeight))
   ) {
     throw new RangeError(
       'WebIframe: designWidth and designHeight must be finite numbers > 0 when webPreviewMode resolves to "fit".',
@@ -405,10 +501,9 @@ export const WebIframe = ({
   const browserConfigSize =
     mode === 'fit' ? { width: designWidth, height: designHeight } : undefined;
 
-  const prevModeRef = useRef(mode);
-  const enableFitTransition = prevModeRef.current === 'fit' && mode === 'fit';
+  const enableFitTransition = prevResolvedMode === 'fit' && mode === 'fit';
   useEffect(() => {
-    prevModeRef.current = mode;
+    prevResolvedModeRef.current = mode;
   }, [mode]);
 
   const { ready, rendered, error } = useWebIframeController({
@@ -419,6 +514,16 @@ export const WebIframe = ({
     browserConfigSize,
   });
 
+  const autoCoverBias = useAutoCoverBias({
+    fit,
+    webPreviewMode,
+    mode,
+    prevMode: prevResolvedMode,
+    reason: resolved.reason,
+    inHysteresisHold: resolved.inHysteresisHold,
+    hysteresisProgress: resolved.hysteresisProgress,
+  });
+
   const fitStyles =
     mode === 'fit'
       ? deriveFitStyles(
@@ -426,6 +531,8 @@ export const WebIframe = ({
           containerHeight,
           designWidth,
           designHeight,
+          fit,
+          autoCoverBias,
           enableFitTransition,
         )
       : null;

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -11,9 +11,9 @@ import {
 import { isFinitePositive } from '../utils/number';
 import { resolveWebPreviewModeWithHysteresis } from '../utils/resolve-web-preview';
 import type {
+  ResolvedWebPreviewFitKind,
   WebPreviewMode,
   ResolvedWebPreviewMode,
-  WebPreviewResolveReason,
 } from '../utils/resolve-web-preview';
 import { LoadingOverlay } from './loading-overlay';
 
@@ -32,6 +32,11 @@ type LynxViewAttributes = React.HTMLAttributes<HTMLElement> & {
 };
 
 type CSSVarProperties = { [key: `--${string}`]: string | number };
+
+type AutoFitBiases = {
+  interiorContainPull: number;
+  interiorCoverPush: number;
+};
 
 type WebIframeProps = {
   show: boolean;
@@ -118,6 +123,10 @@ const FRAME_RESPONSIVE: React.CSSProperties = {
 };
 
 const LYNX_GROUP_ID = 42;
+const EMPTY_AUTO_FIT_BIASES: AutoFitBiases = {
+  interiorContainPull: 0,
+  interiorCoverPush: 0,
+};
 
 let runtimeReady: Promise<void> | null = null;
 function ensureRuntime() {
@@ -321,7 +330,7 @@ function deriveFitStyles(
   designWidth: number,
   designHeight: number,
   fit: 'contain' | 'cover' | 'auto',
-  autoCoverBias: number,
+  autoFitBiases: AutoFitBiases,
   enableTransition: boolean,
 ): {
   frame: React.CSSProperties;
@@ -350,12 +359,12 @@ function deriveFitStyles(
   const FIT_AUTO_MAX_CROP_RATIO = 0.5;
   const FIT_AUTO_COVER_BIAS_EXP = 2;
   const FIT_AUTO_MIN_READABLE_WIDTH = Math.max(
-    200,
-    Math.round(designWidth * 0.64),
+    180,
+    Math.round(designWidth * 0.58),
   );
   const FIT_AUTO_MIN_READABLE_HEIGHT = Math.max(
-    240,
-    Math.round(designHeight * 0.4),
+    220,
+    Math.round(designHeight * 0.36),
   );
 
   if (!isFinitePositive(containerWidth) || !isFinitePositive(containerHeight)) {
@@ -382,11 +391,12 @@ function deriveFitStyles(
   } else {
     const cropRatio = 1 - scaleRange.contain / scaleRange.cover;
     const normalizedCrop = clamp01(cropRatio / FIT_AUTO_MAX_CROP_RATIO);
-    fitProgress = 1 - Math.pow(normalizedCrop, FIT_AUTO_COVER_BIAS_EXP);
-  }
-  if (fit === 'auto') {
-    const t = clamp01(autoCoverBias);
-    fitProgress = fitProgress + (1 - fitProgress) * t;
+    const baseProgress = 1 - Math.pow(normalizedCrop, FIT_AUTO_COVER_BIAS_EXP);
+    const interiorContainPull = clamp01(autoFitBiases.interiorContainPull);
+    const interiorCoverPush = clamp01(autoFitBiases.interiorCoverPush);
+
+    fitProgress = baseProgress * (1 - interiorContainPull);
+    fitProgress = fitProgress + (1 - fitProgress) * interiorCoverPush;
   }
   let scale = lerpFitScale(scaleRange, fitProgress);
   if (fit === 'auto') {
@@ -411,47 +421,88 @@ function deriveFitStyles(
   return createStyles(scale, offsetX, offsetY);
 }
 
-function useAutoCoverBias(args: {
+function useAutoFitBiases(args: {
   fit: 'contain' | 'cover' | 'auto';
   webPreviewMode: WebPreviewMode;
   mode: ResolvedWebPreviewMode;
-  prevMode: ResolvedWebPreviewMode;
-  reason: WebPreviewResolveReason;
-  inHysteresisHold: boolean;
-  hysteresisProgress: number;
-}): number {
-  type AutoFitKind = 'width' | 'height' | null;
-  const autoFitKindRef = useRef<AutoFitKind>(null);
-
+  fitKind: ResolvedWebPreviewFitKind;
+  ratioW: number;
+  ratioH: number;
+  enterThresholdScale: number;
+  enterMinScale: number;
+}): AutoFitBiases {
   const {
     fit,
     webPreviewMode,
     mode,
-    prevMode,
-    reason,
-    inHysteresisHold,
-    hysteresisProgress,
+    fitKind,
+    ratioW,
+    ratioH,
+    enterThresholdScale,
+    enterMinScale,
   } = args;
+  const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+  const smoothstep01 = (v: number) => {
+    const t = clamp01(v);
+    return t * t * (3 - 2 * t);
+  };
 
-  if (fit !== 'auto' || webPreviewMode !== 'auto') {
-    autoFitKindRef.current = null;
-  } else if (prevMode === 'fit' && mode === 'responsive') {
-    autoFitKindRef.current = null;
-  } else if (mode === 'fit') {
-    // Keep the previous bound only while we are inside the hysteresis band.
-    if (reason === 'width_bound') autoFitKindRef.current = 'width';
-    else if (reason === 'height_bound') autoFitKindRef.current = 'height';
+  if (mode !== 'fit' || webPreviewMode !== 'auto' || fit !== 'auto') {
+    return EMPTY_AUTO_FIT_BIASES;
+  }
+  if (
+    !Number.isFinite(ratioW) ||
+    !Number.isFinite(ratioH) ||
+    !isFinitePositive(enterThresholdScale) ||
+    !isFinitePositive(enterMinScale)
+  ) {
+    return EMPTY_AUTO_FIT_BIASES;
   }
 
-  if (mode !== 'fit' || webPreviewMode !== 'auto' || fit !== 'auto') return 0;
+  let interiorContainPull = 0;
+  let interiorCoverPush = 0;
 
-  if (autoFitKindRef.current === 'width') return 1;
+  if (fitKind === 'width') {
+    const widthExtremeScale = Math.max(
+      enterMinScale,
+      enterThresholdScale * 0.62,
+    );
+    const widthRange = enterThresholdScale - widthExtremeScale;
 
-  if (autoFitKindRef.current === 'height') {
-    return inHysteresisHold ? Math.pow(hysteresisProgress, 2) : 0;
+    if (widthRange > 0) {
+      const widthNarrowness = clamp01(
+        (enterThresholdScale - ratioW) / widthRange,
+      );
+      const leftCoverPlateau =
+        1 - smoothstep01((widthNarrowness - 0.18) / 0.48);
+      const midContainWindow =
+        smoothstep01((widthNarrowness - 0.4) / 0.14) *
+        (1 - smoothstep01((widthNarrowness - 0.62) / 0.14));
+      const rightCoverPlateau = smoothstep01((widthNarrowness - 0.76) / 0.12);
+      const coverPlateau = Math.max(leftCoverPlateau, rightCoverPlateau);
+
+      // Shape the width-driven auto-fit response as:
+      // full-cover plateau -> smooth contain window -> full-cover plateau.
+      interiorContainPull = midContainWindow * (1 - coverPlateau) * 0.45;
+      interiorCoverPush = coverPlateau * 0.98;
+    }
+  } else if (fitKind === 'height') {
+    const widthContainSupport = smoothstep01(
+      (ratioW - enterThresholdScale * 0.98) / (enterThresholdScale * 0.22),
+    );
+    const heightShortness = smoothstep01(
+      (enterMinScale - ratioH) / (enterMinScale * 0.5),
+    );
+
+    // When width is already fairly wide but height is slightly short, lean a
+    // bit more toward contain instead of aggressively filling width.
+    interiorContainPull = widthContainSupport * heightShortness * 0.45;
   }
 
-  return 0;
+  return {
+    interiorContainPull,
+    interiorCoverPush,
+  };
 }
 
 export const WebIframe = ({
@@ -481,8 +532,14 @@ export const WebIframe = ({
 
   const dimsReady = containerWidth > 0 && containerHeight > 0;
 
-  const prevResolvedModeRef = useRef<ResolvedWebPreviewMode>('responsive');
-  const prevResolvedMode = prevResolvedModeRef.current;
+  const prevResolvedRef = useRef<{
+    mode: ResolvedWebPreviewMode;
+    fitKind: ResolvedWebPreviewFitKind;
+  }>({
+    mode: 'responsive',
+    fitKind: null,
+  });
+  const prevResolvedMode = prevResolvedRef.current.mode;
   const resolved = resolveWebPreviewModeWithHysteresis(
     {
       webPreviewMode,
@@ -494,11 +551,13 @@ export const WebIframe = ({
       containerHeight,
     },
     prevResolvedMode,
+    prevResolvedRef.current.fitKind,
   );
   const mode = resolved.mode;
+  const usesFitPath = mode === 'fit';
 
   if (
-    mode === 'fit' &&
+    usesFitPath &&
     (!isFinitePositive(designWidth) || !isFinitePositive(designHeight))
   ) {
     throw new RangeError(
@@ -506,13 +565,17 @@ export const WebIframe = ({
     );
   }
 
-  const browserConfigSize =
-    mode === 'fit' ? { width: designWidth, height: designHeight } : undefined;
+  const browserConfigSize = usesFitPath
+    ? { width: designWidth, height: designHeight }
+    : undefined;
 
-  const enableFitTransition = prevResolvedMode === 'fit' && mode === 'fit';
+  const enableFitTransition = prevResolvedMode === 'fit' && usesFitPath;
   useEffect(() => {
-    prevResolvedModeRef.current = mode;
-  }, [mode]);
+    prevResolvedRef.current = {
+      mode,
+      fitKind: resolved.fitKind,
+    };
+  }, [mode, resolved.fitKind]);
 
   const { ready, rendered, error } = useWebIframeController({
     src,
@@ -522,31 +585,35 @@ export const WebIframe = ({
     browserConfigSize,
   });
 
-  const autoCoverBias = useAutoCoverBias({
-    fit,
-    webPreviewMode,
-    mode,
-    prevMode: prevResolvedMode,
-    reason: resolved.reason,
-    inHysteresisHold: resolved.inHysteresisHold,
-    hysteresisProgress: resolved.hysteresisProgress,
-  });
+  // `webPreviewMode='responsive'` resolves to `usesFitPath === false`,
+  // which skips all fit-only interpolation and auto-fit bias logic.
+  const autoFitBiases = usesFitPath
+    ? useAutoFitBiases({
+        fit,
+        webPreviewMode,
+        mode,
+        fitKind: resolved.fitKind,
+        ratioW: resolved.ratioW,
+        ratioH: resolved.ratioH,
+        enterThresholdScale: resolved.enterThresholdScale,
+        enterMinScale: resolved.enterMinScale,
+      })
+    : EMPTY_AUTO_FIT_BIASES;
 
-  const fitStyles =
-    mode === 'fit'
-      ? deriveFitStyles(
-          containerWidth,
-          containerHeight,
-          designWidth,
-          designHeight,
-          fit,
-          autoCoverBias,
-          enableFitTransition,
-        )
-      : null;
+  const fitStyles = usesFitPath
+    ? deriveFitStyles(
+        containerWidth,
+        containerHeight,
+        designWidth,
+        designHeight,
+        fit,
+        autoFitBiases,
+        enableFitTransition,
+      )
+    : null;
 
   const { stage: stageStyle, lynxView: lynxViewStyle } =
-    mode === 'fit' && fitStyles
+    usesFitPath && fitStyles
       ? { stage: STAGE_FIT_ANCHOR, lynxView: fitStyles.lynxView }
       : { stage: STAGE_RESPONSIVE, lynxView: LYNX_VIEW_STYLE_RESPONSIVE };
 
@@ -564,7 +631,7 @@ export const WebIframe = ({
   );
 
   const frameStyle =
-    mode === 'fit' && fitStyles ? fitStyles.frame : FRAME_RESPONSIVE;
+    usesFitPath && fitStyles ? fitStyles.frame : FRAME_RESPONSIVE;
   // Always mount <lynx-view> when src exists so the ref
   // is always populated and shadow DOM persists
   // across tab switches.

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -421,7 +421,7 @@ function deriveFitStyles(
   return createStyles(scale, offsetX, offsetY);
 }
 
-function useAutoFitBiases(args: {
+function computeAutoFitBiases(args: {
   fit: 'contain' | 'cover' | 'auto';
   webPreviewMode: WebPreviewMode;
   mode: ResolvedWebPreviewMode;
@@ -588,7 +588,7 @@ export const WebIframe = ({
   // `webPreviewMode='responsive'` resolves to `usesFitPath === false`,
   // which skips all fit-only interpolation and auto-fit bias logic.
   const autoFitBiases = usesFitPath
-    ? useAutoFitBiases({
+    ? computeAutoFitBiases({
         fit,
         webPreviewMode,
         mode,

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -449,7 +449,7 @@ function useAutoCoverBias(args: {
 export const WebIframe = ({
   show,
   src,
-  webPreviewMode = 'auto',
+  webPreviewMode = 'responsive',
   designWidth = 375,
   designHeight = 812,
   fitThresholdScale = 1.0,

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -328,6 +328,24 @@ function deriveFitStyles(
   lynxView: React.CSSProperties & CSSVarProperties;
 } {
   const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+  const createStyles = (scale: number, offsetX = 0, offsetY = 0) => ({
+    frame: {
+      position: 'absolute' as const,
+      transformOrigin: 'top left' as const,
+      width: designWidth,
+      height: designHeight,
+      transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+      transition: enableTransition ? 'transform 0.2s ease' : undefined,
+    },
+    lynxView: {
+      width: designWidth,
+      height: designHeight,
+      containerType: 'size' as const,
+      '--rpx-unit': `${designWidth / 750}px`,
+      '--vh-unit': `${designHeight / 100}px`,
+      '--vw-unit': `${designWidth / 100}px`,
+    },
+  });
 
   const FIT_AUTO_MAX_CROP_RATIO = 0.5;
   const FIT_AUTO_COVER_BIAS_EXP = 2;
@@ -340,12 +358,22 @@ function deriveFitStyles(
     Math.round(designHeight * 0.4),
   );
 
+  if (!isFinitePositive(containerWidth) || !isFinitePositive(containerHeight)) {
+    return createStyles(0);
+  }
+
   const scaleRange = computeScaleRange({
     containerWidth,
     containerHeight,
     baseWidth: designWidth,
     baseHeight: designHeight,
   });
+  if (
+    !Number.isFinite(scaleRange.contain) ||
+    !isFinitePositive(scaleRange.cover)
+  ) {
+    return createStyles(0);
+  }
   let fitProgress: number;
   if (fit === 'contain') {
     fitProgress = 0;
@@ -380,27 +408,7 @@ function deriveFitStyles(
     ax: 0.5,
     ay: 0.5,
   });
-
-  return {
-    frame: {
-      position: 'absolute',
-      transformOrigin: 'top left',
-      width: designWidth,
-      height: designHeight,
-      transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
-      // Smooth transition for fit→fit scale changes (container resize).
-      // Disabled for fit↔responsive mode switches (hard cut).
-      transition: enableTransition ? 'transform 0.2s ease' : undefined,
-    },
-    lynxView: {
-      width: designWidth,
-      height: designHeight,
-      containerType: 'size',
-      '--rpx-unit': `${designWidth / 750}px`,
-      '--vh-unit': `${designHeight / 100}px`,
-      '--vw-unit': `${designWidth / 100}px`,
-    },
-  };
+  return createStyles(scale, offsetX, offsetY);
 }
 
 function useAutoCoverBias(args: {

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -60,6 +60,7 @@ export interface ExamplePreviewProps {
   designHeight?: number;
   fitThresholdScale?: number;
   fitMinScale?: number;
+  fit?: 'contain' | 'cover' | 'auto';
   /**
    * Override the default preview tab for this instance.
    * Takes precedence over the site-level `GoConfig.defaultTab`.
@@ -116,7 +117,8 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     designWidth = 375,
     designHeight = 812,
     fitThresholdScale = 1.0,
-    fitMinScale = 0.6,
+    fitMinScale = 0.5,
+    fit = 'cover',
   } = props;
 
   // Instance prop > config provider > undefined (let ExampleContent decide)
@@ -277,6 +279,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       designHeight={designHeight}
       fitThresholdScale={fitThresholdScale}
       fitMinScale={fitMinScale}
+      fit={fit}
     />
   );
 };

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -112,7 +112,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     langAlias,
     defaultTab: propsDefaultTab,
     mode = 'linked',
-    webPreviewMode = 'auto',
+    webPreviewMode = 'responsive',
     webPreview = true,
     designWidth = 375,
     designHeight = 812,

--- a/src/example-preview/utils/number.ts
+++ b/src/example-preview/utils/number.ts
@@ -1,0 +1,7 @@
+export function isFinitePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+export function areFinitePositive(...values: number[]): boolean {
+  return values.every(isFinitePositive);
+}

--- a/src/example-preview/utils/resolve-web-preview.ts
+++ b/src/example-preview/utils/resolve-web-preview.ts
@@ -7,6 +7,7 @@ export type WebPreviewResolveReason =
   | 'explicit_fit'
   | 'explicit_responsive'
   | 'invalid_dims'
+  | 'invalid_thresholds'
   | 'width_bound'
   | 'height_bound'
   | 'hysteresis_hold'
@@ -43,6 +44,9 @@ export function resolveWebPreviewMode({
   }
   if (!isFinitePositive(designWidth) || !isFinitePositive(designHeight)) {
     return { mode: 'responsive', reason: 'invalid_dims' };
+  }
+  if (!isFinitePositive(fitThresholdScale) || !isFinitePositive(fitMinScale)) {
+    return { mode: 'responsive', reason: 'invalid_thresholds' };
   }
 
   const ratioW = containerWidth / designWidth;
@@ -83,16 +87,20 @@ export function resolveWebPreviewModeWithHysteresis(
 
   const base = resolveWebPreviewMode(args);
 
-  const invalidDims = base.reason === 'invalid_dims';
+  const invalidBase =
+    base.reason === 'invalid_dims' || base.reason === 'invalid_thresholds';
   const isExplicit =
     base.reason === 'explicit_fit' || base.reason === 'explicit_responsive';
 
-  if (invalidDims || isExplicit) {
+  if (invalidBase || isExplicit) {
+    const ratioW = args.containerWidth / args.designWidth;
+    const ratioH = args.containerHeight / args.designHeight;
+
     return {
       mode: base.mode,
       reason: base.reason,
-      ratioW: NaN,
-      ratioH: NaN,
+      ratioW,
+      ratioH,
       enterThresholdScale: args.fitThresholdScale,
       enterMinScale: args.fitMinScale,
       exitThresholdScale: args.fitThresholdScale,

--- a/src/example-preview/utils/resolve-web-preview.ts
+++ b/src/example-preview/utils/resolve-web-preview.ts
@@ -1,5 +1,16 @@
+import { isFinitePositive } from './number';
+
 export type WebPreviewMode = 'fit' | 'responsive' | 'auto';
 export type ResolvedWebPreviewMode = Exclude<WebPreviewMode, 'auto'>;
+
+export type WebPreviewResolveReason =
+  | 'explicit_fit'
+  | 'explicit_responsive'
+  | 'invalid_dims'
+  | 'width_bound'
+  | 'height_bound'
+  | 'hysteresis_hold'
+  | 'none';
 
 export type ResolveWebPreviewModeArgs = {
   webPreviewMode: WebPreviewMode;
@@ -19,31 +30,135 @@ export function resolveWebPreviewMode({
   fitMinScale,
   containerWidth,
   containerHeight,
-}: ResolveWebPreviewModeArgs): ResolvedWebPreviewMode {
-  if (webPreviewMode === 'fit') return 'fit';
-  if (webPreviewMode === 'responsive') return 'responsive';
+}: ResolveWebPreviewModeArgs): {
+  mode: ResolvedWebPreviewMode;
+  reason: WebPreviewResolveReason;
+} {
+  if (webPreviewMode === 'fit') return { mode: 'fit', reason: 'explicit_fit' };
+  if (webPreviewMode === 'responsive')
+    return { mode: 'responsive', reason: 'explicit_responsive' };
 
-  if (
-    !Number.isFinite(containerWidth) ||
-    containerWidth <= 0 ||
-    !Number.isFinite(containerHeight) ||
-    containerHeight <= 0
-  ) {
-    return 'responsive';
+  if (!isFinitePositive(containerWidth) || !isFinitePositive(containerHeight)) {
+    return { mode: 'responsive', reason: 'invalid_dims' };
   }
-  if (
-    !Number.isFinite(designWidth) ||
-    designWidth <= 0 ||
-    !Number.isFinite(designHeight) ||
-    designHeight <= 0
-  ) {
-    return 'responsive';
+  if (!isFinitePositive(designWidth) || !isFinitePositive(designHeight)) {
+    return { mode: 'responsive', reason: 'invalid_dims' };
   }
 
   const ratioW = containerWidth / designWidth;
   const ratioH = containerHeight / designHeight;
 
-  const shouldUseFit = ratioW < fitThresholdScale || ratioH < fitMinScale;
+  const widthBound = ratioW < fitThresholdScale;
+  const heightBound = ratioH < fitMinScale;
+  const shouldUseFit = widthBound || heightBound;
 
-  return shouldUseFit ? 'fit' : 'responsive';
+  if (shouldUseFit) {
+    return {
+      mode: 'fit',
+      reason: heightBound ? 'height_bound' : 'width_bound',
+    };
+  }
+
+  return { mode: 'responsive', reason: 'none' };
+}
+
+export type ResolveWebPreviewModeWithHysteresisResult = {
+  mode: ResolvedWebPreviewMode;
+  reason: WebPreviewResolveReason;
+  ratioW: number;
+  ratioH: number;
+  enterThresholdScale: number;
+  enterMinScale: number;
+  exitThresholdScale: number;
+  exitMinScale: number;
+  inHysteresisHold: boolean;
+  hysteresisProgress: number;
+};
+
+export function resolveWebPreviewModeWithHysteresis(
+  args: ResolveWebPreviewModeArgs,
+  prevMode: ResolvedWebPreviewMode,
+): ResolveWebPreviewModeWithHysteresisResult {
+  const AUTO_HYSTERESIS_FACTOR = 1.06;
+
+  const base = resolveWebPreviewMode(args);
+
+  const invalidDims = base.reason === 'invalid_dims';
+  const isExplicit =
+    base.reason === 'explicit_fit' || base.reason === 'explicit_responsive';
+
+  if (invalidDims || isExplicit) {
+    return {
+      mode: base.mode,
+      reason: base.reason,
+      ratioW: NaN,
+      ratioH: NaN,
+      enterThresholdScale: args.fitThresholdScale,
+      enterMinScale: args.fitMinScale,
+      exitThresholdScale: args.fitThresholdScale,
+      exitMinScale: args.fitMinScale,
+      inHysteresisHold: false,
+      hysteresisProgress: 0,
+    };
+  }
+
+  const ratioW = args.containerWidth / args.designWidth;
+  const ratioH = args.containerHeight / args.designHeight;
+
+  const enterThresholdScale = args.fitThresholdScale;
+  const enterMinScale = args.fitMinScale;
+  const exitThresholdScale = enterThresholdScale * AUTO_HYSTERESIS_FACTOR;
+  const exitMinScale = enterMinScale * AUTO_HYSTERESIS_FACTOR;
+
+  const enterWidthBound = ratioW < enterThresholdScale;
+  const enterHeightBound = ratioH < enterMinScale;
+  const enterFit = enterWidthBound || enterHeightBound;
+
+  const exitFit = ratioW >= exitThresholdScale && ratioH >= exitMinScale;
+
+  let mode: ResolvedWebPreviewMode;
+  if (prevMode === 'fit') {
+    mode = exitFit ? 'responsive' : 'fit';
+  } else {
+    mode = enterFit ? 'fit' : 'responsive';
+  }
+
+  const inHysteresisHold = prevMode === 'fit' && mode === 'fit' && !enterFit;
+  const hysteresisProgress = inHysteresisHold
+    ? Math.min(
+        1,
+        Math.max(
+          0,
+          Math.min(
+            (ratioW - enterThresholdScale) /
+              (exitThresholdScale - enterThresholdScale),
+            (ratioH - enterMinScale) / (exitMinScale - enterMinScale),
+          ),
+        ),
+      )
+    : 0;
+
+  let reason: WebPreviewResolveReason;
+  if (mode === 'fit') {
+    if (enterFit) {
+      reason = enterHeightBound ? 'height_bound' : 'width_bound';
+    } else {
+      reason = 'hysteresis_hold';
+    }
+  } else {
+    reason = 'none';
+  }
+
+  return {
+    mode,
+    reason,
+    ratioW,
+    ratioH,
+    enterThresholdScale,
+    enterMinScale,
+    exitThresholdScale,
+    exitMinScale,
+    inHysteresisHold,
+    hysteresisProgress,
+  };
 }

--- a/src/example-preview/utils/resolve-web-preview.ts
+++ b/src/example-preview/utils/resolve-web-preview.ts
@@ -23,6 +23,15 @@ export type ResolveWebPreviewModeArgs = {
   containerHeight: number;
 };
 
+function resolveFitReason(
+  widthBound: boolean,
+  heightBound: boolean,
+): WebPreviewResolveReason | null {
+  if (widthBound) return 'width_bound';
+  if (heightBound) return 'height_bound';
+  return null;
+}
+
 export function resolveWebPreviewMode({
   webPreviewMode,
   designWidth,
@@ -54,12 +63,13 @@ export function resolveWebPreviewMode({
 
   const widthBound = ratioW < fitThresholdScale;
   const heightBound = ratioH < fitMinScale;
-  const shouldUseFit = widthBound || heightBound;
+  const fitReason = resolveFitReason(widthBound, heightBound);
+  const shouldUseFit = fitReason !== null;
 
   if (shouldUseFit) {
     return {
       mode: 'fit',
-      reason: heightBound ? 'height_bound' : 'width_bound',
+      reason: fitReason,
     };
   }
 
@@ -120,7 +130,8 @@ export function resolveWebPreviewModeWithHysteresis(
 
   const enterWidthBound = ratioW < enterThresholdScale;
   const enterHeightBound = ratioH < enterMinScale;
-  const enterFit = enterWidthBound || enterHeightBound;
+  const enterReason = resolveFitReason(enterWidthBound, enterHeightBound);
+  const enterFit = enterReason !== null;
 
   const exitFit = ratioW >= exitThresholdScale && ratioH >= exitMinScale;
 
@@ -149,7 +160,7 @@ export function resolveWebPreviewModeWithHysteresis(
   let reason: WebPreviewResolveReason;
   if (mode === 'fit') {
     if (enterFit) {
-      reason = enterHeightBound ? 'height_bound' : 'width_bound';
+      reason = enterReason;
     } else {
       reason = 'hysteresis_hold';
     }

--- a/src/example-preview/utils/resolve-web-preview.ts
+++ b/src/example-preview/utils/resolve-web-preview.ts
@@ -2,6 +2,7 @@ import { isFinitePositive } from './number';
 
 export type WebPreviewMode = 'fit' | 'responsive' | 'auto';
 export type ResolvedWebPreviewMode = Exclude<WebPreviewMode, 'auto'>;
+export type ResolvedWebPreviewFitKind = 'width' | 'height' | null;
 
 export type WebPreviewResolveReason =
   | 'explicit_fit'
@@ -79,6 +80,7 @@ export function resolveWebPreviewMode({
 export type ResolveWebPreviewModeWithHysteresisResult = {
   mode: ResolvedWebPreviewMode;
   reason: WebPreviewResolveReason;
+  fitKind: ResolvedWebPreviewFitKind;
   ratioW: number;
   ratioH: number;
   enterThresholdScale: number;
@@ -92,8 +94,11 @@ export type ResolveWebPreviewModeWithHysteresisResult = {
 export function resolveWebPreviewModeWithHysteresis(
   args: ResolveWebPreviewModeArgs,
   prevMode: ResolvedWebPreviewMode,
+  prevFitKind: ResolvedWebPreviewFitKind,
 ): ResolveWebPreviewModeWithHysteresisResult {
   const AUTO_HYSTERESIS_FACTOR = 1.06;
+  const hasValidDesignSize =
+    isFinitePositive(args.designWidth) && isFinitePositive(args.designHeight);
 
   const base = resolveWebPreviewMode(args);
 
@@ -103,12 +108,17 @@ export function resolveWebPreviewModeWithHysteresis(
     base.reason === 'explicit_fit' || base.reason === 'explicit_responsive';
 
   if (invalidBase || isExplicit) {
-    const ratioW = args.containerWidth / args.designWidth;
-    const ratioH = args.containerHeight / args.designHeight;
+    const ratioW = hasValidDesignSize
+      ? args.containerWidth / args.designWidth
+      : 0;
+    const ratioH = hasValidDesignSize
+      ? args.containerHeight / args.designHeight
+      : 0;
 
     return {
       mode: base.mode,
       reason: base.reason,
+      fitKind: null,
       ratioW,
       ratioH,
       enterThresholdScale: args.fitThresholdScale,
@@ -168,9 +178,19 @@ export function resolveWebPreviewModeWithHysteresis(
     reason = 'none';
   }
 
+  const fitKind: ResolvedWebPreviewFitKind =
+    reason === 'width_bound'
+      ? 'width'
+      : reason === 'height_bound'
+        ? 'height'
+        : reason === 'hysteresis_hold'
+          ? prevFitKind
+          : null;
+
   return {
     mode,
     reason,
+    fitKind,
     ratioW,
     ratioH,
     enterThresholdScale,


### PR DESCRIPTION
This change improves the WebIframe fit pipeline and makes fit/responsive
transitions more stable, while keeping the default web preview behavior
backward compatible for the current Lynx website.

## What changed

- add fit support with `contain`, `cover`, and `auto` strategies
- improve `fit='auto'` behavior with readability guards for very small containers
- refine auto-fit heuristics with width-side cover plateaus, a contain window in the middle, and stronger contain handling for selected height-bound cases
- add hysteresis-based mode switching to reduce resize flicker between `fit` and `responsive`
- return resolved mode reasons and hysteresis state from web preview mode resolution
- harden threshold, dimension, and scale handling to prevent invalid values from propagating into transforms
- add shared numeric validation helpers
- thread fit-related props through example preview and embed entry points
- update README to document the hysteresis-aware `auto` behavior and threshold semantics
- note the known `browserConfig` one-time initialization limitation in comments
- opt selected `lynx-ui-*` examples into `webPreviewMode='auto'`

## Default behavior

- keep the default `webPreviewMode` as `'responsive'`
- use `fit='cover'` as the default fit strategy when the fit path is explicitly enabled

This preserves the current website behavior by default while allowing consumers
to opt into the new fit pipeline when needed.

## Related
- Closes #52