### PR TITLE
feat(preview): native-module & multi-page (MPA) preview extension points

### DIFF
--- a/.changeset/native-mpa-preview.md
+++ b/.changeset/native-mpa-preview.md
@@ -1,0 +1,10 @@
+---
+'@lynx-js/go-web': minor
+---
+
+Add opt-in preview extension points for native modules and multi-page (MPA) examples.
+
+- **Level A** — `GoConfig.previewNativeEnv` and the per-instance `nativeEnv` prop forward a generic native environment (`onNativeModulesCall`, `nativeModulesMap`, `napiModulesMap`, `onNapiModulesCall`, and a static-or-factory `globalProps` / `initData`) to the previewed `<lynx-view>` before it starts.
+- **Level B** — `GoConfig.PreviewRuntime` replaces the built-in single-card renderer with a custom component (receiving every previewable entry plus the resolved native environment) so embedders can stack cards and route cross-page navigation, while go-web keeps owning the tab bar, QR, code browser, scaling, and SSG path.
+
+Both are backwards compatible and product-agnostic: when unset, the preview is identical to before, and go-web hard-codes no framework module names or URL scheme.

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -43,11 +43,30 @@ jobs:
       - name: Type Check
         run: pnpm typecheck
 
+  test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/ci-setup
+
+      - name: Test
+        run: pnpm test
+
   build-example:
     name: Build Example App
     needs:
       - format-check
       - typecheck
+      - test
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,98 @@ Transition behavior:
 - `fit → fit` on container resize: smooth `transform` transition
 - `fit ↔ responsive` mode switch: hard cut, no transition
 
+### Native modules & multi-page (MPA) previews
+
+By default the web preview renders **one** `<lynx-view>` with no native bridge.
+Two opt-in extension points let embedders preview examples that call **native
+modules** and that navigate across **multiple Lynx pages**. Both are generic —
+go-web has no knowledge of any framework's module names or URL scheme — and both
+are backwards compatible: when unset, the preview is byte-for-byte identical to
+today.
+
+#### Level A — native environment (`previewNativeEnv` / `nativeEnv`)
+
+Forward a native environment to the previewed `<lynx-view>` so a bundle that
+calls a native module renders instead of failing with
+`Native module ... is not registered`. Set it site-wide on `GoConfig`
+(`previewNativeEnv`) and/or per instance on `<Go>` (`nativeEnv`, shallow-merged
+over the config — per-instance keys win).
+
+| Field                 | Type                                    | Description                                                                                               |
+| --------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `onNativeModulesCall` | `(name, data, moduleName) => any`       | Handler for NativeModule calls made by the bundle. web-core caches calls made before assignment (safe).   |
+| `nativeModulesMap`    | `Record<string, string>`                | Native-modules definition: `module-name → ESM url`. Consumed by the worker at init, applied before start. |
+| `napiModulesMap`      | `Record<string, string>`                | Napi-modules definition (advanced).                                                                       |
+| `onNapiModulesCall`   | `(...) => any`                          | Handler for NapiModule calls (advanced).                                                                  |
+| `globalProps`         | `Cloneable \| (entryName) => Cloneable` | Per-card `globalProps` (e.g. a container id / query params). Read when the view starts.                   |
+| `initData`            | `Cloneable \| (entryName) => Cloneable` | Per-card `initData`. Read when the view starts.                                                           |
+
+```tsx
+import type { GoConfig } from '@lynx-js/go-web';
+
+const config: GoConfig = {
+  exampleBasePath: '/lynx-examples',
+  previewNativeEnv: {
+    onNativeModulesCall: (name, data, moduleName) => {
+      // Deliver the call to your host bridge and return the result.
+      return myBridge.call(moduleName, name, data);
+    },
+    nativeModulesMap: { MyModule: 'https://cdn.example.com/my-module.js' },
+    globalProps: (entryName) => ({ containerId: `preview:${entryName}` }),
+  },
+};
+```
+
+**Ordering.** `nativeModulesMap` / `napiModulesMap` / `globalProps` / `initData`
+are read by web-core when the view starts; go-web assigns them from the element
+`ref` (the same path the existing `browserConfig` init uses), which lands before
+web-core's async start reads them. `onNativeModulesCall` may be assigned late
+because web-core caches pre-assignment calls.
+
+#### Level B — pluggable preview runtime (`PreviewRuntime`)
+
+The built-in renderer shows a single card, so cross-page navigation has nowhere
+to go. Set `GoConfig.PreviewRuntime` to **replace just the inner card renderer**
+— go-web keeps owning the tab bar, QR, code browser, fit/scaling, and SSG path.
+The component receives every previewable entry plus the resolved Level-A
+environment:
+
+```tsx
+import type { PreviewRuntimeProps } from '@lynx-js/go-web';
+
+function MyRuntime(props: PreviewRuntimeProps) {
+  // props.entries      — every entry with a web bundle ({ name, webUrl, file })
+  // props.activeEntry  — current entry name
+  // props.src          — active entry's web bundle URL
+  // props.nativeEnv    — resolved Level-A environment
+  // props.designWidth / designHeight / fit / webPreviewMode — scaling params
+  // → stack <lynx-view> cards and route navigation between them.
+}
+
+const config: GoConfig = {
+  exampleBasePath: '/lynx-examples',
+  PreviewRuntime: MyRuntime,
+};
+```
+
+**Two shapes, one hook.** This single slot supports both MPA designs:
+
+- **B1 — in-process card stack (recommended).** Keep a stack of `<lynx-view>`
+  cards in React state; push on navigate, pop on `back`. Lower cards stay
+  mounted (stable React key) so their heap and state survive the round-trip. No
+  cross-origin handshake, type-safe composition, reuses go-web scaling. See the
+  runnable prototype in [`example/src/mpa/`](./example/src/mpa/)
+  (`StackedPreviewRuntime.tsx` + the framework-agnostic `card-stack.ts`).
+- **B2 — iframe runtime.** Render a real `<iframe src={runtimeUrl}>` from your
+  `PreviewRuntime` and pass the entries via query/`postMessage`. Because an
+  iframe is a real nested browsing context, `window.history` and navigation are
+  naturally scoped to it — ideal for an embedder that already has a full-page
+  "web shell". It is simply one implementation of the same `PreviewRuntime` hook.
+
+go-web recommends B1 as the default and treats B2 as an escape hatch. Try both
+live in the example app via the **Preview** control (`Default` / `Native` /
+`MPA`).
+
 ## Development
 
 ```bash
@@ -184,9 +276,11 @@ CI always runs `prepare:clean` to ensure that examples are up to date.
 
 ## CI
 
-All three checks must pass on every PR:
+All checks must pass on every PR:
 
+- **Format Check** — `pnpm format:check`
 - **Type Check** — `pnpm typecheck` at the repo root
+- **Unit Test** — `pnpm test` (Vitest)
 - **Build Example App** — standalone Rsbuild example
 - **Build Rspress Example** — rspress integration example
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,35 @@ pnpm prepare:clean
 
 CI always runs `prepare:clean` to ensure that examples are up to date.
 
+### Testing
+
+The preview extension points are verified in two layers:
+
+```bash
+pnpm test          # Vitest — Node unit tests (runs in CI)
+pnpm test:browser  # Playwright — real web-core integration (opt-in, local)
+```
+
+- **Unit (`pnpm test`)** — pure logic plus the native-env wiring against a
+  faithful `<lynx-view>` fake: apply-before-start ordering, merge/resolve,
+  native-call delivery (including calls cached before the handler is assigned),
+  and the MPA card-stack navigation (open → back with the root intact). These
+  validate go-web's own code and are the CI gate.
+- **Real-browser (`pnpm test:browser`)** — drives the built example app in
+  headless Chromium against the **real** `@lynx-js/web-core` runtime and asserts:
+  the default preview still boots exactly one `<lynx-view>`; Level A actually
+  reaches the real element (`nativeModulesMap` / `onNativeModulesCall` /
+  `globalProps`) and it boots; and Level B pushes a **second** real `<lynx-view>`
+  on a native `open` call, with `Back` returning to the original root element
+  (same DOM node ⇒ heap and state intact). Prereq: `cd example && pnpm build`.
+  It is intentionally out of CI (needs the example built and a Chromium binary).
+
+> Literal acceptance of a native-calling / multi-page example needs a fixture
+> bundle that actually invokes native modules (none exists in the public gallery
+> — the `vue-router` example uses in-bundle `createMemoryHistory`). `pnpm
+test:browser` is the harness such a fixture (or the downstream MPA bundle)
+> slots into.
+
 ## CI
 
 All checks must pass on every PR:

--- a/example/src/demo-native-env.ts
+++ b/example/src/demo-native-env.ts
@@ -1,0 +1,50 @@
+/**
+ * Demo `PreviewNativeEnv` (Level A) for the example app.
+ *
+ * Shows the three generic hooks go-web forwards to the previewed `<lynx-view>`:
+ *   1. `onNativeModulesCall` — receives native-module calls made by the bundle.
+ *   2. `nativeModulesMap`    — `module-name -> ESM url` definition consumed by
+ *      the worker at init (here an inline `data:` module, purely illustrative;
+ *      it stays dormant unless a bundle actually imports that module).
+ *   3. `globalProps`         — a `(entryName) => Cloneable` factory injecting a
+ *      per-card container id / query params.
+ *
+ * These are opt-in: examples that don't use native modules are unaffected.
+ */
+import type { PreviewNativeEnv } from '../../src/index';
+
+/** An inline ESM native module, referenced by `nativeModulesMap` below. */
+const DEMO_MODULE_URL =
+  'data:text/javascript,' +
+  encodeURIComponent(
+    `export default function (NativeModules, NativeModulesCall) {
+       return {
+         ping: (msg) => NativeModulesCall('ping', msg, 'DemoModule'),
+       };
+     }`,
+  );
+
+export const demoNativeEnv: PreviewNativeEnv = {
+  // 1. Handler — every native-module call the bundle makes lands here.
+  onNativeModulesCall: (name, data, moduleName) => {
+    console.log('[demo native call]', { moduleName, name, data });
+    if (name === 'ping') {
+      return { ok: true, echo: data, at: 'go-web-demo' };
+    }
+    // Returning undefined leaves other modules to their defaults.
+    return undefined;
+  },
+
+  // 2. Native-modules definition passthrough (module-name -> ESM url).
+  nativeModulesMap: {
+    DemoModule: DEMO_MODULE_URL,
+  },
+
+  // 3. Per-card globalProps factory — inject a container id derived from entry.
+  //    `Cloneable` values are flat primitives (web-core structured-clone shape).
+  globalProps: (entryName) => ({
+    containerId: `go-web-demo:${entryName}`,
+    source: 'go-web',
+    preview: true,
+  }),
+};

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -10,7 +10,13 @@ import { createRoot } from 'react-dom/client';
 import type { BundledLanguage, ShikiTransformer } from 'shiki';
 import type { GoConfig, PreviewTab } from '../../src/config';
 import { Go, GoConfigProvider } from '../../src/index';
+import { demoNativeEnv } from './demo-native-env';
+import { StackedPreviewRuntime } from './mpa/StackedPreviewRuntime';
 import './styles.css';
+
+// Opt-in preview extensions demo (Level A / Level B). 'default' keeps the
+// built-in single-card preview with no native env — identical to before.
+type PreviewExt = 'default' | 'native' | 'mpa';
 
 const LOGO_LIGHT =
   'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg';
@@ -530,6 +536,7 @@ function App() {
   const [mode, setMode] = useState<'linked' | 'preview' | 'source'>(
     initial.mode ?? 'linked',
   );
+  const [previewExt, setPreviewExt] = useState<PreviewExt>('default');
   const [copied, setCopied] = useState(false);
   const [exampleSearch, setExampleSearch] = useState('');
   const [entrySearch, setEntrySearch] = useState('');
@@ -749,6 +756,10 @@ function App() {
     useLang: () => lang,
     useDark: () => dark,
     CodeBlock: StandaloneCodeBlock,
+    // Level A: forward a demo native env to the previewed <lynx-view>.
+    ...(previewExt !== 'default' ? { previewNativeEnv: demoNativeEnv } : {}),
+    // Level B: replace the single-card renderer with a stacked MPA runtime.
+    ...(previewExt === 'mpa' ? { PreviewRuntime: StackedPreviewRuntime } : {}),
   };
 
   return (
@@ -844,6 +855,18 @@ function App() {
                   { value: 'source', label: 'Source' },
                 ]}
                 onChange={(v) => setMode(v as 'linked' | 'preview' | 'source')}
+              />
+            </ControlGroup>
+
+            <ControlGroup label="Preview">
+              <AdaptiveControl
+                value={previewExt}
+                options={[
+                  { value: 'default', label: 'Default' },
+                  { value: 'native', label: 'Native' },
+                  { value: 'mpa', label: 'MPA' },
+                ]}
+                onChange={(v) => setPreviewExt(v as PreviewExt)}
               />
             </ControlGroup>
 
@@ -1254,7 +1277,7 @@ function App() {
               {/* Desktop */}
               <div style={{ flex: '1 1 500px', minWidth: 0 }}>
                 <Go
-                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${mode}`}
+                  key={`desktop-${example}-${selectedEntry}-${defaultTab}-${mode}-${previewExt}`}
                   example={example}
                   defaultFile={defaultFile}
                   defaultTab={defaultTab}
