### PR TITLE
feat!: own go.* i18n in-package; drop Rspress useI18n wiring

### DIFF
--- a/.changeset/i18n-fallback-missing-keys.md
+++ b/.changeset/i18n-fallback-missing-keys.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Fall back to built-in English `go.*` strings when a host `useI18n` (e.g. Rspress) throws or returns a non-string for a missing key, so upgrading `<Go>` without updating site `i18n.json` no longer crashes the host app.

--- a/.changeset/i18n-fallback-missing-keys.md
+++ b/.changeset/i18n-fallback-missing-keys.md
@@ -1,5 +1,9 @@
 ---
-'@lynx-js/go-web': patch
+'@lynx-js/go-web': minor
 ---
 
-Fall back to built-in English `go.*` strings when a host `useI18n` (e.g. Rspress) throws or returns a non-string for a missing key, so upgrading `<Go>` without updating site `i18n.json` no longer crashes the host app.
+Decouple `<Go>` chrome copy from host/Rspress i18n.
+
+- `go.*` strings are package-owned (`en` / `zh` via `useLang`); override with `config.i18n` only.
+- `rspressAdapter` no longer wires Rspress `useI18n` — site `i18n.json` does not need `go.*` keys.
+- Removed `GoConfig.useI18n` (breaking for custom hooks; use `i18n` + `useLang` instead).

--- a/README.md
+++ b/README.md
@@ -26,12 +26,24 @@ import { rspressAdapter } from '@lynx-js/go-web/adapters/rspress';
 
 const config = {
   exampleBasePath: '/lynx-examples',
-  ...rspressAdapter,
+  ...rspressAdapter, // withBase, useLang, useDark, NoSSR, CodeBlock — not useI18n
 };
 
 <GoConfigProvider config={config}>
   <Go example="hello-world" />
 </GoConfigProvider>;
