### PR TITLE
feat: add web preview refresh next to fullscreen

### DIFF
--- a/.changeset/web-preview-refresh-button.md
+++ b/.changeset/web-preview-refresh-button.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Add a Web preview refresh control next to the fullscreen button (same small borderless button sizing) that remounts `<lynx-view>` and busts the bundle URL cache.

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -28,6 +28,7 @@ const DEFAULT_I18N: Record<string, string> = {
   'go.openin.show-qrcode': 'Show QR Code',
   'go.ultra': 'Open frameless',
   'go.ultra.exit': 'Exit frameless',
+  'go.refresh': 'Refresh',
 };
 
 /** Default CodeBlock — plain <pre><code> with no syntax highlighting. */

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -33,6 +33,7 @@ import {
   IconFullscreen,
   IconGithub,
   IconOpenExternal,
+  IconRefresh,
 } from '../utils/icon';
 import { getFrameworkConfig } from '../utils/native-frameworks';
 import { isQrAllowed, resolveOpenIn } from '../utils/open-in-mode';
@@ -196,6 +197,7 @@ export function ExampleContent({
     };
   }, [previewImage, currentEntry, defaultWebPreviewFile]);
   const [tmpCurrentFileName, setTmpCurrentFileName] = useState('');
+  const [webPreviewRevision, setWebPreviewRevision] = useState(0);
   const defaultI18n = (key: string) => DEFAULT_I18N[key] || key;
   const t = useI18nHook ? useI18nHook() : defaultI18n;
   const lang = useLangHook ? useLangHook() : 'en';
@@ -499,6 +501,19 @@ export function ExampleContent({
               onClick={enterFrameless}
             />
           )}
+          {hasWebPreview && previewType === PreviewType.Web && (
+            <Button
+              theme="borderless"
+              icon={
+                <IconRefresh style={{ color: 'var(--semi-color-text-2)' }} />
+              }
+              type="tertiary"
+              size="small"
+              title={t('go.refresh')}
+              aria-label={t('go.refresh')}
+              onClick={() => setWebPreviewRevision((v) => v + 1)}
+            />
+          )}
           <Button
             theme="borderless"
             icon={
@@ -648,6 +663,7 @@ export function ExampleContent({
                   <WebIframe
                     show={previewType === PreviewType.Web || isUltra}
                     src={defaultWebPreviewFile || ''}
+                    reloadKey={webPreviewRevision}
                     webPreviewMode={webPreviewMode}
                     designWidth={designWidth}
                     designHeight={designHeight}

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -1,6 +1,6 @@
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useContainerResize } from '../hooks/use-container-resize';
 import {
@@ -48,11 +48,14 @@ type WebIframeProps = {
   fitThresholdScale?: number;
   fitMinScale?: number;
   fit?: 'contain' | 'cover' | 'auto';
+  /** Bump to remount `<lynx-view>` and bypass cached bundle URL. */
+  reloadKey?: number;
 };
 
 type UseWebIframeControllerArgs = {
   src: string;
   lynxView: LynxView | null;
+  reloadKey: number;
 };
 
 type UseWebIframeControllerResult = {
@@ -179,6 +182,7 @@ function formatLynxErrorMessage(value: unknown): string | null {
 function useWebIframeController({
   src,
   lynxView,
+  reloadKey,
 }: UseWebIframeControllerArgs): UseWebIframeControllerResult {
   const [ready, setReady] = useState(false);
   const [started, setStarted] = useState(false);
@@ -187,12 +191,12 @@ function useWebIframeController({
 
   const startedRef = useRef(false);
 
-  // Reset state when src changes
+  // Reset state when src changes or a manual refresh is requested
   useEffect(() => {
     setStarted(false);
     setPreviewError(null);
     startedRef.current = false;
-  }, [src]);
+  }, [src, reloadKey]);
 
   // Load web-core eagerly on mount
   useEffect(() => {
@@ -247,7 +251,7 @@ function useWebIframeController({
     return () => {
       clearTimeout(t);
     };
-  }, [ready, src, lynxView]);
+  }, [ready, src, lynxView, reloadKey]);
 
   useEffect(() => {
     if (!lynxView) return;
@@ -460,6 +464,7 @@ export const WebIframe = ({
   fitThresholdScale = 1.0,
   fitMinScale = 0.5,
   fit = 'cover',
+  reloadKey = 0,
 }: WebIframeProps) => {
   const [lynxView, setLynxView] = useState<LynxView | null>(null);
   const browserConfigInitializedRef = useRef<WeakSet<LynxView>>(new WeakSet());
@@ -580,9 +585,16 @@ export const WebIframe = ({
     tryInitBrowserConfig,
   ]);
 
+  const resolvedSrc = useMemo(() => {
+    if (!src || reloadKey === 0) return src;
+    const separator = src.includes('?') ? '&' : '?';
+    return `${src}${separator}goWebReload=${reloadKey}`;
+  }, [src, reloadKey]);
+
   const { ready, started, error } = useWebIframeController({
-    src,
+    src: resolvedSrc,
     lynxView,
+    reloadKey,
   });
 
   // `webPreviewMode='responsive'` resolves to `usesFitPath === false`,
@@ -619,11 +631,11 @@ export const WebIframe = ({
 
   const loading = show && (!ready || !started || !!error);
 
-  const lynxViewNode = ready && src && (
+  const lynxViewNode = ready && resolvedSrc && (
     <lynx-view
-      key={src}
+      key={resolvedSrc}
       ref={handleLynxViewRef}
-      url={src}
+      url={resolvedSrc}
       style={lynxViewStyle}
       lynx-group-id={LYNX_GROUP_ID}
       transform-vh={true}

--- a/src/example-preview/utils/icon.tsx
+++ b/src/example-preview/utils/icon.tsx
@@ -91,6 +91,23 @@ export function IconOpenExternal(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function IconRefresh(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M17.65 6.35A7.95 7.95 0 0012 4V1L7 6l5 5V7c2.76 0 5 2.24 5 5a5 5 0 01-5 5 5 5 0 01-4.9-4H5.08A7 7 0 0012 19a7 7 0 007-7c0-1.94-.78-3.7-2.05-4.97z"
+      />
+    </svg>
+  );
+}
+
 export function IconCopyLink(props: SVGProps<SVGSVGElement>) {
   return (
     <svg


### PR DESCRIPTION
Place a same-sized refresh control beside the fullscreen button (not a tiny left-slot action). Bump reloadKey to remount <lynx-view> and bust cached bundle URLs.