@@ -1288,7 +1311,7 @@ function App() {
                   }}
                 >
                   <Go
-                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${mode}`}
+                    key={`mobile-${example}-${selectedEntry}-${defaultTab}-${mode}-${previewExt}`}
                     example={example}
                     defaultFile={defaultFile}
                     defaultTab={defaultTab}

--- a/example/src/mpa/StackedPreviewRuntime.tsx
+++ b/example/src/mpa/StackedPreviewRuntime.tsx
@@ -1,0 +1,211 @@
+/**
+ * Demo `PreviewRuntime` (Level B, shape B1) — an in-process card stack.
+ *
+ * Replaces go-web's built-in single-card web preview with a stack of
+ * `<lynx-view>` cards so a multi-page (MPA) example can open a second card and
+ * navigate `back`. go-web still owns the tab bar, QR, code browser, and
+ * scaling; this component only renders (and routes between) the cards.
+ *
+ * Why B1 here: no cross-origin/postMessage handshake, type-safe React
+ * composition, and lower cards stay mounted (stable React key) so their runtime
+ * heap — and state — survives forward/back navigation. An embedder that already
+ * has a full-page "web shell" can instead implement B2 by rendering an
+ * `<iframe src={runtimeUrl}>` from a `PreviewRuntime` of their own; both plug
+ * into the same `GoConfig.PreviewRuntime` hook.
+ *
+ * This file is a COPYABLE PROTOTYPE. The navigation convention (native `open` /
+ * `back`) lives in `./nav-intent`, on the embedder side — go-web knows none of
+ * it.
+ */
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from 'react';
+import type { LynxViewElement } from '@lynx-js/web-core/client';
+import {
+  applyPreviewNativeEnv,
+  type PreviewNativeEnv,
+  type PreviewRuntimeProps,
+} from '../../../src/index';
+import {
+  activeCard,
+  cardStackReducer,
+  createInitialStack,
+  type PreviewCard,
+} from './card-stack';
+import { resolveDemoNavIntent } from './nav-intent';
+
+const LYNX_GROUP_ID = 43;
+
+let cardSeq = 0;
+function nextCardId(entryName: string): string {
+  cardSeq += 1;
+  return `${entryName}#${cardSeq}`;
+}
+
+/** A single stacked `<lynx-view>` card. */
+function Card({
+  card,
+  visible,
+  nativeEnv,
+}: {
+  card: PreviewCard;
+  visible: boolean;
+  nativeEnv?: PreviewNativeEnv;
+}) {
+  const appliedRef = useRef<WeakSet<LynxViewElement>>(new WeakSet());
+
+  const handleRef = useCallback(
+    (el: LynxViewElement | null) => {
+      if (!el) return;
+      // Apply the resolved native env before the view starts (see
+      // applyPreviewNativeEnv for the ordering guarantee), tagging each card
+      // with its own id via globalProps so stacked containers stay distinct.
+      applyPreviewNativeEnv(el, nativeEnv, card.entryName, appliedRef.current);
+    },
+    [card.entryName, nativeEnv],
+  );
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        visibility: visible ? 'visible' : 'hidden',
+        pointerEvents: visible ? 'auto' : 'none',
+        background: 'var(--sb-bg, #fff)',
+      }}
+    >
+      {React.createElement('lynx-view' as unknown as 'div', {
+        key: card.id,
+        ref: handleRef as never,
+        url: card.src,
+        'lynx-group-id': LYNX_GROUP_ID,
+        'transform-vh': true,
+        'transform-vw': true,
+        style: {
+          width: '100%',
+          height: '100%',
+          containerType: 'size',
+          '--rpx-unit': 'calc(100cqw / 750)',
+          '--vh-unit': '1cqh',
+          '--vw-unit': '1cqw',
+        } as React.CSSProperties,
+      })}
+    </div>
+  );
+}
+
+export function StackedPreviewRuntime({
+  entries,
+  activeEntry,
+  src,
+  show,
+  nativeEnv,
+}: PreviewRuntimeProps) {
+  const rootCard = useMemo<PreviewCard>(
+    () => ({
+      id: nextCardId(activeEntry || 'root'),
+      entryName: activeEntry,
+      src,
+    }),
+    // A new root card whenever the active entry or its url changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeEntry, src],
+  );
+
+  const [state, dispatch] = useReducer(
+    cardStackReducer,
+    rootCard,
+    createInitialStack,
+  );
+
+  // Reset the stack when the root card changes (entry/example switch).
+  const rootIdRef = useRef(rootCard.id);
+  useEffect(() => {
+    if (rootIdRef.current !== rootCard.id) {
+      rootIdRef.current = rootCard.id;
+      dispatch({ type: 'reset', root: rootCard });
+    }
+  }, [rootCard]);
+
+  const top = activeCard(state);
+
+  // Wrap the embedder's native env: intercept navigation calls, delegate the
+  // rest. globalProps is augmented per card with its stack id.
+  const runtimeEnv = useMemo<PreviewNativeEnv>(() => {
+    const baseGlobalProps = nativeEnv?.globalProps;
+    return {
+      ...nativeEnv,
+      globalProps: (entryName: string) => {
+        const resolved =
+          typeof baseGlobalProps === 'function'
+            ? baseGlobalProps(entryName)
+            : baseGlobalProps;
+        return { ...(resolved as object), __previewEntry: entryName };
+      },
+      onNativeModulesCall: (
+        name: string,
+        data: unknown,
+        moduleName: string,
+      ) => {
+        const intent = resolveDemoNavIntent(name, data, entries);
+        if (intent) {
+          if (intent.type === 'back') {
+            dispatch({ type: 'back' });
+          } else {
+            dispatch({
+              type: 'push',
+              card: {
+                id: nextCardId(intent.entry.name),
+                entryName: intent.entry.name,
+                src: intent.entry.webUrl,
+              },
+            });
+          }
+          return undefined;
+        }
+        return nativeEnv?.onNativeModulesCall?.(name, data, moduleName);
+      },
+    };
+  }, [entries, nativeEnv]);
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {/* Every card in the stack stays mounted so lower cards keep their state;
+          only the top card is visible. */}
+      {state.cards.map((card) => (
+        <Card
+          key={card.id}
+          card={card}
+          visible={show && card.id === top?.id}
+          nativeEnv={runtimeEnv}
+        />
+      ))}
+      {state.cards.length > 1 && (
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'back' })}
+          style={{
+            position: 'absolute',
+            top: 8,
+            left: 8,
+            zIndex: 10,
+            padding: '4px 10px',
+            fontSize: 12,
+            borderRadius: 6,
+            border: '1px solid var(--sb-border, #ccc)',
+            background: 'var(--sb-surface, rgba(255,255,255,0.85))',
+            cursor: 'pointer',
+          }}
+          aria-label="Back"
+        >
+          ‹ Back
+        </button>
+      )}
+    </div>
+  );
+}

--- a/example/src/mpa/card-stack.ts
+++ b/example/src/mpa/card-stack.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure card-stack model for the demo MPA `PreviewRuntime` (Level B, shape B1).
+ *
+ * A multi-page (MPA) example demonstrates cross-page navigation by STACKING
+ * `<lynx-view>` cards: opening a page pushes a card, `back` pops it. Because
+ * lower cards are never unmounted (their `<lynx-view>` elements keep a stable
+ * React key), each card's runtime heap — and therefore its state — survives
+ * navigating forward and back.
+ *
+ * This model is deliberately framework-agnostic: it knows nothing about any
+ * router's method names or URL scheme. The demo runtime maps native calls
+ * (e.g. `router.open` / `back`) onto these actions; the mapping lives on the
+ * embedder side, not here.
+ */
+
+export interface PreviewCard {
+  /** Stable id — used as the React key and to keep the card's heap alive. */
+  id: string;
+  /** Entry whose web bundle this card renders. */
+  entryName: string;
+  /** Web bundle URL for this card. */
+  src: string;
+}
+
+export interface CardStackState {
+  /** Bottom-to-top: `cards[0]` is the root, the last item is the active card. */
+  cards: PreviewCard[];
+}
+
+export type CardStackAction =
+  | { type: 'reset'; root: PreviewCard }
+  | { type: 'push'; card: PreviewCard }
+  | { type: 'back' };
+
+/** Initial stack containing just the root card. */
+export function createInitialStack(root: PreviewCard): CardStackState {
+  return { cards: [root] };
+}
+
+/** The active (top-most) card, or `undefined` for an empty stack. */
+export function activeCard(state: CardStackState): PreviewCard | undefined {
+  return state.cards[state.cards.length - 1];
+}
+
+/**
+ * Reduce a navigation action.
+ *
+ * - `reset` — start a fresh stack from a new root (e.g. entry/example change).
+ * - `push`  — open a new card on top (forward navigation).
+ * - `back`  — pop the top card; a single-card stack is left untouched so the
+ *   root is never unmounted and keeps its state.
+ */
+export function cardStackReducer(
+  state: CardStackState,
+  action: CardStackAction,
+): CardStackState {
+  switch (action.type) {
+    case 'reset':
+      return createInitialStack(action.root);
+    case 'push':
+      return { cards: [...state.cards, action.card] };
+    case 'back':
+      if (state.cards.length <= 1) return state;
+      return { cards: state.cards.slice(0, -1) };
+    default:
+      return state;
+  }
+}

--- a/example/src/mpa/nav-intent.ts
+++ b/example/src/mpa/nav-intent.ts
@@ -1,0 +1,77 @@
+/**
+ * Demo-only mapping from a native-module call to a card-stack navigation intent.
+ *
+ * This encodes the EMBEDDER's convention — go-web itself stays product-agnostic
+ * and knows none of this. Here the demo treats a native call named `open` as
+ * "push a card" and `back` as "pop a card". `open` carries either an `entry`
+ * name or a `url` identifying the target bundle; we resolve it against the
+ * example's previewable entries.
+ *
+ * A real integration (e.g. a vue-router example whose `router.open` stacks
+ * native containers) would parse its own schema here instead.
+ */
+import type { PreviewRuntimeEntry } from '../../../src/example-preview/preview-runtime';
+
+export type NavIntent =
+  | { type: 'back' }
+  | { type: 'push'; entry: PreviewRuntimeEntry };
+
+/** Names this demo treats as navigation (case-insensitive). */
+const OPEN_METHODS = new Set(['open', 'push', 'navigate', 'openpage']);
+const BACK_METHODS = new Set(['back', 'pop', 'goback', 'close']);
+
+/**
+ * Resolve a native call into a navigation intent, or `null` if the call is not
+ * navigation (and should be delegated to the embedder's own handler).
+ */
+export function resolveDemoNavIntent(
+  name: string,
+  data: unknown,
+  entries: PreviewRuntimeEntry[],
+): NavIntent | null {
+  const method = String(name).toLowerCase();
+  if (BACK_METHODS.has(method)) {
+    return { type: 'back' };
+  }
+  if (OPEN_METHODS.has(method)) {
+    const target = findTarget(data, entries);
+    if (target) return { type: 'push', entry: target };
+  }
+  return null;
+}
+
+function findTarget(
+  data: unknown,
+  entries: PreviewRuntimeEntry[],
+): PreviewRuntimeEntry | undefined {
+  const payload = normalizePayload(data);
+  if (payload.entry) {
+    const byName = entries.find((e) => e.name === payload.entry);
+    if (byName) return byName;
+  }
+  if (payload.url) {
+    const byUrl = entries.find(
+      (e) => e.webUrl === payload.url || e.file === payload.url,
+    );
+    if (byUrl) return byUrl;
+  }
+  // Fall back to the next entry after the first, so the demo can advance even
+  // without a precise target — enough to show a second card opening.
+  return entries[1];
+}
+
+function normalizePayload(data: unknown): { entry?: string; url?: string } {
+  if (typeof data === 'string') return { url: data };
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>;
+    const entry = typeof obj.entry === 'string' ? obj.entry : undefined;
+    const url =
+      typeof obj.url === 'string'
+        ? obj.url
+        : typeof obj.schema === 'string'
+          ? obj.schema
+          : undefined;
+    return { entry, url };
+  }
+  return {};
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format:check": "prettier --check .",
     "prepare": "husky",
     "test": "vitest run",
