### PR TITLE
Add Lynx web preview refresh button

### DIFF
--- a/src/example-preview/components/index.module.scss
+++ b/src/example-preview/components/index.module.scss
@@ -126,6 +126,10 @@
       padding: 0 4px;
       flex-shrink: 0;
       border-bottom: 1px solid var(--semi-color-border);
+      .preview-header-action {
+        width: 24px;
+        flex-shrink: 0;
+      }
       :global {
         .semi-radioGroup.semi-radioGroup-buttonRadio {
           background: transparent !important;

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -284,11 +284,17 @@ export function ExampleContent({
               <Button
                 theme="borderless"
                 icon={
-                  <IconRefresh style={{ color: 'var(--semi-color-text-2)' }} />
+                  <IconRefresh
+                    style={{
+                      color: 'var(--semi-color-text-2)',
+                      fontSize: '16px',
+                    }}
+                  />
                 }
                 type="tertiary"
                 size="small"
                 aria-label="Reload Lynx bundle"
+                style={{ width: 24, height: 24, padding: 0 }}
                 onClick={() => setWebPreviewRevision((v) => v + 1)}
               />
             )}

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -1,4 +1,8 @@
-import { IconChevronRightStroked, IconList } from '@douyinfe/semi-icons';
+import {
+  IconChevronRightStroked,
+  IconList,
+  IconRefresh,
+} from '@douyinfe/semi-icons';
 import {
   Button,
   Radio,
@@ -148,6 +152,8 @@ export function ExampleContent({
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
+  const [webPreviewRevision, setWebPreviewRevision] = useState(0);
+
   const [previewType, setPreviewType] = useState(() => {
     if (defaultTab === 'preview' && previewImage) return PreviewType.Preview;
     if (defaultTab === 'qrcode') return PreviewType.QRCode;
@@ -273,7 +279,20 @@ export function ExampleContent({
     <div className={s['preview-wrap']}>
       <div className={s['preview-wrap-content']}>
         <div className={s['preview-header']}>
-          <div style={{ width: 24, flexShrink: 0 }} />
+          <div className={s['preview-header-action']}>
+            {hasWebPreview && previewType === PreviewType.Web && (
+              <Button
+                theme="borderless"
+                icon={
+                  <IconRefresh style={{ color: 'var(--semi-color-text-2)' }} />
+                }
+                type="tertiary"
+                size="small"
+                aria-label="Reload Lynx bundle"
+                onClick={() => setWebPreviewRevision((v) => v + 1)}
+              />
+            )}
+          </div>
           <RadioGroup
             onChange={(e) => setPreviewType(e.target.value)}
             value={previewType}
@@ -434,6 +453,7 @@ export function ExampleContent({
                   <WebIframe
                     show={previewType === PreviewType.Web}
                     src={defaultWebPreviewFile || ''}
+                    reloadKey={webPreviewRevision}
                     webPreviewMode={webPreviewMode}
                     designWidth={designWidth}
                     designHeight={designHeight}

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,6 +1,6 @@
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useContainerResize } from '../hooks/use-container-resize';
 import {
@@ -48,11 +48,13 @@ type WebIframeProps = {
   fitThresholdScale?: number;
   fitMinScale?: number;
   fit?: 'contain' | 'cover' | 'auto';
+  reloadKey?: number;
 };
 
 type UseWebIframeControllerArgs = {
   src: string;
   lynxView: LynxView | null;
+  reloadKey: number;
 };
 
 type UseWebIframeControllerResult = {
@@ -179,6 +181,7 @@ function formatLynxErrorMessage(value: unknown): string | null {
 function useWebIframeController({
   src,
   lynxView,
+  reloadKey,
 }: UseWebIframeControllerArgs): UseWebIframeControllerResult {
   const [ready, setReady] = useState(false);
   const [started, setStarted] = useState(false);
@@ -192,7 +195,7 @@ function useWebIframeController({
     setStarted(false);
     setPreviewError(null);
     startedRef.current = false;
-  }, [src]);
+  }, [src, reloadKey]);
 
   // Load web-core eagerly on mount
   useEffect(() => {
@@ -247,7 +250,7 @@ function useWebIframeController({
     return () => {
       clearTimeout(t);
     };
-  }, [ready, src, lynxView]);
+  }, [ready, src, lynxView, reloadKey]);
 
   useEffect(() => {
     if (!lynxView) return;
@@ -460,6 +463,7 @@ export const WebIframe = ({
   fitThresholdScale = 1.0,
   fitMinScale = 0.5,
   fit = 'cover',
+  reloadKey = 0,
 }: WebIframeProps) => {
   const [lynxView, setLynxView] = useState<LynxView | null>(null);
   const browserConfigInitializedRef = useRef<WeakSet<LynxView>>(new WeakSet());
@@ -580,9 +584,16 @@ export const WebIframe = ({
     tryInitBrowserConfig,
   ]);
 
+  const resolvedSrc = useMemo(() => {
+    if (!src || reloadKey === 0) return src;
+    const separator = src.includes('?') ? '&' : '?';
+    return `${src}${separator}goWebReload=${reloadKey}`;
+  }, [src, reloadKey]);
+
   const { ready, started, error } = useWebIframeController({
-    src,
+    src: resolvedSrc,
     lynxView,
+    reloadKey,
   });
 
   // `webPreviewMode='responsive'` resolves to `usesFitPath === false`,
@@ -619,11 +630,11 @@ export const WebIframe = ({
 
   const loading = show && (!ready || !started || !!error);
 
-  const lynxViewNode = ready && src && (
+  const lynxViewNode = ready && resolvedSrc && (
     <lynx-view
-      key={src}
+      key={resolvedSrc}
       ref={handleLynxViewRef}
-      url={src}
+      url={resolvedSrc}
       style={lynxViewStyle}
       lynx-group-id={LYNX_GROUP_ID}
       transform-vh={true}


### PR DESCRIPTION
### Motivation
- Provide a simple UI control to reload the Lynx web preview bundle and restart the embedded `<lynx-view>` without reloading the whole page.
- Make manual refresh restart the runtime and avoid reusing a cached bundle URL when the user requests a reload.

### Description
- Added a refresh button in the Web preview header using `IconRefresh` and a `webPreviewRevision` counter in `ExampleContent` to trigger reloads (`src/example-preview/components/index.tsx`).
- Plumbed a `reloadKey` prop from `ExampleContent` into `WebIframe` so manual refreshes can be signaled (`src/example-preview/components/index.tsx`, `src/example-preview/components/web-iframe.tsx`).
- `WebIframe` now accepts `reloadKey`, appends a `goWebReload` query parameter when `reloadKey > 0`, and uses the resolved URL as the `<lynx-view>` `key`/`url` so the view remounts and the Lynx bundle reloads (`src/example-preview/components/web-iframe.tsx`).
- Reserve a fixed header action slot so the refresh button aligns with existing controls by adding `.preview-header-action` in the stylesheet (`src/example-preview/components/index.module.scss`).

### Testing
- Ran `pnpm typecheck` and it completed successfully.
- Ran `pnpm exec prettier --check src/example-preview/components/index.tsx src/example-preview/components/web-iframe.tsx src/example-preview/components/index.module.scss` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56867d98ec8329a461b4798bdc7d15)