### PR TITLE
feat: Web preview soft-refresh next to fullscreen

### DIFF
--- a/.changeset/web-preview-refresh.md
+++ b/.changeset/web-preview-refresh.md
@@ -2,4 +2,4 @@
 '@lynx-js/go-web': patch
 ---
 
-Add a Web preview refresh control next to the fullscreen button. It appears only after the initial Lynx bundle has downloaded, and soft-refreshes by remounting `<lynx-view>` into the rendering overlay stage (not downloading).
+Add a Web preview refresh control next to the fullscreen button. It appears only after the initial Lynx bundle has downloaded, and soft-refreshes via `<lynx-view>.reload()` into the rendering overlay stage (not downloading).

--- a/.changeset/web-preview-refresh.md
+++ b/.changeset/web-preview-refresh.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Add a Web preview refresh control next to the fullscreen button. It appears only after the initial Lynx bundle has downloaded, and soft-refreshes by remounting `<lynx-view>` into the rendering overlay stage (not downloading).

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -28,6 +28,7 @@ const DEFAULT_I18N: Record<string, string> = {
   'go.openin.show-qrcode': 'Show QR Code',
   'go.ultra': 'Open frameless',
   'go.ultra.exit': 'Exit frameless',
+  'go.refresh': 'Refresh',
 };
 
 /** Default CodeBlock — plain <pre><code> with no syntax highlighting. */

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -1,4 +1,8 @@
-import { IconChevronRightStroked, IconList } from '@douyinfe/semi-icons';
+import {
+  IconChevronRightStroked,
+  IconList,
+  IconRefresh,
+} from '@douyinfe/semi-icons';
 import {
   Button,
   Radio,
@@ -155,6 +159,10 @@ export function ExampleContent({
   const isUltra = fullscreenMode === 'ultra';
   const isUltraRef = useRef(false);
   isUltraRef.current = isUltra;
+  // Soft-refresh of the Web preview: remount <lynx-view> after the initial
+  // bundle download. Button stays hidden until WebIframe unlocks it.
+  const [webReloadKey, setWebReloadKey] = useState(0);
+  const [canRefreshWeb, setCanRefreshWeb] = useState(false);
 
   useEffect(() => {
     const el = boxRef.current;
@@ -499,6 +507,23 @@ export function ExampleContent({
               onClick={enterFrameless}
             />
           )}
+          {/* Soft refresh sits immediately beside fullscreen (same Button
+              size/theme). Only after the initial web bundle has downloaded. */}
+          {hasWebPreview &&
+            previewType === PreviewType.Web &&
+            canRefreshWeb && (
+              <Button
+                theme="borderless"
+                icon={
+                  <IconRefresh style={{ color: 'var(--semi-color-text-2)' }} />
+                }
+                type="tertiary"
+                size="small"
+                title={t('go.refresh')}
+                aria-label={t('go.refresh')}
+                onClick={() => setWebReloadKey((v) => v + 1)}
+              />
+            )}
           <Button
             theme="borderless"
             icon={
@@ -654,6 +679,8 @@ export function ExampleContent({
                     fitThresholdScale={fitThresholdScale}
                     fitMinScale={fitMinScale}
                     fit={fit}
+                    reloadKey={webReloadKey}
+                    onCanRefreshChange={setCanRefreshWeb}
                   />
                 </Suspense>
               </NoSSRComponent>

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -1,8 +1,4 @@
-import {
-  IconChevronRightStroked,
-  IconList,
-  IconRefresh,
-} from '@douyinfe/semi-icons';
+import { IconChevronRightStroked, IconList } from '@douyinfe/semi-icons';
 import {
   Button,
   Radio,
@@ -37,6 +33,7 @@ import {
   IconFullscreen,
   IconGithub,
   IconOpenExternal,
+  IconRefresh,
 } from '../utils/icon';
 import { getFrameworkConfig } from '../utils/native-frameworks';
 import { isQrAllowed, resolveOpenIn } from '../utils/open-in-mode';

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -50,8 +50,8 @@ type WebIframeProps = {
   fitMinScale?: number;
   fit?: 'contain' | 'cover' | 'auto';
   /**
-   * Increment to soft-refresh the preview: remount `<lynx-view>` and show the
-   * loading overlay in the rendering stage (bundle already downloaded).
+   * Increment to soft-refresh the preview: call `<lynx-view>.reload()` and show
+   * the loading overlay in the rendering stage (bundle already downloaded).
    */
   reloadKey?: number;
   /** Fires when the initial bundle has been downloaded and refresh is safe. */
@@ -64,6 +64,9 @@ type UseWebIframeControllerArgs = {
   reloadKey: number;
   onCanRefreshChange?: (canRefresh: boolean) => void;
 };
+
+/** web-core marks torn-down page roots with this before clearing the shadow. */
+const LYNX_DISPOSED_ATTR = 'l-disposed';
 
 type UseWebIframeControllerResult = {
   /**
@@ -209,9 +212,10 @@ function useWebIframeController({
 
   const renderedRef = useRef(false);
   const bundlePhaseRef = useRef<'downloading' | 'rendering'>('downloading');
-  // Soft refresh: remount after the initial download — overlay stays on
-  // "rendering", never re-enters the downloading stage.
+  // Soft refresh: native lynx-view.reload() — overlay stays on "rendering",
+  // never re-enters the downloading stage.
   const softRefreshRef = useRef(false);
+  const pendingReloadRef = useRef(false);
   const canRefreshRef = useRef(false);
   const prevSrcRef = useRef(src);
   const prevReloadKeyRef = useRef(reloadKey);
@@ -237,11 +241,13 @@ function useWebIframeController({
 
     if (srcChanged) {
       softRefreshRef.current = false;
+      pendingReloadRef.current = false;
       notifyCanRefresh(false);
       setBundlePhase('downloading');
       bundlePhaseRef.current = 'downloading';
     } else if (reloadChanged && reloadKey > 0) {
       softRefreshRef.current = true;
+      pendingReloadRef.current = true;
       setBundlePhase('rendering');
       bundlePhaseRef.current = 'rendering';
     }
@@ -290,11 +296,21 @@ function useWebIframeController({
     let raf = 0;
 
     // Soft refresh skips downloading; initial / src loads start there.
-    const initialPhase: 'downloading' | 'rendering' = softRefreshRef.current
+    const isSoftRefresh = softRefreshRef.current;
+    const initialPhase: 'downloading' | 'rendering' = isSoftRefresh
       ? 'rendering'
       : 'downloading';
     setBundlePhase(initialPhase);
     bundlePhaseRef.current = initialPhase;
+
+    // Consume the pending reload once; snapshot the pre-reload page so we
+    // never treat it as the post-reload paint signal.
+    const shouldReload = pendingReloadRef.current;
+    if (shouldReload) pendingReloadRef.current = false;
+    const host = lynxView as unknown as HTMLElement;
+    const previousPage = shouldReload
+      ? host.shadowRoot?.querySelector('[part="page"], [lynx-tag="page"]')
+      : null;
 
     const unlockRefresh = () => {
       // Bundle has been downloaded (decode chrome or page paint). Parent can
@@ -337,9 +353,14 @@ function useWebIframeController({
     // web-core may create the shadow root asynchronously and append chrome
     // (iframe / placeholder <link>) before the template finishes downloading.
     // The rendered page root is `[part="page"]` (web-core >=0.20) or
-    // `[lynx-tag="page"]` (older). Do not treat any shadow child as ready.
-    const isContentReady = (shadow: ShadowRoot) =>
-      !!shadow.querySelector('[part="page"], [lynx-tag="page"]');
+    // `[lynx-tag="page"]` (older). Ignore disposed / pre-reload page nodes.
+    const isContentReady = (shadow: ShadowRoot) => {
+      const page = shadow.querySelector('[part="page"], [lynx-tag="page"]');
+      if (!page) return false;
+      if (page.hasAttribute(LYNX_DISPOSED_ATTR)) return false;
+      if (previousPage && page === previousPage) return false;
+      return true;
+    };
 
     // Early chrome is iframe + empty blob <link>. A real <style> lands after
     // the template is decoded — use that as downloading → rendering. (Bundle
@@ -349,33 +370,49 @@ function useWebIframeController({
         (el) => (el.textContent || '').trim().length > 0,
       );
 
+    const evaluate = (shadow: ShadowRoot, source: string) => {
+      if (isContentReady(shadow)) {
+        markRendered(source);
+        return;
+      }
+      if (hasDecodeChrome(shadow)) {
+        markRendering(`shadow-style:${source}`);
+      }
+    };
+
     const setupShadow = (shadow: ShadowRoot) => {
-      mo = new MutationObserver(() => {
-        if (isContentReady(shadow)) {
-          markRendered('page');
-          return;
-        }
-        if (hasDecodeChrome(shadow)) {
-          markRendering('shadow-style');
-        }
-      });
+      mo = new MutationObserver(() => evaluate(shadow, 'page'));
       mo.observe(shadow, {
         childList: true,
         subtree: true,
         characterData: true,
+        attributes: true,
+        attributeFilter: [LYNX_DISPOSED_ATTR],
       });
-      if (isContentReady(shadow)) {
-        markRendered('page-existing');
-      } else if (hasDecodeChrome(shadow)) {
-        markRendering('shadow-style');
-      }
+      evaluate(shadow, 'page-existing');
     };
 
     const pollShadow = () => {
       if (disposed || renderedRef.current) return;
-      const shadow = (lynxView as unknown as HTMLElement).shadowRoot;
+      const shadow = host.shadowRoot;
       if (shadow) {
         setupShadow(shadow);
+        // Arm observer before reload so dispose/rebuild mutations are seen.
+        // Snapshotting `previousPage` prevents the pre-reload root from
+        // clearing the overlay early.
+        if (shouldReload) {
+          console.log(tag, 'soft-refresh via lynx-view.reload()');
+          lynxView.reload();
+          // Cached rebuilds can finish between turns; re-check a few times.
+          queueMicrotask(() => {
+            if (!disposed && host.shadowRoot)
+              evaluate(host.shadowRoot, 'page-microtask');
+          });
+          requestAnimationFrame(() => {
+            if (!disposed && host.shadowRoot)
+              evaluate(host.shadowRoot, 'page-raf');
+          });
+        }
       } else {
         raf = requestAnimationFrame(pollShadow);
       }
@@ -767,11 +804,11 @@ export const WebIframe = ({
 
   const loading = show && (!ready || !rendered || !!error);
 
-  // Remount on soft refresh via key; keep `url` stable so the browser can
-  // reuse the already-downloaded bundle (rendering stage, not downloading).
+  // Keep `<lynx-view>` mounted across soft refreshes; reloadKey drives
+  // `lynxView.reload()` inside the controller (rendering stage, not remount).
   const lynxViewNode = ready && src && (
     <lynx-view
-      key={`${src}::${reloadKey}`}
+      key={src}
       ref={handleLynxViewRef}
       url={src}
       style={lynxViewStyle}

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -49,11 +49,20 @@ type WebIframeProps = {
   fitThresholdScale?: number;
   fitMinScale?: number;
   fit?: 'contain' | 'cover' | 'auto';
+  /**
+   * Increment to soft-refresh the preview: remount `<lynx-view>` and show the
+   * loading overlay in the rendering stage (bundle already downloaded).
+   */
+  reloadKey?: number;
+  /** Fires when the initial bundle has been downloaded and refresh is safe. */
+  onCanRefreshChange?: (canRefresh: boolean) => void;
 };
 
 type UseWebIframeControllerArgs = {
   src: string;
   lynxView: LynxView | null;
+  reloadKey: number;
+  onCanRefreshChange?: (canRefresh: boolean) => void;
 };
 
 type UseWebIframeControllerResult = {
@@ -187,6 +196,8 @@ function formatLynxErrorMessage(value: unknown): string | null {
 function useWebIframeController({
   src,
   lynxView,
+  reloadKey,
+  onCanRefreshChange,
 }: UseWebIframeControllerArgs): UseWebIframeControllerResult {
   const [ready, setReady] = useState(false);
   const [rendered, setRendered] = useState(false);
@@ -198,15 +209,43 @@ function useWebIframeController({
 
   const renderedRef = useRef(false);
   const bundlePhaseRef = useRef<'downloading' | 'rendering'>('downloading');
+  // Soft refresh: remount after the initial download — overlay stays on
+  // "rendering", never re-enters the downloading stage.
+  const softRefreshRef = useRef(false);
+  const canRefreshRef = useRef(false);
+  const prevSrcRef = useRef(src);
+  const prevReloadKeyRef = useRef(reloadKey);
+  const onCanRefreshChangeRef = useRef(onCanRefreshChange);
+  onCanRefreshChangeRef.current = onCanRefreshChange;
 
-  // Reset state when src changes
+  const notifyCanRefresh = useCallback((can: boolean) => {
+    if (canRefreshRef.current === can) return;
+    canRefreshRef.current = can;
+    onCanRefreshChangeRef.current?.(can);
+  }, []);
+
+  // Reset when src changes (hard load) or reloadKey changes (soft refresh).
   useEffect(() => {
+    const srcChanged = prevSrcRef.current !== src;
+    const reloadChanged = prevReloadKeyRef.current !== reloadKey;
+    prevSrcRef.current = src;
+    prevReloadKeyRef.current = reloadKey;
+
     setRendered(false);
-    setBundlePhase('downloading');
-    bundlePhaseRef.current = 'downloading';
     setPreviewError(null);
     renderedRef.current = false;
-  }, [src]);
+
+    if (srcChanged) {
+      softRefreshRef.current = false;
+      notifyCanRefresh(false);
+      setBundlePhase('downloading');
+      bundlePhaseRef.current = 'downloading';
+    } else if (reloadChanged && reloadKey > 0) {
+      softRefreshRef.current = true;
+      setBundlePhase('rendering');
+      bundlePhaseRef.current = 'rendering';
+    }
+  }, [src, reloadKey, notifyCanRefresh]);
 
   // Load web-core eagerly on mount
   useEffect(() => {
@@ -250,12 +289,23 @@ function useWebIframeController({
     let mo: MutationObserver | undefined;
     let raf = 0;
 
-    setBundlePhase('downloading');
-    bundlePhaseRef.current = 'downloading';
+    // Soft refresh skips downloading; initial / src loads start there.
+    const initialPhase: 'downloading' | 'rendering' = softRefreshRef.current
+      ? 'rendering'
+      : 'downloading';
+    setBundlePhase(initialPhase);
+    bundlePhaseRef.current = initialPhase;
+
+    const unlockRefresh = () => {
+      // Bundle has been downloaded (decode chrome or page paint). Parent can
+      // show the refresh control from here on for this src.
+      notifyCanRefresh(true);
+    };
 
     const markRendered = (source: string) => {
       if (renderedRef.current || disposed) return;
       renderedRef.current = true;
+      unlockRefresh();
       mo?.disconnect();
       console.log(
         tag,
@@ -273,6 +323,7 @@ function useWebIframeController({
 
     const markRendering = (source: string) => {
       if (disposed || renderedRef.current) return;
+      unlockRefresh();
       if (bundlePhaseRef.current === 'rendering') return;
       bundlePhaseRef.current = 'rendering';
       console.log(
@@ -339,7 +390,7 @@ function useWebIframeController({
       clearTimeout(fallback);
       mo?.disconnect();
     };
-  }, [ready, src, lynxView]);
+  }, [ready, src, lynxView, reloadKey, notifyCanRefresh]);
 
   useEffect(() => {
     if (!lynxView) return;
@@ -553,6 +604,8 @@ export const WebIframe = ({
   fitThresholdScale = 1.0,
   fitMinScale = 0.5,
   fit = 'cover',
+  reloadKey = 0,
+  onCanRefreshChange,
 }: WebIframeProps) => {
   const [lynxView, setLynxView] = useState<LynxView | null>(null);
   const browserConfigInitializedRef = useRef<WeakSet<LynxView>>(new WeakSet());
@@ -676,6 +729,8 @@ export const WebIframe = ({
   const { ready, rendered, stage, error } = useWebIframeController({
     src,
     lynxView,
+    reloadKey,
+    onCanRefreshChange,
   });
 
   // `webPreviewMode='responsive'` resolves to `usesFitPath === false`,
@@ -712,9 +767,11 @@ export const WebIframe = ({
 
   const loading = show && (!ready || !rendered || !!error);
 
+  // Remount on soft refresh via key; keep `url` stable so the browser can
+  // reuse the already-downloaded bundle (rendering stage, not downloading).
   const lynxViewNode = ready && src && (
     <lynx-view
-      key={src}
+      key={`${src}::${reloadKey}`}
       ref={handleLynxViewRef}
       url={src}
       style={lynxViewStyle}

--- a/src/example-preview/utils/icon.tsx
+++ b/src/example-preview/utils/icon.tsx
@@ -56,7 +56,7 @@ export function IconFullscreen(props: SVGProps<SVGSVGElement>) {
   );
 }
 
-/** Match header action icons (fullscreen / open-external): 1em, no Semi size wrap. */
+/** Same Material 24dp optical size as IconFullscreen / IconOpenExternal. */
 export function IconRefresh(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
@@ -68,7 +68,7 @@ export function IconRefresh(props: SVGProps<SVGSVGElement>) {
     >
       <path
         fill="currentColor"
-        d="M4.5 12a7.5 7.5 0 0 1 13.8-4.07l-2-.4a1.5 1.5 0 0 0-.6 2.94l5 1c.76.15 1.51-.3 1.74-1.04l1.5-5a1.5 1.5 0 1 0-2.88-.86l-.43 1.45A10.49 10.49 0 0 0 1.5 12a10.5 10.5 0 0 0 20.4 3.5 1.5 1.5 0 1 0-2.83-1A7.5 7.5 0 0 1 4.5 12Z"
+        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
       />
     </svg>
   );

--- a/src/example-preview/utils/icon.tsx
+++ b/src/example-preview/utils/icon.tsx
@@ -56,6 +56,24 @@ export function IconFullscreen(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+/** Match header action icons (fullscreen / open-external): 1em, no Semi size wrap. */
+export function IconRefresh(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M4.5 12a7.5 7.5 0 0 1 13.8-4.07l-2-.4a1.5 1.5 0 0 0-.6 2.94l5 1c.76.15 1.51-.3 1.74-1.04l1.5-5a1.5 1.5 0 1 0-2.88-.86l-.43 1.45A10.49 10.49 0 0 0 1.5 12a10.5 10.5 0 0 0 20.4 3.5 1.5 1.5 0 1 0-2.83-1A7.5 7.5 0 0 1 4.5 12Z"
+      />
+    </svg>
+  );
+}
+
 export function IconExitFullscreen(props: SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/src/example-preview/utils/icon.tsx
+++ b/src/example-preview/utils/icon.tsx
@@ -56,7 +56,10 @@ export function IconFullscreen(props: SVGProps<SVGSVGElement>) {
   );
 }
 
-/** Same Material 24dp optical size as IconFullscreen / IconOpenExternal. */
+/**
+ * Header refresh control. Material refresh ink is optically larger than the
+ * neighboring corner-bracket icons, so scale ~0.85 around center to match.
+ */
 export function IconRefresh(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
@@ -66,10 +69,12 @@ export function IconRefresh(props: SVGProps<SVGSVGElement>) {
       height="1em"
       {...props}
     >
-      <path
-        fill="currentColor"
-        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-      />
+      <g transform="translate(12 12) scale(0.85) translate(-12 -12)">
+        <path
+          fill="currentColor"
+          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+        />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation
- #64 put the refresh control on the wrong side of the preview header (left spacer), with mismatched sizing, and always showed it on the Web tab.
- Soft refresh should only be available after the initial Lynx bundle has downloaded, and should bring the loading overlay back in the **rendering** stage — not re-enter downloading / cache-bust the URL.

### Description
Supersedes #64 (prefer closing that PR in favor of this one).

- Add a refresh button immediately beside the fullscreen control, using a custom 1em `IconRefresh` that matches the other header action icons (`src/example-preview/utils/icon.tsx`, `src/example-preview/components/index.tsx`).
- Unlock the button only after `WebIframe` reports the initial bundle was downloaded (`onCanRefreshChange`), so it stays hidden during runtime/download.
- Soft refresh increments `reloadKey` and calls native `<lynx-view>.reload()` (no remount / no cache-bust query param), forcing the overlay into the **rendering** stage. Paint detection ignores the pre-reload page node and `l-disposed` roots (`src/example-preview/components/web-iframe.tsx`).
- Add `go.refresh` i18n string and a patch changeset.

### Testing
- `pnpm typecheck`
- `pnpm exec prettier --check` on the touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9eef1ef5-1cb3-4404-952f-3b0270c3173c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eef1ef5-1cb3-4404-952f-3b0270c3173c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