+    "test:browser": "node test/browser/run.mjs",
     "typecheck": "tsc --noEmit"
   },
   "lint-staged": {
@@ -58,6 +59,7 @@
     "@types/react-dom": "^18.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "playwright": "^1.61.1",
     "prettier": "^3.8.3",
     "prettier-plugin-packagejson": "^3.0.2",
     "qrcode.react": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "lint-staged": {
@@ -65,6 +66,7 @@
     "react-dom": "^18.2.0",
     "swr": "^2.2.5",
     "typescript": "^5.7.0",
+    "vitest": "^3.2.7",
     "vscode-icons-js": "^11.6.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,11 +67,20 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@24.12.2)(jsdom@25.0.1)(yaml@2.8.3)
       vscode-icons-js:
         specifier: ^11.6.1
         version: 11.6.1
 
 packages:
+  '@asamuzakjp/css-color@3.2.0':
+    resolution:
+      {
+        integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==,
+      }
+
   '@babel/runtime@7.28.6':
     resolution:
       {
@@ -194,6 +203,49 @@ packages:
         integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
       }
 
+  '@csstools/color-helpers@5.1.0':
+    resolution:
+      {
+        integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==,
+      }
+    engines: { node: '>=18' }
+
+  '@csstools/css-calc@2.1.4':
+    resolution:
+      {
+        integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution:
+      {
+        integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution:
+      {
+        integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution:
+      {
+        integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==,
+      }
+    engines: { node: '>=18' }
+
   '@dnd-kit/accessibility@3.1.1':
     resolution:
       {
@@ -289,6 +341,240 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution:
+      {
+        integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution:
+      {
+        integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution:
+      {
+        integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution:
+      {
+        integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution:
+      {
+        integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
+      }
+    engines: { node: '>=18' }
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution:
+      {
+        integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution:
+      {
+        integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [win32]
+
   '@floating-ui/core@1.7.5':
     resolution:
       {
@@ -318,6 +604,12 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
 
   '@lynx-js/lynx-core@0.1.3':
     resolution:
@@ -400,6 +692,219 @@ packages:
       {
         integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==,
       }
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution:
+      {
+        integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==,
+      }
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==,
+      }
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==,
+      }
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==,
+      }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution:
+      {
+        integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution:
+      {
+        integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution:
+      {
+        integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==,
+      }
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution:
+      {
+        integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==,
+      }
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution:
+      {
+        integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution:
+      {
+        integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==,
+      }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution:
+      {
+        integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==,
+      }
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution:
+      {
+        integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==,
+      }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution:
+      {
+        integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution:
+      {
+        integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==,
+      }
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution:
+      {
+        integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution:
+      {
+        integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==,
+      }
+    cpu: [x64]
+    os: [win32]
 
   '@shikijs/core@3.23.0':
     resolution:
@@ -708,10 +1213,22 @@ packages:
       '@tiptap/core': ^3.20.1
       '@tiptap/pm': ^3.20.1
 
+  '@types/chai@5.2.3':
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
+
   '@types/debug@4.1.12':
     resolution:
       {
         integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+      }
+
+  '@types/deep-eql@4.0.2':
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
       }
 
   '@types/estree-jsx@1.0.5':
@@ -724,6 +1241,12 @@ packages:
     resolution:
       {
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
+
+  '@types/estree@1.0.9':
+    resolution:
+      {
+        integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
   '@types/hast@3.0.4':
@@ -842,6 +1365,56 @@ packages:
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
 
+  '@vitest/expect@3.2.7':
+    resolution:
+      {
+        integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==,
+      }
+
+  '@vitest/mocker@3.2.7':
+    resolution:
+      {
+        integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==,
+      }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution:
+      {
+        integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==,
+      }
+
+  '@vitest/runner@3.2.7':
+    resolution:
+      {
+        integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==,
+      }
+
+  '@vitest/snapshot@3.2.7':
+    resolution:
+      {
+        integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==,
+      }
+
+  '@vitest/spy@3.2.7':
+    resolution:
+      {
+        integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==,
+      }
+
+  '@vitest/utils@3.2.7':
+    resolution:
+      {
+        integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==,
+      }
+
   acorn-jsx@5.3.2:
     resolution:
       {
@@ -857,6 +1430,13 @@ packages:
       }
     engines: { node: '>=0.4.0' }
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution:
+      {
+        integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
+      }
+    engines: { node: '>= 14' }
 
   ansi-colors@4.1.3:
     resolution:
@@ -912,6 +1492,13 @@ packages:
       }
     engines: { node: '>=8' }
 
+  assertion-error@2.0.1:
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: '>=12' }
+
   astring@1.9.0:
     resolution:
       {
@@ -923,6 +1510,12 @@ packages:
     resolution:
       {
         integrity: sha512-8eLCg00W9pIRZSB781UUX/H6Oskmm8xloZfr09lz5bikRpBVDlJ3hRVuxxP1SxcwsEYfJ4IU8Q19Y8/893r3rQ==,
+      }
+
+  asynckit@0.4.0:
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
 
   bail@2.0.2:
@@ -951,11 +1544,32 @@ packages:
       }
     engines: { node: '>=8' }
 
+  cac@6.7.14:
+    resolution:
+      {
+        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
+      }
+    engines: { node: '>=8' }
+
+  call-bind-apply-helpers@1.0.2:
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: '>= 0.4' }
+
   ccount@2.0.1:
     resolution:
       {
         integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
       }
+
+  chai@5.3.3:
+    resolution:
+      {
+        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
+      }
+    engines: { node: '>=18' }
 
   character-entities-html4@2.1.0:
     resolution:
@@ -986,6 +1600,13 @@ packages:
       {
         integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
       }
+
+  check-error@2.1.3:
+    resolution:
+      {
+        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
+      }
+    engines: { node: '>= 16' }
 
   classnames@2.5.1:
     resolution:
@@ -1025,6 +1646,13 @@ packages:
       {
         integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
       }
+
+  combined-stream@1.0.8:
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: '>= 0.8' }
 
   comma-separated-tokens@2.0.3:
     resolution:
@@ -1071,11 +1699,25 @@ packages:
       }
     engines: { node: '>= 8' }
 
+  cssstyle@4.6.0:
+    resolution:
+      {
+        integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==,
+      }
+    engines: { node: '>=18' }
+
   csstype@3.2.3:
     resolution:
       {
         integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
       }
+
+  data-urls@5.0.0:
+    resolution:
+      {
+        integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==,
+      }
+    engines: { node: '>=18' }
 
   dataloader@1.4.0:
     resolution:
@@ -1110,11 +1752,31 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution:
+      {
+        integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
+      }
+
   decode-named-character-reference@1.3.0:
     resolution:
       {
         integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
       }
+
+  deep-eql@5.0.2:
+    resolution:
+      {
+        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
+      }
+    engines: { node: '>=6' }
+
+  delayed-stream@1.0.0:
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: '>=0.4.0' }
 
   dequal@2.0.3:
     resolution:
@@ -1170,6 +1832,13 @@ packages:
       }
     engines: { node: '>=12' }
 
+  dunder-proto@1.0.1:
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: '>= 0.4' }
+
   emoji-regex@10.6.0:
     resolution:
       {
@@ -1190,12 +1859,53 @@ packages:
       }
     engines: { node: '>=0.12' }
 
+  entities@6.0.1:
+    resolution:
+      {
+        integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
+      }
+    engines: { node: '>=0.12' }
+
   environment@1.1.0:
     resolution:
       {
         integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
       }
     engines: { node: '>=18' }
+
+  es-define-property@1.0.1:
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: '>= 0.4' }
+
+  es-errors@1.3.0:
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: '>= 0.4' }
+
+  es-module-lexer@1.7.0:
+    resolution:
+      {
+        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+      }
+
+  es-object-atoms@1.1.2:
+    resolution:
+      {
+        integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==,
+      }
+    engines: { node: '>= 0.4' }
+
+  es-set-tostringtag@2.1.0:
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: '>= 0.4' }
 
   esast-util-from-estree@2.0.0:
     resolution:
@@ -1208,6 +1918,14 @@ packages:
       {
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
+
+  esbuild@0.28.1:
+    resolution:
+      {
+        integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
 
   escape-string-regexp@4.0.0:
     resolution:
@@ -1279,6 +1997,13 @@ packages:
         integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
       }
 
+  expect-type@1.4.0:
+    resolution:
+      {
+        integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==,
+      }
+    engines: { node: '>=12.0.0' }
+
   extend@3.0.2:
     resolution:
       {
@@ -1343,6 +2068,13 @@ packages:
       }
     engines: { node: '>=8' }
 
+  form-data@4.0.6:
+    resolution:
+      {
+        integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==,
+      }
+    engines: { node: '>= 6' }
+
   fs-extra@7.0.1:
     resolution:
       {
@@ -1357,12 +2089,40 @@ packages:
       }
     engines: { node: '>=6 <7 || >=8' }
 
+  fsevents@2.3.3:
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
+
   get-east-asian-width@1.5.0:
     resolution:
       {
         integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
       }
     engines: { node: '>=18' }
+
+  get-intrinsic@1.3.0:
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: '>= 0.4' }
+
+  get-proto@1.0.1:
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: '>= 0.4' }
 
   git-hooks-list@4.2.1:
     resolution:
@@ -1384,11 +2144,39 @@ packages:
       }
     engines: { node: '>=10' }
 
+  gopd@1.2.0:
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: '>= 0.4' }
+
   graceful-fs@4.2.11:
     resolution:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
+
+  has-symbols@1.1.0:
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: '>= 0.4' }
+
+  has-tostringtag@1.0.2:
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: '>= 0.4' }
+
+  hasown@2.0.4:
+    resolution:
+      {
+        integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
+      }
+    engines: { node: '>= 0.4' }
 
   hast-util-to-estree@3.1.3:
     resolution:
@@ -1414,11 +2202,32 @@ packages:
         integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
       }
 
+  html-encoding-sniffer@4.0.0:
+    resolution:
+      {
+        integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==,
+      }
+    engines: { node: '>=18' }
+
   html-void-elements@3.0.0:
     resolution:
       {
         integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==,
       }
+
+  http-proxy-agent@7.0.2:
+    resolution:
+      {
+        integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==,
+      }
+    engines: { node: '>= 14' }
+
+  https-proxy-agent@7.0.6:
+    resolution:
+      {
+        integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
+      }
+    engines: { node: '>= 14' }
 
   human-id@4.1.3:
     resolution:
@@ -1434,6 +2243,13 @@ packages:
       }
     engines: { node: '>=18' }
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution:
+      {
+        integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==,
+      }
+    engines: { node: '>=0.10.0' }
 
   iconv-lite@0.7.2:
     resolution:
@@ -1514,6 +2330,12 @@ packages:
       }
     engines: { node: '>=12' }
 
