### PR TITLE
ci: add format-check and done jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,15 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       contents: read
+
+  done:
+    name: Done
+    needs:
+      - validate
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Fail If Any Job Did Not Succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -7,6 +7,24 @@ env:
   CI: 1
 
 jobs:
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/ci-setup
+
+      - name: Format Check
+        run: pnpm format:check
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
@@ -27,7 +45,9 @@ jobs:
 
   build-example:
     name: Build Example App
-    needs: typecheck
+    needs:
+      - format-check
+      - typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
Add a dedicated format-check job to the reusable test workflow and a final done job to the ci workflow.

This keeps the required check surface stable for Web UI / bot triggers, so branch protection does not get bypassed or blocked by missing aggregated statuses.