+```
+
+`<Go>` owns its UI chrome strings (`en` / `zh` selected by `useLang`). You do **not** need `go.*` keys in the site's `i18n.json`. Optional wording overrides:
+
+```tsx
+const config = {
+  exampleBasePath: '/lynx-examples',
+  ...rspressAdapter,
+  i18n: {
+    'go.refresh': 'Reload preview',
+  },
+};
 ```
 
 ### SSG (Static Site Generation)

--- a/example-rspress/src/components/Go.tsx
+++ b/example-rspress/src/components/Go.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 
 const config = {
   exampleBasePath: '/lynx-examples',
-  // Full adapter is safe: missing go.* keys fall back to package English.
+  // useLang selects package en/zh catalogs; no site go.* i18n.json needed.
   ...rspressAdapter,
   SSGComponent: ExamplePreviewSSG,
   ssgExampleRoot: path?.join?.(__dirname, '../../docs/public/lynx-examples'),

--- a/example-rspress/src/components/Go.tsx
+++ b/example-rspress/src/components/Go.tsx
@@ -4,20 +4,17 @@ import { ExamplePreviewSSG } from '@lynx-js/go-web/ssg';
 import path from 'path';
 import { useEffect } from 'react';
 
-// Exclude useI18n — rspress's i18n doesn't have go.* keys.
-// go-web falls back to its built-in English strings.
-const { useI18n: _, ...adapter } = rspressAdapter;
-
 const config = {
   exampleBasePath: '/lynx-examples',
-  ...adapter,
+  // Full adapter is safe: missing go.* keys fall back to package English.
+  ...rspressAdapter,
   SSGComponent: ExamplePreviewSSG,
   ssgExampleRoot: path?.join?.(__dirname, '../../docs/public/lynx-examples'),
 };
 
 /** Sync rspress dark mode → Semi UI body attribute */
 function useSemiDarkMode() {
-  const dark = adapter.useDark!();
+  const dark = rspressAdapter.useDark!();
   useEffect(() => {
     document.body.setAttribute('theme-mode', dark ? 'dark' : 'light');
   }, [dark]);

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -20,49 +20,6 @@ const LOGO_DARK =
 type Lang = 'en' | 'zh';
 
 // ---------------------------------------------------------------------------
-// i18n translations
-// ---------------------------------------------------------------------------
-
-const translations: Record<string, Record<string, string>> = {
-  en: {
-    'go.preview': 'Preview',
-    'go.qrcode': 'QRCode',
-    'go.files': 'Files',
-    'go.scan.message-1': 'Download ',
-    'go.scan.message-2': 'and scan the QR code to get started.',
-    'go.qrcode.copy-link': 'Copy Link',
-    'go.qrcode.copied': 'Copied',
-    'go.qrcode.entry': 'Entry',
-    'go.openin': 'Open',
-    'go.deeplink.open.default': 'Open in Lynx Explorer',
-    'go.deeplink.open.lynxtron': 'Open in Lynxtron Go',
-    'go.deeplink.open.sparkling': 'Open in Sparkling',
-    'go.deeplink.hint-desktop': 'desktop only',
-    'go.deeplink.hint-mobile': 'mobile only',
-    'go.deeplink.or': 'or',
-    'go.openin.show-qrcode': 'Show QR Code',
-  },
-  zh: {
-    'go.preview': '预览',
-    'go.qrcode': '二维码',
-    'go.files': '文件',
-    'go.scan.message-1': '请下载 ',
-    'go.scan.message-2': '扫描二维码预览',
-    'go.qrcode.copy-link': '复制链接',
-    'go.qrcode.copied': '已复制',
-    'go.qrcode.entry': '入口',
-    'go.openin': '打开',
-    'go.deeplink.open.default': '在 Lynx Explorer 中打开',
-    'go.deeplink.open.lynxtron': '在 Lynxtron Go 中打开',
-    'go.deeplink.open.sparkling': '在 Sparkling 中打开',
-    'go.deeplink.hint-desktop': '仅桌面',
-    'go.deeplink.hint-mobile': '仅移动端',
-    'go.deeplink.or': '或',
-    'go.openin.show-qrcode': '显示二维码',
-  },
-};
-
-// ---------------------------------------------------------------------------
 // Standalone CodeBlock (shiki-based syntax highlighting)
 // ---------------------------------------------------------------------------
 
@@ -953,8 +910,7 @@ function App() {
       cn: 'https://lynxjs.org/zh/guide/start/quick-start.html#download-lynx-explorer',
     },
     explorerText: 'Lynx Explorer',
-    useI18n: () => (key: string) =>
-      translations[lang]?.[key] ?? translations.en[key] ?? key,
+    // Package-owned en/zh via useLang; optional config.i18n for overrides.
     useLang: () => lang,
     useDark: () => dark,
     CodeBlock: StandaloneCodeBlock,

--- a/src/adapters/rspress.tsx
+++ b/src/adapters/rspress.tsx
@@ -10,15 +10,13 @@
  * This file imports from `@rspress/core` and `@theme` — these resolve only
  * when the consumer's bundler processes this file (i.e. in an rspress site).
  * Non-rspress consumers never import this module, so no breakage occurs.
+ *
+ * Intentionally does **not** wire Rspress `useI18n`. `<Go>` owns its `go.*`
+ * chrome strings (en/zh via `useLang`); override with `config.i18n` if needed.
+ * Site `i18n.json` does not need `go.*` keys.
  */
 import React from 'react';
-import {
-  useI18n,
-  useLang,
-  useDark,
-  withBase,
-  NoSSR,
-} from '@rspress/core/runtime';
+import { useLang, useDark, withBase, NoSSR } from '@rspress/core/runtime';
 import { CodeBlockRuntime } from '@theme';
 import { transformerAddLineNumbers } from '@rspress/core/shiki-transformers';
 import type { GoConfig } from '../config';
@@ -56,20 +54,16 @@ const RspressCodeBlock = ({
 };
 
 /**
- * Spread this into your GoConfig to wire up all rspress integrations:
- * `withBase`, `useI18n`, `useLang`, `useDark`, `NoSSR`, and `CodeBlock`.
+ * Spread this into your GoConfig to wire up rspress integrations:
+ * `withBase`, `useLang`, `useDark`, `NoSSR`, and `CodeBlock`.
  *
- * Rspress `useI18n` throws when a key is absent from the site's `i18n.json`.
- * `<Go>` catches that and falls back to package English defaults, so upgrading
- * `@lynx-js/go-web` without immediately adding new `go.*` keys will not crash
- * the host site (still add the keys when you want localized copy).
+ * Does not include `useI18n` — `<Go>` chrome copy is package-owned.
  */
 export const rspressAdapter: Pick<
   GoConfig,
-  'withBase' | 'useI18n' | 'useLang' | 'useDark' | 'NoSSR' | 'CodeBlock'
+  'withBase' | 'useLang' | 'useDark' | 'NoSSR' | 'CodeBlock'
 > = {
   withBase,
-  useI18n: () => useI18n(),
   useLang: () => useLang(),
   useDark: () => useDark(),
   NoSSR,

--- a/src/adapters/rspress.tsx
+++ b/src/adapters/rspress.tsx
@@ -58,6 +58,11 @@ const RspressCodeBlock = ({
 /**
  * Spread this into your GoConfig to wire up all rspress integrations:
  * `withBase`, `useI18n`, `useLang`, `useDark`, `NoSSR`, and `CodeBlock`.
+ *
+ * Rspress `useI18n` throws when a key is absent from the site's `i18n.json`.
+ * `<Go>` catches that and falls back to package English defaults, so upgrading
+ * `@lynx-js/go-web` without immediately adding new `go.*` keys will not crash
+ * the host site (still add the keys when you want localized copy).
  */
 export const rspressAdapter: Pick<
   GoConfig,

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -5,8 +5,39 @@ import { useIsClient } from './example-preview/hooks/use-is-client';
 
 export type PreviewTab = 'preview' | 'web' | 'qrcode';
 
-/** Built-in English i18n strings. Consumers can override via useI18n. */
-const DEFAULT_I18N: Record<string, string> = {
+/** Known `go.*` chrome keys owned by this package. */
+export type GoI18nKey =
+  | 'go.preview'
+  | 'go.qrcode'
+  | 'go.files'
+  | 'go.scan.message-1'
+  | 'go.scan.message-2'
+  | 'go.qrcode.copy-link'
+  | 'go.qrcode.copied'
+  | 'go.qrcode.entry'
+  | 'go.openin'
+  | 'go.deeplink.open.default'
+  | 'go.deeplink.open.lynxtron'
+  | 'go.deeplink.open.sparkling'
+  | 'go.deeplink.hint-desktop'
+  | 'go.deeplink.hint-mobile'
+  | 'go.deeplink.or'
+  | 'go.openin.show-qrcode'
+  | 'go.ultra'
+  | 'go.ultra.exit'
+  | 'go.refresh';
+
+export type GoI18nCatalog = Record<GoI18nKey, string>;
+
+/**
+ * Partial overrides for package-owned chrome strings (never via host i18n hooks).
+ * Also accepts `go.deeplink.open.{nativeFramework}` for custom frameworks.
+ */
+export type GoI18nOverrides = Partial<
+  Record<GoI18nKey | `go.deeplink.open.${string}`, string>
+>;
+
+const GO_I18N_EN: GoI18nCatalog = {
   'go.preview': 'Preview',
   'go.qrcode': 'QR Code',
   'go.files': 'Files',
@@ -31,24 +62,56 @@ const DEFAULT_I18N: Record<string, string> = {
   'go.refresh': 'Refresh',
 };
 
+const GO_I18N_ZH: GoI18nCatalog = {
+  'go.preview': '预览',
+  'go.qrcode': '二维码',
+  'go.files': '文件',
+  'go.scan.message-1': '请下载 ',
+  'go.scan.message-2': '扫描二维码预览',
+  'go.qrcode.copy-link': '复制链接',
+  'go.qrcode.copied': '已复制',
+  'go.qrcode.entry': '入口',
+  'go.openin': '打开',
+  'go.deeplink.open.default': '在 Lynx Explorer 中打开',
+  'go.deeplink.open.lynxtron': '在 Lynxtron Go 中打开',
+  'go.deeplink.open.sparkling': '在 Sparkling 中打开',
+  'go.deeplink.hint-desktop': '仅桌面',
+  'go.deeplink.hint-mobile': '仅移动端',
+  'go.deeplink.or': '或',
+  'go.openin.show-qrcode': '显示二维码',
+  'go.ultra': '打开无边框',
+  'go.ultra.exit': '退出无边框',
+  'go.refresh': '刷新',
+};
+
+const BUILTIN_I18N: Record<'en' | 'zh', GoI18nCatalog> = {
+  en: GO_I18N_EN,
+  zh: GO_I18N_ZH,
+};
+
+/** @deprecated Use {@link GO_I18N_EN}. Kept for existing imports. */
+const DEFAULT_I18N: Record<string, string> = GO_I18N_EN;
+
+function resolveBuiltinLang(lang: string): 'en' | 'zh' {
+  const base = lang.toLowerCase().split(/[-_]/)[0] ?? 'en';
+  return base === 'zh' ? 'zh' : 'en';
+}
+
 /**
- * Resolve a `go.*` string through an optional host translator, then
- * {@link DEFAULT_I18N}. Host hooks like Rspress `useI18n` throw on missing
- * keys — catch that so a site missing e.g. `go.refresh` cannot crash `<Go>`.
+ * Resolve a `go.*` chrome string from package catalogs.
+ * Order: config `i18n` override → builtin for `lang` → English → raw key.
+ * Host site i18n systems (Rspress, etc.) are intentionally not consulted.
  */
 export function translateGoI18n(
-  hostTranslate: ((key: string) => string) | null | undefined,
   key: string,
+  lang: string = 'en',
+  overrides?: GoI18nOverrides,
 ): string {
-  if (hostTranslate) {
-    try {
-      const value = hostTranslate(key);
-      if (typeof value === 'string') return value;
-    } catch {
-      // Host i18n threw (missing key) — fall through to defaults.
-    }
-  }
-  return DEFAULT_I18N[key] || key;
+  const fromOverride = overrides?.[key as keyof GoI18nOverrides];
+  if (typeof fromOverride === 'string') return fromOverride;
+
+  const builtin = BUILTIN_I18N[resolveBuiltinLang(lang)];
+  return builtin[key as GoI18nKey] ?? GO_I18N_EN[key as GoI18nKey] ?? key;
 }
 
 /** Default CodeBlock — plain <pre><code> with no syntax highlighting. */
@@ -120,16 +183,17 @@ export interface GoConfig {
   /** Absolute disk path to examples directory, for built-in SSG component */
   ssgExampleRoot?: string;
 
+  /**
+   * Optional overrides for package-owned `go.*` chrome strings.
+   * Prefer this over host i18n systems — `<Go>` never calls Rspress/site `useI18n`.
+   */
+  i18n?: GoI18nOverrides;
+
   // --- Framework adapter ---
 
   /** Prepend site base path to URLs. Default: identity */
   withBase?: (path: string) => string;
-  /**
-   * i18n hook returning a translation function.
-   * Missing / throwing host keys fall back to built-in English (`DEFAULT_I18N`).
-   */
-  useI18n?: () => (key: string) => string;
-  /** Language detection hook. Default: () => 'en' */
+  /** Language detection hook. Default: () => 'en'. Selects builtin en/zh catalogs. */
   useLang?: () => string;
   /** Dark mode detection hook. Default: prefers-color-scheme media query */
   useDark?: () => boolean;
@@ -169,4 +233,12 @@ export function useGoConfig(): GoConfig {
 }
 
 // Re-export defaults for use in components
-export { DEFAULT_I18N, DefaultCodeBlock, DefaultNoSSR, defaultUseDark };
+export {
+  BUILTIN_I18N,
+  DEFAULT_I18N,
+  DefaultCodeBlock,
+  DefaultNoSSR,
+  defaultUseDark,
+  GO_I18N_EN,
+  GO_I18N_ZH,
+};

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -31,6 +31,26 @@ const DEFAULT_I18N: Record<string, string> = {
   'go.refresh': 'Refresh',
 };
 
+/**
+ * Resolve a `go.*` string through an optional host translator, then
+ * {@link DEFAULT_I18N}. Host hooks like Rspress `useI18n` throw on missing
+ * keys — catch that so a site missing e.g. `go.refresh` cannot crash `<Go>`.
+ */
+export function translateGoI18n(
+  hostTranslate: ((key: string) => string) | null | undefined,
+  key: string,
+): string {
+  if (hostTranslate) {
+    try {
+      const value = hostTranslate(key);
+      if (typeof value === 'string') return value;
+    } catch {
+      // Host i18n threw (missing key) — fall through to defaults.
+    }
+  }
+  return DEFAULT_I18N[key] || key;
+}
+
 /** Default CodeBlock — plain <pre><code> with no syntax highlighting. */
 const DefaultCodeBlock = ({
   code,
@@ -104,7 +124,10 @@ export interface GoConfig {
 
   /** Prepend site base path to URLs. Default: identity */
   withBase?: (path: string) => string;
-  /** i18n hook returning a translation function. Default: built-in English strings */
+  /**
+   * i18n hook returning a translation function.
+   * Missing / throwing host keys fall back to built-in English (`DEFAULT_I18N`).
+   */
   useI18n?: () => (key: string) => string;
   /** Language detection hook. Default: () => 'en' */
   useLang?: () => string;

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -132,8 +132,8 @@ export function ExampleContent({
   const {
     explorerUrl,
     explorerText,
+    i18n: i18nOverrides,
     withBase: withBaseFn = (p: string) => p,
-    useI18n: useI18nHook,
     useLang: useLangHook,
     NoSSR: NoSSRComponent = DefaultNoSSR,
   } = useGoConfig();
@@ -201,11 +201,10 @@ export function ExampleContent({
     };
   }, [previewImage, currentEntry, defaultWebPreviewFile]);
   const [tmpCurrentFileName, setTmpCurrentFileName] = useState('');
-  // Host useI18n (e.g. Rspress) may throw on missing keys — always fall back
-  // to package DEFAULT_I18N so a stale site i18n.json cannot crash <Go>.
-  const hostT = useI18nHook ? useI18nHook() : undefined;
-  const t = (key: string) => translateGoI18n(hostT, key);
+  // Package-owned chrome strings (+ optional config.i18n overrides). Never
+  // call host/Rspress useI18n — missing site keys must not crash <Go>.
   const lang = useLangHook ? useLangHook() : 'en';
+  const t = (key: string) => translateGoI18n(key, lang, i18nOverrides);
 
   // Lock body scroll while in widget fullscreen / frameless.
   // CSS class keeps <lynx-view> mounted (no remount on enter/exit).

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -23,7 +23,7 @@ import { SplitPane, type SplitPaneHandle } from './split-pane';
 import { SwitchSchema } from './switch-schema';
 
 import type { PreviewTab } from '../../config';
-import { DEFAULT_I18N, DefaultNoSSR, useGoConfig } from '../../config';
+import { DefaultNoSSR, translateGoI18n, useGoConfig } from '../../config';
 import { useIsMobile } from '../hooks/use-is-mobile';
 import type { SchemaOptionsData } from '../hooks/use-switch-schema';
 import { useTreeController } from '../hooks/use-tree-controller';
@@ -201,8 +201,10 @@ export function ExampleContent({
     };
   }, [previewImage, currentEntry, defaultWebPreviewFile]);
   const [tmpCurrentFileName, setTmpCurrentFileName] = useState('');
-  const defaultI18n = (key: string) => DEFAULT_I18N[key] || key;
-  const t = useI18nHook ? useI18nHook() : defaultI18n;
+  // Host useI18n (e.g. Rspress) may throw on missing keys — always fall back
+  // to package DEFAULT_I18N so a stale site i18n.json cannot crash <Go>.
+  const hostT = useI18nHook ? useI18nHook() : undefined;
+  const t = (key: string) => translateGoI18n(hostT, key);
   const lang = useLangHook ? useLangHook() : 'en';
 
   // Lock body scroll while in widget fullscreen / frameless.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,17 @@
-export { GoConfigProvider, useGoConfig } from './config';
-export type { GoConfig, PreviewTab } from './config';
+export {
+  GoConfigProvider,
+  useGoConfig,
+  GO_I18N_EN,
+  GO_I18N_ZH,
+  translateGoI18n,
+} from './config';
+export type {
+  GoConfig,
+  GoI18nCatalog,
+  GoI18nKey,
+  GoI18nOverrides,
+  PreviewTab,
+} from './config';
 export { ExamplePreview, type ExamplePreviewProps } from './example-preview';
 export type { ExampleMetadata, ExamplePreviewMode } from './example-preview';
 export { getFileCodeLanguage } from './example-preview/utils/example-data';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation
Rspress `useI18n` **throws** on missing keys. Host sites that spread `rspressAdapter` (which used to wire `useI18n: () => useI18n()`) crashed the whole app when upgrading `@lynx-js/go-web` without adding new `go.*` keys (e.g. `go.refresh`) to site `i18n.json`.

`<Go>` itself never needed Rspress i18n — non-Rspress sites were fine because they never set `useI18n`. The adapter was the coupling.

### Description
Hard-decouple chrome copy from host i18n systems:

- Package owns `go.*` strings: built-in **en** / **zh** catalogs, selected by `useLang`.
- Optional overrides via `config.i18n` only (typed `GoI18nOverrides`).
- **`rspressAdapter` no longer includes `useI18n`** — still wires `withBase`, `useLang`, `useDark`, `NoSSR`, `CodeBlock`.
- **Removed `GoConfig.useI18n`** (breaking for custom hooks; migrate to `i18n` + `useLang`).
- Site `i18n.json` does **not** need `go.*` keys anymore.

### Migration
```tsx
// before
...rspressAdapter, // included useI18n → site i18n.json required go.* keys

// after
...rspressAdapter, // useLang picks package en/zh
i18n: { 'go.refresh': 'Reload preview' }, // optional overrides only
```

Hosts can delete `go.*` entries from `i18n.json` when convenient; leaving them is harmless (unused).

### Testing
- `pnpm typecheck`
- `pnpm exec prettier --check` on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-077e67e0-59bd-4900-8916-cdeaf8e3dc0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-077e67e0-59bd-4900-8916-cdeaf8e3dc0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