+  is-potential-custom-element-name@1.0.1:
+    resolution:
+      {
+        integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==,
+      }
+
   is-subdir@1.2.0:
     resolution:
       {
@@ -1540,6 +2362,12 @@ packages:
         integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
       }
 
+  js-tokens@9.0.1:
+    resolution:
+      {
+        integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
+      }
+
   js-yaml@3.14.2:
     resolution:
       {
@@ -1553,6 +2381,18 @@ packages:
         integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
       }
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution:
+      {
+        integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==,
+      }
+    engines: { node: '>=18' }
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsonc-parser@3.3.1:
     resolution:
@@ -1638,6 +2478,24 @@ packages:
         integrity: sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==,
       }
 
+  loupe@3.2.1:
+    resolution:
+      {
+        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
+      }
+
+  lru-cache@10.4.3:
+    resolution:
+      {
+        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+      }
+
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
   markdown-extensions@2.0.0:
     resolution:
       {
@@ -1657,6 +2515,13 @@ packages:
       {
         integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
       }
+
+  math-intrinsics@1.1.0:
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: '>= 0.4' }
 
   mdast-util-find-and-replace@3.0.2:
     resolution:
@@ -1990,6 +2855,20 @@ packages:
       }
     engines: { node: '>=8.6' }
 
+  mime-db@1.52.0:
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: '>= 0.6' }
+
+  mime-types@2.1.35:
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: '>= 0.6' }
+
   mimic-function@5.0.1:
     resolution:
       {
@@ -2010,6 +2889,14 @@ packages:
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
 
+  nanoid@3.3.16:
+    resolution:
+      {
+        integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
   node-fetch@2.7.0:
     resolution:
       {
@@ -2021,6 +2908,12 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  nwsapi@2.2.24:
+    resolution:
+      {
+        integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==,
+      }
 
   object-assign@4.1.1:
     resolution:
@@ -2095,6 +2988,12 @@ packages:
         integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
       }
 
+  parse5@7.3.0:
+    resolution:
+      {
+        integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
+      }
+
   path-exists@4.0.0:
     resolution:
       {
@@ -2115,6 +3014,19 @@ packages:
         integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
       }
     engines: { node: '>=8' }
+
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
+  pathval@2.0.1:
+    resolution:
+      {
+        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
+      }
+    engines: { node: '>= 14.16' }
 
   picocolors@1.1.1:
     resolution:
@@ -2142,6 +3054,13 @@ packages:
         integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
       }
     engines: { node: '>=6' }
+
+  postcss@8.5.19:
+    resolution:
+      {
+        integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prettier-plugin-packagejson@3.0.2:
     resolution:
@@ -2305,6 +3224,13 @@ packages:
     resolution:
       {
         integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==,
+      }
+    engines: { node: '>=6' }
+
+  punycode@2.3.1:
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
       }
     engines: { node: '>=6' }
 
@@ -2481,10 +3407,30 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
+  rollup@4.62.2:
+    resolution:
+      {
+        integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==,
+      }
+    engines: { node: '>=18.0.0', npm: '>=8.0.0' }
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution:
       {
         integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==,
+      }
+
+  rrweb-cssom@0.7.1:
+    resolution:
+      {
+        integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==,
+      }
+
+  rrweb-cssom@0.8.0:
+    resolution:
+      {
+        integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==,
       }
 
   run-parallel@1.2.0:
@@ -2498,6 +3444,13 @@ packages:
       {
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
+
+  saxes@6.0.0:
+    resolution:
+      {
+        integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
+      }
+    engines: { node: '>=v12.22.7' }
 
   scheduler@0.23.2:
     resolution:
@@ -2532,6 +3485,12 @@ packages:
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
     engines: { node: '>=8' }
+
+  siginfo@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
 
   signal-exit@4.1.0:
     resolution:
@@ -2575,6 +3534,13 @@ packages:
     engines: { node: '>=20' }
     hasBin: true
 
+  source-map-js@1.2.1:
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: '>=0.10.0' }
+
   source-map@0.7.6:
     resolution:
       {
@@ -2598,6 +3564,18 @@ packages:
     resolution:
       {
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
+      }
+
+  stackback@0.0.2:
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
+
+  std-env@3.10.0:
+    resolution:
+      {
+        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
       }
 
   string-argv@0.3.2:
@@ -2648,6 +3626,12 @@ packages:
       }
     engines: { node: '>=4' }
 
+  strip-literal@3.1.0:
+    resolution:
+      {
+        integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==,
+      }
+
   style-to-js@1.1.21:
     resolution:
       {
@@ -2668,12 +3652,30 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution:
+      {
+        integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
+      }
+
   term-size@2.2.1:
     resolution:
       {
         integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
       }
     engines: { node: '>=8' }
+
+  tinybench@2.9.0:
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
+
+  tinyexec@0.3.2:
+    resolution:
+      {
+        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
+      }
 
   tinyexec@1.1.1:
     resolution:
@@ -2689,6 +3691,40 @@ packages:
       }
     engines: { node: '>=12.0.0' }
 
+  tinypool@1.1.1:
+    resolution:
+      {
+        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
+      }
+    engines: { node: ^18.0.0 || >=20.0.0 }
+
+  tinyrainbow@2.0.0:
+    resolution:
+      {
+        integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
+      }
+    engines: { node: '>=14.0.0' }
+
+  tinyspy@4.0.4:
+    resolution:
+      {
+        integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
+      }
+    engines: { node: '>=14.0.0' }
+
+  tldts-core@6.1.86:
+    resolution:
+      {
+        integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==,
+      }
+
+  tldts@6.1.86:
+    resolution:
+      {
+        integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
+      }
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution:
       {
@@ -2702,11 +3738,25 @@ packages:
         integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==,
       }
 
+  tough-cookie@5.1.2:
+    resolution:
+      {
+        integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==,
+      }
+    engines: { node: '>=16' }
+
   tr46@0.0.3:
     resolution:
       {
         integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
       }
+
+  tr46@5.1.1:
+    resolution:
+      {
+        integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==,
+      }
+    engines: { node: '>=18' }
 
   trim-lines@3.0.1:
     resolution:
@@ -2822,6 +3872,88 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
+  vite-node@3.2.4:
+    resolution:
+      {
+        integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+
+  vite@7.3.6:
+    resolution:
+      {
+        integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution:
+      {
+        integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-icons-js@11.6.1:
     resolution:
       {
@@ -2834,6 +3966,13 @@ packages:
         integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==,
       }
 
+  w3c-xmlserializer@5.0.0:
+    resolution:
+      {
+        integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
+      }
+    engines: { node: '>=18' }
+
   wasm-feature-detect@1.8.0:
     resolution:
       {
@@ -2845,6 +3984,35 @@ packages:
       {
         integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
       }
+
+  webidl-conversions@7.0.0:
+    resolution:
+      {
+        integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==,
+      }
+    engines: { node: '>=12' }
+
+  whatwg-encoding@3.1.1:
+    resolution:
+      {
+        integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
+      }
+    engines: { node: '>=18' }
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution:
+      {
+        integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
+      }
+    engines: { node: '>=18' }
+
+  whatwg-url@14.2.0:
+    resolution:
+      {
+        integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==,
+      }
+    engines: { node: '>=18' }
 
   whatwg-url@5.0.0:
     resolution:
@@ -2860,12 +4028,48 @@ packages:
     engines: { node: '>= 8' }
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: '>=8' }
+    hasBin: true
+
   wrap-ansi@9.0.2:
     resolution:
       {
         integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
       }
     engines: { node: '>=18' }
+
+  ws@8.21.0:
+    resolution:
+      {
+        integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
+      }
+    engines: { node: '>=10.0.0' }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution:
+      {
+        integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==,
+      }
+    engines: { node: '>=18' }
+
+  xmlchars@2.2.0:
+    resolution:
+      {
+        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
+      }
 
   yaml@2.8.3:
     resolution:
@@ -2882,6 +4086,15 @@ packages:
       }
 
 snapshots:
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+    optional: true
+
   '@babel/runtime@7.28.6': {}
 
   '@changesets/apply-release-plan@7.1.0':
@@ -3034,6 +4247,31 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@csstools/color-helpers@5.1.0':
+    optional: true
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+    optional: true
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+    optional: true
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+    optional: true
+
+  '@csstools/css-tokenizer@3.0.4':
+    optional: true
+
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -3152,6 +4390,84 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -3172,6 +4488,8 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 24.12.2
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@lynx-js/lynx-core@0.1.3':
     optional: true
@@ -3252,6 +4570,81 @@ snapshots:
       fastq: 1.20.1
 
   '@remirror/core-constants@3.0.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
 
   '@shikijs/core@3.23.0':
     dependencies:
@@ -3479,15 +4872,24 @@ snapshots:
       '@tiptap/core': 3.20.1(@tiptap/pm@3.20.1)
       '@tiptap/pm': 3.20.1
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -3544,11 +4946,56 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@24.12.2)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.12.2)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@7.1.4:
+    optional: true
 
   ansi-colors@4.1.3: {}
 
@@ -3570,9 +5017,14 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   astring@1.9.0: {}
 
   async-validator@3.5.2: {}
+
+  asynckit@0.4.0:
+    optional: true
 
   bail@2.0.2: {}
 
@@ -3586,7 +5038,23 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+    optional: true
+
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   character-entities-html4@2.1.0: {}
 
@@ -3597,6 +5065,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   classnames@2.5.1: {}
 
@@ -3614,6 +5084,11 @@ snapshots:
   collapse-white-space@2.1.0: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+    optional: true
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3635,7 +5110,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+    optional: true
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+    optional: true
 
   dataloader@1.4.0: {}
 
@@ -3651,9 +5138,17 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0:
+    optional: true
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  deep-eql@5.0.2: {}
+
+  delayed-stream@1.0.0:
+    optional: true
 
   dequal@2.0.3: {}
 
@@ -3677,6 +5172,13 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
   emoji-regex@10.6.0: {}
 
   enquirer@2.4.1:
@@ -3686,7 +5188,31 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1:
+    optional: true
+
   environment@1.1.0: {}
+
+  es-define-property@1.0.1:
+    optional: true
+
+  es-errors@1.3.0:
+    optional: true
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+    optional: true
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+    optional: true
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -3701,6 +5227,35 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-string-regexp@4.0.0: {}
 
@@ -3743,6 +5298,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.4.0: {}
+
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
@@ -3776,6 +5333,15 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+    optional: true
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3788,7 +5354,33 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2:
+    optional: true
+
   get-east-asian-width@1.5.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+    optional: true
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+    optional: true
 
   git-hooks-list@4.2.1: {}
 
@@ -3805,7 +5397,23 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0:
+    optional: true
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0:
+    optional: true
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+    optional: true
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+    optional: true
 
   hast-util-to-estree@3.1.3:
     dependencies:
@@ -3866,11 +5474,37 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+    optional: true
+
   html-void-elements@3.0.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   human-id@4.1.3: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3905,6 +5539,9 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1:
+    optional: true
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -3915,6 +5552,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -3923,6 +5562,35 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   jsonc-parser@3.3.1: {}
 
@@ -3978,6 +5646,15 @@ snapshots:
 
   lottie-web@5.13.0: {}
 
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3:
+    optional: true
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   markdown-extensions@2.0.0: {}
 
   markdown-it@14.1.1:
@@ -3990,6 +5667,9 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0:
+    optional: true
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -4429,15 +6109,28 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0:
+    optional: true
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+    optional: true
+
   mimic-function@5.0.1: {}
 
   mri@1.2.0: {}
 
   ms@2.1.3: {}
 
+  nanoid@3.3.16: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  nwsapi@2.2.24:
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -4479,11 +6172,20 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+    optional: true
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -4492,6 +6194,12 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier-plugin-packagejson@3.0.2(prettier@3.8.3):
     dependencies:
@@ -4617,6 +6325,9 @@ snapshots:
       prosemirror-transform: 1.11.0
 
   punycode.js@2.3.1: {}
+
+  punycode@2.3.1:
+    optional: true
 
   qrcode.react@4.2.0(react@18.3.1):
     dependencies:
@@ -4761,13 +6472,55 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   rope-sequence@1.3.4: {}
+
+  rrweb-cssom@0.7.1:
+    optional: true
+
+  rrweb-cssom@0.8.0:
+    optional: true
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+    optional: true
 
   scheduler@0.23.2:
     dependencies:
@@ -4784,6 +6537,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -4811,6 +6566,8 @@ snapshots:
       sort-object-keys: 2.1.0
       tinyglobby: 0.2.16
 
+  source-map-js@1.2.1: {}
+
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
@@ -4821,6 +6578,10 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-argv@0.3.2: {}
 
@@ -4850,6 +6611,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -4864,7 +6629,14 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  symbol-tree@3.2.4:
+    optional: true
+
   term-size@2.2.1: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.1.1: {}
 
@@ -4873,13 +6645,37 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@6.1.86:
+    optional: true
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+    optional: true
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toggle-selection@1.0.6: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+    optional: true
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+    optional: true
 
   trim-lines@3.0.1: {}
 
@@ -4948,15 +6744,114 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@24.12.2)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@24.12.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@24.12.2)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.19
+      rollup: 4.62.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      yaml: 2.8.3
+
+  vitest@3.2.7(@types/debug@4.1.12)(@types/node@24.12.2)(jsdom@25.0.1)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@24.12.2)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@24.12.2)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.12.2)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.12.2
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vscode-icons-js@11.6.1:
     dependencies:
       '@types/jasmine': 3.10.19
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+    optional: true
+
   wasm-feature-detect@1.8.0: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0:
+    optional: true
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
+  whatwg-mimetype@4.0.0:
+    optional: true
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -4967,11 +6862,25 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.21.0:
+    optional: true
+
+  xml-name-validator@5.0.0:
+    optional: true
+
+  xmlchars@2.2.0:
+    optional: true
 
   yaml@2.8.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2089,6 +2092,14 @@ packages:
       }
     engines: { node: '>=6 <7 || >=8' }
 
+  fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution:
       {
@@ -3054,6 +3065,22 @@ packages:
         integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
       }
     engines: { node: '>=6' }
+
+  playwright-core@1.61.1:
+    resolution:
+      {
+        integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution:
+      {
+        integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
 
   postcss@8.5.19:
     resolution:
@@ -5354,6 +5381,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6194,6 +6224,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.19:
     dependencies:

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -1,6 +1,8 @@
 import type React from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ExamplePreviewProps } from './example-preview';
+import type { PreviewNativeEnv } from './example-preview/preview-native-env';
+import type { PreviewRuntimeComponent } from './example-preview/preview-runtime';
 import { useIsClient } from './example-preview/hooks/use-is-client';
 
 export type PreviewTab = 'preview' | 'web' | 'qrcode';
@@ -85,6 +87,29 @@ export interface GoConfig {
   LoadingComponent?: React.ComponentType<{ visible: boolean }>;
   /** Absolute disk path to examples directory, for built-in SSG component */
   ssgExampleRoot?: string;
+
+  // --- Live preview extension points (opt-in) ---
+
+  /**
+   * Level A — native environment forwarded to the previewed `<lynx-view>`.
+   *
+   * Site-wide defaults for registering a native-modules bridge, injecting
+   * per-card `globalProps`/`initData`, and handling native-module calls made by
+   * the previewed bundle. Per-instance `nativeEnv` on `<Go>` is shallow-merged
+   * over this. Unset ⇒ preview behavior is unchanged.
+   */
+  previewNativeEnv?: PreviewNativeEnv;
+
+  /**
+   * Level B — replace the built-in single-card web preview renderer.
+   *
+   * When provided, go-web renders this component in place of the default
+   * `<lynx-view>` card (still inside go-web's tab bar / QR / code browser /
+   * scaling), passing every previewable entry plus the resolved native
+   * environment. Use it to stack cards and route cross-page (MPA) navigation.
+   * Unset ⇒ the built-in single-card preview is used.
+   */
+  PreviewRuntime?: PreviewRuntimeComponent;
 
   // --- Framework adapter ---
 

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -24,6 +24,11 @@ import { SwitchSchema } from './switch-schema';
 import type { PreviewTab } from '../../config';
 import { DEFAULT_I18N, DefaultNoSSR, useGoConfig } from '../../config';
 import type { SchemaOptionsData } from '../hooks/use-switch-schema';
+import type { PreviewNativeEnv } from '../preview-native-env';
+import type {
+  PreviewRuntimeComponent,
+  PreviewRuntimeEntry,
+} from '../preview-runtime';
 import { useTreeController } from '../hooks/use-tree-controller';
 import {
   IconCopyLink,
@@ -83,6 +88,12 @@ interface ExampleContentProps {
   fitThresholdScale?: number;
   fitMinScale?: number;
   fit?: 'contain' | 'cover' | 'auto';
+  /** Level A — native environment forwarded to the previewed `<lynx-view>`. */
+  nativeEnv?: PreviewNativeEnv;
+  /** Level B — every previewable entry (with web bundle), for a custom runtime. */
+  webEntries?: PreviewRuntimeEntry[];
+  /** Level B — custom preview runtime replacing the built-in single card. */
+  PreviewRuntime?: PreviewRuntimeComponent;
 }
 
 export function ExampleContent({
@@ -114,8 +125,12 @@ export function ExampleContent({
   fitThresholdScale = 1.0,
   fitMinScale = 0.5,
   fit = 'cover',
+  nativeEnv,
+  webEntries,
+  PreviewRuntime,
 }: ExampleContentProps) {
   const {
+    exampleBasePath,
     explorerUrl,
     explorerText,
     withBase: withBaseFn = (p: string) => p,
@@ -431,16 +446,36 @@ export function ExampleContent({
             >
               <NoSSRComponent>
                 <Suspense fallback={<div>Loading...</div>}>
-                  <WebIframe
-                    show={previewType === PreviewType.Web}
-                    src={defaultWebPreviewFile || ''}
-                    webPreviewMode={webPreviewMode}
-                    designWidth={designWidth}
-                    designHeight={designHeight}
-                    fitThresholdScale={fitThresholdScale}
-                    fitMinScale={fitMinScale}
-                    fit={fit}
-                  />
+                  {PreviewRuntime ? (
+                    <PreviewRuntime
+                      example={name}
+                      exampleBaseUrl={withBaseFn(exampleBasePath)}
+                      entries={webEntries ?? []}
+                      activeEntry={currentEntry}
+                      src={defaultWebPreviewFile || ''}
+                      show={previewType === PreviewType.Web}
+                      nativeEnv={nativeEnv}
+                      webPreviewMode={webPreviewMode}
+                      designWidth={designWidth}
+                      designHeight={designHeight}
+                      fitThresholdScale={fitThresholdScale}
+                      fitMinScale={fitMinScale}
+                      fit={fit}
+                    />
+                  ) : (
+                    <WebIframe
+                      show={previewType === PreviewType.Web}
+                      src={defaultWebPreviewFile || ''}
+                      webPreviewMode={webPreviewMode}
+                      designWidth={designWidth}
+                      designHeight={designHeight}
+                      fitThresholdScale={fitThresholdScale}
+                      fitMinScale={fitMinScale}
+                      fit={fit}
+                      nativeEnv={nativeEnv}
+                      entryName={currentEntry}
+                    />
+                  )}
                 </Suspense>
               </NoSSRComponent>
             </div>

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -9,6 +9,8 @@ import {
   lerpFitScale,
 } from '../utils/fit-scale';
 import { isFinitePositive } from '../utils/number';
+import type { PreviewNativeEnv } from '../preview-native-env';
+import { applyPreviewNativeEnv } from '../preview-native-env';
 import { resolveWebPreviewModeWithHysteresis } from '../utils/resolve-web-preview';
 import type {
   ResolvedWebPreviewFitKind,
@@ -48,6 +50,10 @@ type WebIframeProps = {
   fitThresholdScale?: number;
   fitMinScale?: number;
   fit?: 'contain' | 'cover' | 'auto';
+  /** Level A — native environment forwarded to the `<lynx-view>` before start. */
+  nativeEnv?: PreviewNativeEnv;
+  /** Active entry name, passed to `globalProps`/`initData` factories. */
+  entryName?: string;
 };
 
 type UseWebIframeControllerArgs = {
@@ -460,9 +466,12 @@ export const WebIframe = ({
   fitThresholdScale = 1.0,
   fitMinScale = 0.5,
   fit = 'cover',
+  nativeEnv,
+  entryName = '',
 }: WebIframeProps) => {
   const [lynxView, setLynxView] = useState<LynxView | null>(null);
   const browserConfigInitializedRef = useRef<WeakSet<LynxView>>(new WeakSet());
+  const nativeEnvAppliedRef = useRef<WeakSet<LynxView>>(new WeakSet());
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
@@ -561,9 +570,21 @@ export const WebIframe = ({
     return true;
   }, []);
 
+  // Latest native env, read imperatively from the ref callback (which runs
+  // outside React's render cycle) to avoid stale closures.
+  const nativeEnvArgsRef = useRef({ nativeEnv, entryName });
+  useEffect(() => {
+    nativeEnvArgsRef.current = { nativeEnv, entryName };
+  });
+
   const handleLynxViewRef = useCallback((el: LynxView | null) => {
     setLynxView(el);
     if (!el) return;
+    // Apply Level-A native env before browserConfig. Both are consumed by
+    // web-core inside its async `#render()` microtask (after the iframe realm
+    // resolves), so assignment from this ref lands before the worker reads them.
+    const { nativeEnv: env, entryName: name } = nativeEnvArgsRef.current;
+    applyPreviewNativeEnv(el, env, name, nativeEnvAppliedRef.current);
     tryInitBrowserConfig(el);
   }, []);
 

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -6,6 +6,9 @@ import type { PreviewTab } from '../config';
 import { useGoConfig } from '../config';
 import { ExampleContent } from './components';
 import type { SchemaOptionsData } from './hooks/use-switch-schema';
+import type { PreviewNativeEnv } from './preview-native-env';
+import { mergePreviewNativeEnv } from './preview-native-env';
+import type { PreviewRuntimeEntry } from './preview-runtime';
 import { isAssetFileType } from './utils/example-data';
 import type { WebPreviewMode } from './utils/resolve-web-preview';
 
@@ -70,6 +73,12 @@ export interface ExamplePreviewProps {
    * - `'qrcode'`  — QR code for Lynx Explorer
    */
   defaultTab?: PreviewTab;
+  /**
+   * Level A — native environment for this instance's web preview. Shallow-merged
+   * over the site-wide `GoConfig.previewNativeEnv` (per-instance keys win).
+   * Forwarded to the previewed `<lynx-view>` (and to a custom `PreviewRuntime`).
+   */
+  nativeEnv?: PreviewNativeEnv;
 }
 
 export interface ExampleMetadata {
@@ -91,6 +100,8 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     SSGComponent,
     defaultTab: configDefaultTab,
     withBase: withBaseFn = (p: string) => p,
+    previewNativeEnv,
+    PreviewRuntime,
   } = useGoConfig();
   const EXAMPLE_BASE_URL = withBaseFn(exampleBasePath);
 
@@ -111,6 +122,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     schemaOptions,
     langAlias,
     defaultTab: propsDefaultTab,
+    nativeEnv: propsNativeEnv,
     mode = 'linked',
     webPreviewMode = 'responsive',
     webPreview = true,
@@ -123,6 +135,12 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
 
   // Instance prop > config provider > undefined (let ExampleContent decide)
   const defaultTab = propsDefaultTab ?? configDefaultTab;
+
+  // Level A: per-instance native env merged over the site-wide config.
+  const nativeEnv = useMemo(
+    () => mergePreviewNativeEnv(previewNativeEnv, propsNativeEnv),
+    [previewNativeEnv, propsNativeEnv],
+  );
   const resolvedDefaultTab =
     webPreview === false && defaultTab === 'web' ? undefined : defaultTab;
 
@@ -198,6 +216,21 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     }
     return '';
   }, [exampleData, currentEntry, schema]);
+
+  // Level B: every previewable entry (those with a web bundle), with absolute
+  // web URLs. Fed to a custom `PreviewRuntime` so it can stack cards for MPA.
+  const webEntries = useMemo<PreviewRuntimeEntry[]>(() => {
+    if (!PreviewRuntime || webPreview === false) return [];
+    const origin = typeof window !== 'undefined' ? window.location.origin : '';
+    return (exampleData?.templateFiles ?? [])
+      .filter((file) => Boolean(file.webFile))
+      .map((file) => ({
+        name: file.name,
+        file: file.webFile!,
+        webUrl: `${origin}${EXAMPLE_BASE_URL}/${example}/${file.webFile}`,
+      }));
+  }, [PreviewRuntime, exampleData, EXAMPLE_BASE_URL, example, webPreview]);
+
   useEffect(() => {
     if (exampleData?.templateFiles && exampleData?.templateFiles.length > 0) {
       let tmpEntry;
@@ -280,6 +313,9 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       fitThresholdScale={fitThresholdScale}
       fitMinScale={fitMinScale}
       fit={fit}
+      nativeEnv={nativeEnv}
+      webEntries={webEntries}
+      PreviewRuntime={PreviewRuntime}
     />
   );
 };

--- a/src/example-preview/preview-native-env.ts
+++ b/src/example-preview/preview-native-env.ts
@@ -1,0 +1,161 @@
+/**
+ * Level A — configurable native environment for the previewed `<lynx-view>`.
+ *
+ * go-web stays PRODUCT-AGNOSTIC: it does not know any framework's native module
+ * names or URL scheme. It only forwards a small, generic set of hooks to the
+ * underlying web-core `<lynx-view>` element so an embedder can register a
+ * native-modules bridge, inject per-card `globalProps`/`initData`, and handle
+ * native-module calls made by the previewed bundle.
+ *
+ * All hooks are opt-in. When unset, preview behavior is identical to before.
+ *
+ * The concrete web-core types are DERIVED from `LynxViewElement` so this file
+ * stays correct across web-core versions without importing internal type paths.
+ */
+import type { LynxViewElement } from '@lynx-js/web-core/client';
+
+/** A structured-clone-safe value, as accepted by `<lynx-view>`. */
+export type Cloneable = LynxViewElement['globalProps'];
+
+/**
+ * Handler invoked when the previewed bundle calls a NativeModule.
+ * web-core CACHES calls made before this handler is assigned, so forwarding it
+ * via the element `ref` (after connect) is safe.
+ */
+export type NativeModulesCall = NonNullable<
+  LynxViewElement['onNativeModulesCall']
+>;
+
+/** Map of `module-name -> ESM url`, consumed by the worker at init time. */
+export type NativeModulesMap = NonNullable<LynxViewElement['nativeModulesMap']>;
+
+/** Handler invoked when the previewed bundle calls a NapiModule (advanced). */
+export type NapiModulesCall = NonNullable<LynxViewElement['onNapiModulesCall']>;
+
+/** Map of `module-name -> ESM url` for napi modules (advanced). */
+export type NapiModulesMap = NonNullable<LynxViewElement['napiModulesMap']>;
+
+/**
+ * A `globalProps`/`initData` value: either a static `Cloneable`, or a factory
+ * that derives the value from the entry name (e.g. to inject a per-card
+ * container id or query params). The factory is called once per card, right
+ * before the view starts.
+ */
+export type CloneableInput = Cloneable | ((entryName: string) => Cloneable);
+
+/**
+ * Opt-in native environment forwarded to the previewed `<lynx-view>`.
+ *
+ * Can be set site-wide via `GoConfig.previewNativeEnv` and/or per-instance via
+ * the `nativeEnv` prop on `<Go>` / `<ExamplePreview>`. Per-instance values are
+ * shallow-merged over the site-wide config (see {@link mergePreviewNativeEnv}).
+ */
+export interface PreviewNativeEnv {
+  /**
+   * Handler for NativeModules calls made by the previewed bundle. Forwarded to
+   * `<lynx-view>.onNativeModulesCall`. Late assignment is safe (web-core caches
+   * pre-assignment calls).
+   */
+  onNativeModulesCall?: NativeModulesCall;
+  /**
+   * Native-modules DEFINITION: `module-name -> ESM url`. Forwarded to
+   * `<lynx-view>.nativeModulesMap`. Read by the worker at init, so it is applied
+   * before the view starts.
+   */
+  nativeModulesMap?: NativeModulesMap;
+  /** Napi-modules definition: `module-name -> ESM url` (advanced). */
+  napiModulesMap?: NapiModulesMap;
+  /** Handler for NapiModules calls made by the previewed bundle (advanced). */
+  onNapiModulesCall?: NapiModulesCall;
+  /**
+   * Per-card `globalProps`: a static `Cloneable` or a `(entryName) => Cloneable`
+   * factory. Read by web-core when the view starts.
+   */
+  globalProps?: CloneableInput;
+  /**
+   * Per-card `initData`: a static `Cloneable` or a `(entryName) => Cloneable`
+   * factory. Read by web-core when the view starts.
+   */
+  initData?: CloneableInput;
+}
+
+/**
+ * Resolve a {@link CloneableInput} to a concrete `Cloneable` for a given entry.
+ * A function input is invoked with `entryName`; anything else is returned as-is.
+ */
+export function resolveCloneableInput(
+  input: CloneableInput | undefined,
+  entryName: string,
+): Cloneable | undefined {
+  if (typeof input === 'function') {
+    return input(entryName);
+  }
+  return input;
+}
+
+/**
+ * Shallow-merge a per-instance native env over a site-wide one. Per-instance
+ * keys win; a key that is present but `undefined` does not override the base.
+ * Returns `undefined` when both inputs are absent, so the default (unset) path
+ * is preserved.
+ */
+export function mergePreviewNativeEnv(
+  base: PreviewNativeEnv | undefined,
+  override: PreviewNativeEnv | undefined,
+): PreviewNativeEnv | undefined {
+  if (!base) return override;
+  if (!override) return base;
+  const merged: PreviewNativeEnv = { ...base };
+  for (const key of Object.keys(override) as (keyof PreviewNativeEnv)[]) {
+    const value = override[key];
+    if (value !== undefined) {
+      // Each key is independently typed; the assignment is safe per-key.
+      (merged as Record<string, unknown>)[key] = value;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Imperatively apply a resolved native env to a `<lynx-view>` element for a
+ * given entry. Idempotent per element+env via the provided `applied` guard set.
+ *
+ * ORDERING: web-core reads `nativeModulesMap` / `napiModulesMap` / `globalProps`
+ * / `initData` asynchronously inside its `#render()` microtask (after awaiting
+ * the iframe realm), so assigning them from the element `ref` — as done here and
+ * as the existing `browserConfig` init already does — happens before the worker
+ * consumes them. `onNativeModulesCall` / `onNapiModulesCall` are additionally
+ * safe to assign late because web-core caches pre-assignment calls.
+ */
+export function applyPreviewNativeEnv(
+  el: LynxViewElement,
+  env: PreviewNativeEnv | undefined,
+  entryName: string,
+  applied: WeakSet<LynxViewElement>,
+): void {
+  if (!env) return;
+  if (applied.has(el)) return;
+  applied.add(el);
+
+  // Worker-init values first, before any late handler assignment.
+  if (env.nativeModulesMap !== undefined) {
+    el.nativeModulesMap = env.nativeModulesMap;
+  }
+  if (env.napiModulesMap !== undefined) {
+    el.napiModulesMap = env.napiModulesMap;
+  }
+  const globalProps = resolveCloneableInput(env.globalProps, entryName);
+  if (globalProps !== undefined) {
+    el.globalProps = globalProps;
+  }
+  const initData = resolveCloneableInput(env.initData, entryName);
+  if (initData !== undefined) {
+    el.initData = initData;
+  }
+  if (env.onNativeModulesCall !== undefined) {
+    el.onNativeModulesCall = env.onNativeModulesCall;
+  }
+  if (env.onNapiModulesCall !== undefined) {
+    el.onNapiModulesCall = env.onNapiModulesCall;
+  }
+}

--- a/src/example-preview/preview-runtime.ts
+++ b/src/example-preview/preview-runtime.ts
@@ -1,0 +1,83 @@
+/**
+ * Level B — pluggable preview runtime.
+ *
+ * The built-in web preview renders exactly ONE `<lynx-view>` (see
+ * `components/web-iframe.tsx`), which cannot demonstrate multi-page (MPA)
+ * examples: cross-page navigation has no second card to navigate to.
+ *
+ * A `PreviewRuntime` lets an embedder REPLACE just the inner card renderer so it
+ * can stack multiple `<lynx-view>` cards and route navigation between them,
+ * while go-web keeps owning the tab bar, QR, code browser, fit/scaling, and the
+ * SSG path. The runtime receives every previewable entry plus the resolved
+ * Level-A native environment.
+ *
+ * ── Two usage shapes, one hook ──────────────────────────────────────────────
+ * This single component slot supports BOTH designs discussed for MPA:
+ *
+ *   B1) In-process card stack. The runtime keeps a stack of `<lynx-view>`
+ *       elements in React state and pushes/pops on native navigation calls
+ *       (`router.open` / `back`). Navigation state lives in the component, so no
+ *       `window.history` pollution and the first card's heap stays intact.
+ *
+ *   B2) Iframe runtime. The runtime renders a real
+ *       `<iframe src={embedderRuntimeUrl}>` and passes `entries` via the query
+ *       string / `postMessage`. Because an iframe is a real nested browsing
+ *       context, `window.history` and navigation are naturally scoped to it —
+ *       the web's native "separate document" model. This is ideal for embedders
+ *       (e.g. a full-page "web shell") that already assemble stacked lynx-views
+ *       + native bridge + globalProps and want to plug that page in as-is.
+ *
+ * go-web recommends B1 as the default (no cross-origin handshake, type-safe
+ * composition, reuses go-web scaling) and treats B2 as an escape hatch that is
+ * trivially expressible as a `PreviewRuntime` that renders an `<iframe>`.
+ */
+import type { ComponentType } from 'react';
+import type { PreviewNativeEnv } from './preview-native-env';
+import type { WebPreviewMode } from './utils/resolve-web-preview';
+
+/** A single previewable entry (an example bundle with a web build). */
+export interface PreviewRuntimeEntry {
+  /** Entry name (`templateFiles[].name` from example-metadata.json). */
+  name: string;
+  /** Absolute URL of the web bundle for this entry. */
+  webUrl: string;
+  /** Source bundle path relative to the example root (`templateFiles[].file`). */
+  file: string;
+}
+
+/**
+ * Props passed to a custom `PreviewRuntime`. go-web resolves all example data,
+ * scaling parameters, and the native environment, then hands them over. A
+ * runtime is only responsible for rendering (and, for MPA, routing between)
+ * `<lynx-view>` cards inside the box go-web gives it.
+ */
+export interface PreviewRuntimeProps {
+  /** Example folder name (under `exampleBasePath`). */
+  example: string;
+  /** Base URL where this example's assets live. */
+  exampleBaseUrl: string;
+  /** Every previewable entry (those with a `webFile`), in metadata order. */
+  entries: PreviewRuntimeEntry[];
+  /** Currently active entry name (driven by the entry selector). */
+  activeEntry: string;
+  /**
+   * Web bundle URL of the active entry — the same URL the built-in single-card
+   * preview would render. Convenience for runtimes that only need the root card.
+   */
+  src: string;
+  /** Whether the Web preview tab is currently visible. */
+  show: boolean;
+  /** Resolved Level-A native environment (may be `undefined`). */
+  nativeEnv?: PreviewNativeEnv;
+
+  // ── Scaling / fit parameters, forwarded so runtimes can match go-web ──
+  webPreviewMode: WebPreviewMode;
+  designWidth: number;
+  designHeight: number;
+  fitThresholdScale: number;
+  fitMinScale: number;
+  fit: 'contain' | 'cover' | 'auto';
+}
+
+/** A custom preview runtime component (the `GoConfig.PreviewRuntime` slot). */
+export type PreviewRuntimeComponent = ComponentType<PreviewRuntimeProps>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,26 @@ export { ExamplePreview, type ExamplePreviewProps } from './example-preview';
 export type { ExampleMetadata } from './example-preview';
 export { getFileCodeLanguage } from './example-preview/utils/example-data';
 export { Go, type GoProps } from './Go';
+
+// Level A — configurable native environment for the previewed <lynx-view>.
+export {
+  resolveCloneableInput,
+  mergePreviewNativeEnv,
+  applyPreviewNativeEnv,
+} from './example-preview/preview-native-env';
+export type {
+  PreviewNativeEnv,
+  CloneableInput,
+  Cloneable,
+  NativeModulesCall,
+  NativeModulesMap,
+  NapiModulesCall,
+  NapiModulesMap,
+} from './example-preview/preview-native-env';
+
+// Level B — pluggable preview runtime for multi-page (MPA) examples.
+export type {
+  PreviewRuntimeComponent,
+  PreviewRuntimeProps,
+  PreviewRuntimeEntry,
+} from './example-preview/preview-runtime';

--- a/test/browser/run.mjs
+++ b/test/browser/run.mjs
@@ -1,0 +1,224 @@
+/**
+ * Real-browser integration test for the preview extension points.
+ *
+ * Unlike test/*.test.ts (which run in Node against a faithful `<lynx-view>`
+ * FAKE), this drives the built example app in headless Chromium against the
+ * REAL `@lynx-js/web-core` runtime. It verifies, end to end:
+ *
+ *   Default   — the built-in preview boots exactly one real <lynx-view>
+ *               (no regression when the new hooks are unset).
+ *   Level A   — with `previewNativeEnv` set, the real <lynx-view> actually
+ *               receives our `nativeModulesMap` / `globalProps` /
+ *               `onNativeModulesCall` and boots.
+ *   Level B   — with `PreviewRuntime` set, invoking the view's
+ *               `onNativeModulesCall('open', …)` — exactly what a native-calling
+ *               bundle does — pushes a SECOND real <lynx-view> that also boots,
+ *               and Back pops it, leaving the ORIGINAL root element (same DOM
+ *               node ⇒ heap/state intact).
+ *
+ * Prereq: `cd example && pnpm install && pnpm build` (serves example/dist).
+ * Run:    `pnpm test:browser`
+ *
+ * This is intentionally NOT part of `pnpm test` / CI: it needs the example
+ * built and a Chromium binary. It is the layer that a native-module fixture or
+ * the downstream MPA bundle would slot into for literal acceptance.
+ */
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, '../../example/dist');
+const EXAMPLE = 'vue-vue-router'; // has a real dist/main.web.bundle
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+  '.bundle': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.map': 'application/json',
+};
+
+function findChromium() {
+  try {
+    const p = chromium.executablePath();
+    if (p && fs.existsSync(p)) return p;
+  } catch {}
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH || '/opt/pw-browsers';
+  const dirs = fs.existsSync(root) ? fs.readdirSync(root) : [];
+  for (const d of dirs.filter((d) => /^chromium-\d/.test(d))) {
+    const candidate = path.join(root, d, 'chrome-linux', 'chrome');
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return undefined; // let Playwright try its default
+}
+
+function startServer() {
+  const server = http.createServer((req, res) => {
+    let p = decodeURIComponent(req.url.split('?')[0]);
+    if (p === '/') p = '/index.html';
+    let file = path.join(DIST, p);
+    if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) {
+      file = path.join(DIST, 'index.html');
+    }
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    res.setHeader(
+      'Content-Type',
+      MIME[path.extname(file)] || 'application/octet-stream',
+    );
+    fs.createReadStream(file).pipe(res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => resolve({ server, port: server.address().port }));
+  });
+}
+
+// Desktop preview only (the app also renders a mobile clone under .mobile-preview).
+const DESKTOP_VIEWS = `Array.from(document.querySelectorAll('lynx-view')).filter((v) => !v.closest('.mobile-preview'))`;
+
+const results = [];
+function check(name, cond, detail = '') {
+  results.push({ name, ok: !!cond, detail });
+  console.log(
+    `${cond ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`,
+  );
+}
+
+async function waitForBooted(page, n, timeout = 25000) {
+  await page.waitForFunction(
+    ([expr, n]) =>
+      eval(expr).filter(
+        (v) => v.shadowRoot && v.shadowRoot.childNodes.length > 0,
+      ).length === n,
+    [DESKTOP_VIEWS, n],
+    { timeout },
+  );
+}
+
+async function clickPreview(page, label) {
+  await page.evaluate((label) => {
+    const btn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent.trim() === label,
+    );
+    if (!btn) throw new Error(`preview toggle "${label}" not found`);
+    btn.click();
+  }, label);
+}
+
+async function main() {
+  if (!fs.existsSync(path.join(DIST, 'index.html'))) {
+    console.error(`example/dist not found. Run: cd example && pnpm build`);
+    process.exit(2);
+  }
+
+  const { server, port } = await startServer();
+  const base = `http://127.0.0.1:${port}`;
+  const browser = await chromium.launch({ executablePath: findChromium() });
+  const page = await browser.newPage({
+    viewport: { width: 1280, height: 800 },
+  });
+  page.on('pageerror', (e) => console.log('[pageerror]', e.message));
+
+  try {
+    const hash = encodeURIComponent(
+      JSON.stringify({ example: EXAMPLE, tab: 'web', mode: 'preview' }),
+    );
+    await page.goto(`${base}/#${hash}`, { waitUntil: 'load' });
+
+    // ── Default: one real <lynx-view> boots (unchanged behavior) ──
+    await waitForBooted(page, 1);
+    check('default: exactly one real <lynx-view> boots', true);
+
+    // ── Level A: native env reaches the real element and it boots ──
+    await clickPreview(page, 'Native');
+    await waitForBooted(page, 1);
+    const envApplied = await page.evaluate((expr) => {
+      const v = eval(expr)[0];
+      return {
+        hasMap: !!(v.nativeModulesMap && v.nativeModulesMap.DemoModule),
+        hasHandler: typeof v.onNativeModulesCall === 'function',
+        containerId:
+          v.globalProps && typeof v.globalProps === 'object'
+            ? v.globalProps.containerId
+            : undefined,
+      };
+    }, DESKTOP_VIEWS);
+    check(
+      'level A: real <lynx-view> received nativeModulesMap + handler + globalProps',
+      envApplied.hasMap &&
+        envApplied.hasHandler &&
+        typeof envApplied.containerId === 'string',
+      JSON.stringify(envApplied),
+    );
+
+    // ── Level B: a native "open" pushes a 2nd real card; Back pops it ──
+    await clickPreview(page, 'MPA');
+    await waitForBooted(page, 1);
+    const rootId = await page.evaluate((expr) => {
+      const v = eval(expr)[0];
+      v.dataset.testid = 'root-card';
+      return v.getAttribute('url');
+    }, DESKTOP_VIEWS);
+
+    // A native-calling bundle would invoke this; we invoke it at the same
+    // integration boundary (the view's onNativeModulesCall).
+    await page.evaluate((expr) => {
+      const v = eval(expr)[0];
+      v.onNativeModulesCall('open', { entry: 'main' }, 'Router');
+    }, DESKTOP_VIEWS);
+
+    await waitForBooted(page, 2);
+    check('level B: opening pushes a second real <lynx-view> that boots', true);
+
+    const backClicked = await page.evaluate(() => {
+      const btn = Array.from(
+        document.querySelectorAll('button[aria-label="Back"]'),
+      ).find((b) => !b.closest('.mobile-preview'));
+      if (!btn) return false;
+      btn.click();
+      return true;
+    });
+    check('level B: Back control is present while stacked', backClicked);
+
+    await waitForBooted(page, 1);
+    const rootIntact = await page.evaluate(
+      ([expr, expectedUrl]) => {
+        const views = eval(expr);
+        return (
+          views.length === 1 &&
+          views[0].dataset.testid === 'root-card' &&
+          views[0].getAttribute('url') === expectedUrl
+        );
+      },
+      [DESKTOP_VIEWS, rootId],
+    );
+    check(
+      'level B: Back returns to the original root element (state intact)',
+      rootIntact,
+      `root url ${rootId}`,
+    );
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(
+    `\n${results.length - failed.length}/${results.length} checks passed`,
+  );
+  process.exit(failed.length ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/mpa-card-stack.test.ts
+++ b/test/mpa-card-stack.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activeCard,
+  cardStackReducer,
+  createInitialStack,
+  type PreviewCard,
+} from '../example/src/mpa/card-stack';
+import { resolveDemoNavIntent } from '../example/src/mpa/nav-intent';
+import type { PreviewRuntimeEntry } from '../src/example-preview/preview-runtime';
+
+const root: PreviewCard = { id: 'root#1', entryName: 'home', src: 'home.web' };
+const second: PreviewCard = {
+  id: 'second#2',
+  entryName: 'details',
+  src: 'details.web',
+};
+
+const entries: PreviewRuntimeEntry[] = [
+  { name: 'home', file: 'home.web.bundle', webUrl: 'home.web' },
+  { name: 'details', file: 'details.web.bundle', webUrl: 'details.web' },
+];
+
+describe('cardStackReducer', () => {
+  it('starts with a single root card', () => {
+    const s = createInitialStack(root);
+    expect(s.cards).toHaveLength(1);
+    expect(activeCard(s)).toBe(root);
+  });
+
+  it('push opens a card on top; back pops it', () => {
+    let s = createInitialStack(root);
+    s = cardStackReducer(s, { type: 'push', card: second });
+    expect(s.cards).toHaveLength(2);
+    expect(activeCard(s)).toBe(second);
+
+    s = cardStackReducer(s, { type: 'back' });
+    expect(s.cards).toHaveLength(1);
+    expect(activeCard(s)).toBe(root);
+  });
+
+  it('back on the root is a no-op — the root is never unmounted', () => {
+    const s = createInitialStack(root);
+    const after = cardStackReducer(s, { type: 'back' });
+    expect(after.cards).toHaveLength(1);
+    expect(activeCard(after)).toBe(root);
+  });
+
+  it('opening a second card and going back keeps the first card intact', () => {
+    // Acceptance (Level B): "a multi-page example opens a second card and back
+    // returns to the first with its state intact."
+    let s = createInitialStack(root);
+    s = cardStackReducer(s, { type: 'push', card: second });
+    s = cardStackReducer(s, { type: 'back' });
+    // Identity preserved => the root <lynx-view> keeps its React key and heap,
+    // so its runtime state survives the round-trip.
+    expect(activeCard(s)).toBe(root);
+    expect(s.cards[0]).toBe(root);
+  });
+
+  it('reset replaces the stack with a fresh root', () => {
+    let s = createInitialStack(root);
+    s = cardStackReducer(s, { type: 'push', card: second });
+    s = cardStackReducer(s, { type: 'reset', root: second });
+    expect(s.cards).toEqual([second]);
+  });
+});
+
+describe('resolveDemoNavIntent (embedder navigation convention)', () => {
+  it('maps an "open" call with an entry name to a push intent', () => {
+    const intent = resolveDemoNavIntent('open', { entry: 'details' }, entries);
+    expect(intent).toEqual({ type: 'push', entry: entries[1] });
+  });
+
+  it('maps an "open" call with a url to a push intent', () => {
+    const intent = resolveDemoNavIntent(
+      'open',
+      { url: 'details.web' },
+      entries,
+    );
+    expect(intent).toEqual({ type: 'push', entry: entries[1] });
+  });
+
+  it('maps a "back" call to a back intent', () => {
+    expect(resolveDemoNavIntent('back', undefined, entries)).toEqual({
+      type: 'back',
+    });
+  });
+
+  it('returns null for non-navigation calls (delegated to the embedder)', () => {
+    expect(resolveDemoNavIntent('ping', { msg: 'hi' }, entries)).toBeNull();
+  });
+
+  it('end-to-end: an open intent drives a push that a back reverses', () => {
+    let s = createInitialStack(root);
+    const open = resolveDemoNavIntent('open', { entry: 'details' }, entries);
+    expect(open?.type).toBe('push');
+    if (open?.type === 'push') {
+      s = cardStackReducer(s, {
+        type: 'push',
+        card: {
+          id: 'details#9',
+          entryName: open.entry.name,
+          src: open.entry.webUrl,
+        },
+      });
+    }
+    expect(activeCard(s)?.entryName).toBe('details');
+
+    const back = resolveDemoNavIntent('back', null, entries);
+    expect(back).toEqual({ type: 'back' });
+    s = cardStackReducer(s, { type: 'back' });
+    expect(activeCard(s)).toBe(root);
+  });
+});

--- a/test/preview-native-env.test.ts
+++ b/test/preview-native-env.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LynxViewElement } from '@lynx-js/web-core/client';
+import {
+  applyPreviewNativeEnv,
+  mergePreviewNativeEnv,
+  resolveCloneableInput,
+  type NativeModulesCall,
+  type PreviewNativeEnv,
+} from '../src/example-preview/preview-native-env';
+
+/**
+ * A faithful fake of the web-core `<lynx-view>` contract that matters for
+ * Level A:
+ *  - `nativeModulesMap` / `globalProps` / `initData` are read when the view
+ *    STARTS (we snapshot them in `start()`), so they must be set beforehand.
+ *  - native-module calls made BEFORE `onNativeModulesCall` is assigned are
+ *    CACHED and flushed once the handler is set (late assignment is safe).
+ */
+class FakeLynxView {
+  nativeModulesMap: Record<string, string> | undefined;
+  napiModulesMap: Record<string, string> | undefined;
+  onNapiModulesCall: ((...a: unknown[]) => unknown) | undefined;
+
+  #globalProps: unknown = {};
+  #initData: unknown = {};
+  #handler: NativeModulesCall | undefined;
+  #pending: Array<{
+    name: string;
+    data: unknown;
+    moduleName: string;
+    resolve: (v: unknown) => void;
+  }> = [];
+
+  startSnapshot: {
+    globalProps: unknown;
+    initData: unknown;
+    nativeModulesMap: Record<string, string> | undefined;
+  } | null = null;
+
+  get globalProps() {
+    return this.#globalProps;
+  }
+  set globalProps(v: unknown) {
+    this.#globalProps = v;
+  }
+  get initData() {
+    return this.#initData;
+  }
+  set initData(v: unknown) {
+    this.#initData = v;
+  }
+
+  get onNativeModulesCall() {
+    return this.#handler;
+  }
+  set onNativeModulesCall(handler: NativeModulesCall | undefined) {
+    this.#handler = handler;
+    // Flush cached calls, mirroring web-core's caching behavior.
+    const pending = this.#pending;
+    this.#pending = [];
+    for (const call of pending) {
+      call.resolve(handler?.(call.name, call.data, call.moduleName));
+    }
+  }
+
+  /** Simulate the previewed bundle invoking a NativeModule method. */
+  callNativeModule(name: string, data: unknown, moduleName: string) {
+    if (this.#handler) {
+      return Promise.resolve(this.#handler(name, data, moduleName));
+    }
+    return new Promise((resolve) => {
+      this.#pending.push({ name, data, moduleName, resolve });
+    });
+  }
+
+  /** Simulate web-core reading start-time properties when the view boots. */
+  start() {
+    this.startSnapshot = {
+      globalProps: this.#globalProps,
+      initData: this.#initData,
+      nativeModulesMap: this.nativeModulesMap,
+    };
+  }
+}
+
+function makeView() {
+  return new FakeLynxView() as unknown as LynxViewElement & FakeLynxView;
+}
+
+describe('resolveCloneableInput', () => {
+  it('returns a static value unchanged', () => {
+    expect(resolveCloneableInput({ a: 1 }, 'entry')).toEqual({ a: 1 });
+  });
+  it('invokes a factory with the entry name', () => {
+    const factory = (name: string) => ({ containerId: `c:${name}` });
+    expect(resolveCloneableInput(factory, 'second')).toEqual({
+      containerId: 'c:second',
+    });
+  });
+  it('passes through undefined', () => {
+    expect(resolveCloneableInput(undefined, 'x')).toBeUndefined();
+  });
+});
+
+describe('mergePreviewNativeEnv', () => {
+  it('returns undefined when both are unset (default path preserved)', () => {
+    expect(mergePreviewNativeEnv(undefined, undefined)).toBeUndefined();
+  });
+  it('per-instance keys win; present-but-undefined does not clobber base', () => {
+    const base: PreviewNativeEnv = {
+      nativeModulesMap: { A: 'a.js' },
+      globalProps: { from: 'base' },
+    };
+    const override: PreviewNativeEnv = {
+      globalProps: { from: 'override' },
+      nativeModulesMap: undefined,
+    };
+    const merged = mergePreviewNativeEnv(base, override);
+    expect(merged?.nativeModulesMap).toEqual({ A: 'a.js' });
+    expect(merged?.globalProps).toEqual({ from: 'override' });
+  });
+});
+
+describe('applyPreviewNativeEnv', () => {
+  it('is a no-op when env is undefined (default behavior unchanged)', () => {
+    const view = makeView();
+    applyPreviewNativeEnv(view, undefined, 'entry', new WeakSet());
+    view.start();
+    expect(view.startSnapshot?.nativeModulesMap).toBeUndefined();
+    expect(view.startSnapshot?.globalProps).toEqual({});
+  });
+
+  it('sets worker-init values before the view starts', () => {
+    const view = makeView();
+    const env: PreviewNativeEnv = {
+      nativeModulesMap: { DemoModule: 'demo.js' },
+      globalProps: (entryName) => ({ containerId: `go:${entryName}` }),
+      initData: { seeded: true },
+    };
+    applyPreviewNativeEnv(view, env, 'second', new WeakSet());
+    // The view boots after ref assignment.
+    view.start();
+    expect(view.startSnapshot).toEqual({
+      nativeModulesMap: { DemoModule: 'demo.js' },
+      globalProps: { containerId: 'go:second' },
+      initData: { seeded: true },
+    });
+  });
+
+  it('applies once per element (idempotent via the guard set)', () => {
+    const view = makeView();
+    const guard = new WeakSet<LynxViewElement>();
+    applyPreviewNativeEnv(view, { globalProps: { v: 1 } }, 'e', guard);
+    // A second call with different values must not re-apply.
+    applyPreviewNativeEnv(view, { globalProps: { v: 2 } }, 'e', guard);
+    view.start();
+    expect(view.startSnapshot?.globalProps).toEqual({ v: 1 });
+  });
+
+  it('delivers native-module calls to the handler, incl. calls cached before assignment', async () => {
+    const view = makeView();
+    const handler = vi.fn<NativeModulesCall>((name, data) =>
+      name === 'ping' ? { ok: true, echo: data } : undefined,
+    );
+
+    // A call made BEFORE the env is applied is cached by the fake view.
+    const early = view.callNativeModule('ping', 'hello', 'DemoModule');
+
+    applyPreviewNativeEnv(
+      view,
+      { onNativeModulesCall: handler },
+      'entry',
+      new WeakSet(),
+    );
+
+    // Cached call is flushed and routed to the embedder's handler.
+    await expect(early).resolves.toEqual({ ok: true, echo: 'hello' });
+
+    // A later call routes straight through.
+    const late = await view.callNativeModule('ping', 'again', 'DemoModule');
+    expect(late).toEqual({ ok: true, echo: 'again' });
+    expect(handler).toHaveBeenCalledWith('ping', 'hello', 'DemoModule');
+    expect(handler).toHaveBeenCalledWith('ping', 'again', 'DemoModule');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Pure-logic tests (no DOM). Faithful fakes stand in for `<lynx-view>`.
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

The web preview renders a single `<lynx-view>` (`components/web-iframe.tsx`) with **no** way to register a native-modules bridge, inject per-card `globalProps`, or stack cards. So any example whose bundle calls a native module fails at runtime (`Native module … is not registered`), and multi-page (MPA) examples can't be demonstrated — cross-page navigation has no second card to go to.

This PR adds two **opt-in, product-agnostic** extension points. go-web hard-codes **no** framework module names or URL scheme; it only provides generic hooks. **When unset, the preview is byte-for-byte identical to today.**

## web-core API confirmed (pinned `@lynx-js/web-core@0.20.3`)

`<lynx-view>` (`LynxViewElement`) exposes: `onNativeModulesCall` (setter; runtime **caches** calls made before assignment), `nativeModulesMap` (`module-name → ESM url`, read at worker init), `napiModulesMap` / `onNapiModulesCall`, and `globalProps` / `initData`. Crucially, `#render()` reads `nativeModulesMap`/`globalProps`/`initData` **asynchronously** inside a `queueMicrotask` after `await`-ing the iframe realm — so assigning them from the element `ref` (exactly the path the existing `browserConfig` init already uses) lands **before** web-core consumes them. Types are **derived from `LynxViewElement`** so they stay correct across web-core versions.

## Level A — native environment (required)

New `GoConfig.previewNativeEnv` and per-instance `nativeEnv` prop (shallow-merged, per-instance wins) forward a generic env to the previewed view:

| Field | Purpose |
| --- | --- |
| `onNativeModulesCall` | receive NativeModule calls (late assignment safe — web-core caches) |
| `nativeModulesMap` | `module-name → ESM url` definition (applied before start) |
| `napiModulesMap` / `onNapiModulesCall` | napi equivalents (advanced) |
| `globalProps` / `initData` | `Cloneable` **or** `(entryName) => Cloneable` factory |

## Level B — pluggable preview runtime

New `GoConfig.PreviewRuntime` **replaces just the inner card renderer** — go-web keeps owning the tab bar, QR, code browser, fit/scaling, and SSG path. The component receives every previewable `entry` (with absolute web URLs) plus the resolved native env.

### A/B design tradeoff (evaluated both, recommending B1)

**One hook covers both MPA shapes:**

- **B1 — in-process card stack (✅ recommended default).** Keep a stack of `<lynx-view>` cards in React state; push on navigate, pop on `back`. Lower cards stay mounted (stable React key) so their heap **and state survive** the round-trip. No cross-origin/postMessage handshake, type-safe composition, reuses go-web scaling.
- **B2 — iframe runtime (escape hatch).** A `PreviewRuntime` that renders `<iframe src={runtimeUrl}>` and passes entries via query/`postMessage`. An iframe is a real nested browsing context, so `window.history`/navigation are naturally scoped to it — ideal for an embedder that already has a full-page "web shell". B2 is simply *one implementation* of the same `PreviewRuntime` hook, so go-web ships a single generic slot rather than two APIs.

Recommendation: **B1** as the built-in default (simpler, in-process, satisfies the acceptance test via an in-memory stack); **B2** documented as the escape hatch for embedders with an existing full-page shell.

## Demo + tests

- `example/src/mpa/` — a runnable **B1 prototype** (`StackedPreviewRuntime.tsx` + framework-agnostic `card-stack.ts` + demo-side `nav-intent.ts`) and `demo-native-env.ts` (Level A: `onNativeModulesCall` + `nativeModulesMap` + a `globalProps` factory). Wired into the example app behind an opt-in **Preview** toggle (`Default` / `Native` / `MPA`) — default is unchanged.
- **Vitest** (new) with 19 tests:
  - Level A — `resolveCloneableInput`, `mergePreviewNativeEnv`, and `applyPreviewNativeEnv` against a faithful `<lynx-view>` fake: worker-init values set before start, idempotency, and a native call (incl. one **cached before** handler assignment) delivered to the embedder's handler.
  - Level B — `cardStackReducer` + `resolveDemoNavIntent`: opening a second card and `back` returns to the first **with its state intact** (root card identity preserved).

## Compatibility & checks

- Backwards compatible; opt-in; default preview identical to today (verified: `nativeEnv` unset ⇒ no-op; `PreviewRuntime` unset ⇒ built-in `WebIframe`). SSG path preserved.
- Local: `pnpm format:check` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (19) · example `tsc --noEmit` ✅ · `pnpm build` ✅. Added a **Unit Test** CI job.

## Public API additions

`GoConfig.previewNativeEnv`, `GoConfig.PreviewRuntime`, `GoProps.nativeEnv`; exported `PreviewNativeEnv`, `CloneableInput`, `Cloneable`, `NativeModulesCall/Map`, `NapiModulesCall/Map`, `PreviewRuntimeComponent/Props/Entry`, and helpers `resolveCloneableInput` / `mergePreviewNativeEnv` / `applyPreviewNativeEnv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnnSHyr2e9qXzWHZSCSMVx)_