### PR TITLE
feat: demonstrate gesture-driven examples with autoGesture

### DIFF
--- a/.changeset/auto-gesture.md
+++ b/.changeset/auto-gesture.md
@@ -1,0 +1,19 @@
+---
+'@lynx-js/go-web': minor
+---
+
+Add `autoGesture` to `<Go>`, and ship the driver behind it as `@lynx-js/go-web/auto-gesture`.
+
+A gesture-driven example cannot demonstrate itself in an embedded preview. The Lynx Product Detail tutorial is a carousel whose whole point is that the drag, the release and the snap all run on the main thread — but it binds `touchstart`/`touchmove`/`touchend`, so a desktop reader's mouse never reaches it and every preview on the page reads as a still image. `autoGesture` performs the gesture with synthesized touches and draws the contact point the way a device simulator does.
+
+The driver takes a host element and fractional coordinates and knows nothing about Lynx, React, or any framework, so it is exported on its own for sites that render `<lynx-view>` themselves. Coordinates are fractions of the host box, so a set of steps survives a resize; a step may carry `iterations` to repeat itself, so a sequence can walk a carousel to its end and back without knowing anything about carousels.
+
+Four details in it are worth knowing before reusing it.
+
+It dispatches a pointer event _and_ a touch event per contact, because real touch input produces both. The touch half is the one that does the work — web-core binds `touchstart`/`touchend`/`touchcancel` and no pointer events at all.
+
+Safari needs a different code path and does not advertise it. It declares `Touch` and throws `Illegal constructor` when you call it, accepts `new TouchEvent`, still ships the legacy `document.createTouch`, and rejects a plain array where the current spec says `sequence<Touch>` — so each strategy is probed by building one throwaway event rather than inferred from a `typeof`. Before this, the throw rejected the playback loop and took the whole demonstration down with it.
+
+Playback runs only while the preview is on screen. A tutorial page carries one preview per step, and the driver aims its contacts with `document.elementFromPoint` — viewport-relative, and empty below the fold — so an ungated preview starts a playback that silently hits nothing, and a reader scrolling down arrives to find it already finished and motionless.
+
+It hands control back on the first `isTrusted` event, a flag only the browser can set, so a reader touching the preview always wins over the demonstration. Stopping mid-drag lifts the contact first, so the example runs its release handler instead of being left believing a finger is still down.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,60 @@ const html = generateSSGHTML({
 
 The `./ssg` export uses Node.js `fs`/`path` and must not be bundled into browser code.
 
+### Demonstrating a gesture-driven example
+
+A carousel that binds `touchstart`/`touchmove`/`touchend` shows nothing in an
+embedded preview: a desktop reader's mouse never reaches it, so it looks like a
+still image. `autoGesture` performs the gesture and draws the contact point the
+way a device simulator does.
+
+```tsx
+<Go
+  example="swiper"
+  autoGesture={{
+    loop: true,
+    startDelayMs: 1400,
+    steps: [
+      {
+        path: [
+          { x: 0.98, y: 0.3 },
+          { x: -0.02, y: 0.3 },
+        ],
+        iterations: 7,
+        durationMs: 520,
+        restMs: 2600,
+      },
+    ],
+  }}
+/>
+```
+
+Coordinates are fractions of the preview's box, so a step survives a resize and
+does not need to know the design width. A step may carry `iterations` to repeat
+itself before the sequence advances, so a carousel can be walked to its end and
+back without the driver knowing anything about carousels.
+
+The events are synthesized, so `isTrusted` is `false` — which is also how the
+real thing is told apart: the first trusted pointer or touch stops the playback
+and hands the example back to the reader. Playback only runs while the preview
+is on screen. Tell readers the gesture is simulated; everything it triggers is
+real.
+
+Safari is handled. It refuses `new Touch()` while still shipping the legacy
+`document.createTouch`, so the driver probes how this browser will let it build
+a `TouchEvent` and caches the answer.
+
+For a site that renders `<lynx-view>` itself rather than through `<Go>`, the
+driver is also available on its own — it takes a host element and knows nothing
+about Lynx, React, or any framework:
+
+```ts
+import { playAutoGesture } from '@lynx-js/go-web/auto-gesture';
+
+const playback = playAutoGesture(hostElement, { steps });
+playback.stop();
+```
+
 ### Iframe Embed (no React required)
 
 For non-React sites (Hugo, Jekyll, plain HTML, etc.), use the iframe embed API. The host page only loads a tiny JS file — React runs inside the iframe.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     ".": "./src/index.ts",
     "./adapters/rspress": "./src/adapters/rspress.tsx",
     "./ssg": "./src/ssg.tsx",
-    "./embed": "./src/embed.ts"
+    "./embed": "./src/embed.ts",
+    "./auto-gesture": "./src/auto-gesture.ts"
   },
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/src/auto-gesture.ts
+++ b/src/auto-gesture.ts
@@ -1,0 +1,469 @@
+/**
+ * Drive a preview with simulated touches, and show them.
+ *
+ * A gesture-driven example cannot demonstrate itself in an embedded preview.
+ * The Product Detail tutorial is a carousel whose whole point is that the drag,
+ * the release and the snap all run on the main thread — but it binds
+ * `touchstart`, `touchmove` and `touchend`, so a desktop reader's mouse never
+ * reaches it and the example looks like a still image.
+ *
+ * So the preview performs the gesture itself and draws the contact point the
+ * way a device simulator does, which reads as a demonstration rather than as an
+ * animation the example happens to contain.
+ *
+ * Two properties keep it honest and portable:
+ *
+ *   - The events are synthesized, so `isTrusted` is false. That is also how a
+ *     real touch is told apart from these: the first trusted pointer or touch
+ *     stops the playback and hands the example back to the reader.
+ *   - Nothing here knows about Lynx, React, or any UI framework. It takes a
+ *     host element and fractional coordinates.
+ *
+ * Coordinates are fractions of the host's box rather than pixels, so a set of
+ * steps survives a resize and does not have to know the design width.
+ */
+
+/** A point as a fraction of the host box: `{x: 0, y: 0}` top-left, `{x: 1, y: 1}` bottom-right. */
+export type GesturePoint = {
+  x: number;
+  y: number;
+};
+
+export type GestureStep = {
+  /** Contact path. One point taps; two or more drag through each in turn. */
+  path: readonly GesturePoint[];
+  /**
+   * Perform this step this many times before advancing. Defaults to one.
+   *
+   * This is what lets a sequence walk a carousel to its end and back without
+   * the driver knowing anything about carousels: seven swipes left, then seven
+   * right, expressed as two steps.
+   */
+  iterations?: number;
+  /** How long the contact lasts. */
+  durationMs?: number;
+  /** How long to wait after lifting, before the next step. */
+  restMs?: number;
+};
+
+export type AutoGestureOptions = {
+  steps: readonly GestureStep[];
+  /** Repeat the sequence. */
+  loop?: boolean;
+  /** Wait before the first step, so the example is readable first. */
+  startDelayMs?: number;
+  /** Draw the contact point. */
+  showPointer?: boolean;
+  /**
+   * Stop as soon as the reader interacts. On by default: once someone is
+   * driving it themselves, a demonstration fighting them is worse than none.
+   */
+  stopOnUserInput?: boolean;
+};
+
+export type AutoGestureHandle = {
+  stop: () => void;
+};
+
+const DEFAULT_DURATION_MS = 550;
+const DEFAULT_REST_MS = 2000;
+const DEFAULT_START_DELAY_MS = 1200;
+/** One move per frame is what a real drag produces. */
+const FRAME_MS = 16;
+const POINTER_SIZE = 30;
+
+const USER_INPUT_EVENTS = ['pointerdown', 'touchstart', 'wheel'] as const;
+
+const POINTER_TYPE = {
+  touchstart: 'pointerdown',
+  touchmove: 'pointermove',
+  touchend: 'pointerup',
+} as const;
+
+/**
+ * Play `steps` against `host` until stopped.
+ *
+ * `host` is the element the gesture is measured against and dispatched into —
+ * for a Lynx preview, the `<lynx-view>`. Events are dispatched at the deepest
+ * element under each point, including through a shadow root, because that is
+ * where a component's own listener lives.
+ */
+export function playAutoGesture(
+  host: HTMLElement,
+  options: AutoGestureOptions,
+): AutoGestureHandle {
+  const {
+    steps,
+    loop = true,
+    startDelayMs = DEFAULT_START_DELAY_MS,
+    showPointer = true,
+    stopOnUserInput = true,
+  } = options;
+
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let identifier = 1;
+  let activeContact:
+    | {
+        target: Element;
+        identifier: number;
+        point: { clientX: number; clientY: number };
+      }
+    | undefined;
+  const pointer = showPointer ? createPointer(host) : undefined;
+
+  /**
+   * Lift the finger, if one is down.
+   *
+   * Stopping mid-drag — which is exactly what a reader touching the preview
+   * does — would otherwise leave the example believing a contact is still
+   * active, and it would never run its release handler.
+   */
+  const endActiveContact = (): void => {
+    if (!activeContact) return;
+    const { target, identifier, point } = activeContact;
+    activeContact = undefined;
+    dispatchContact(target, 'touchend', identifier, point);
+    hidePointer(pointer);
+  };
+
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    endActiveContact();
+    pointer?.remove();
+    for (const type of USER_INPUT_EVENTS) {
+      host.removeEventListener(type, onUserInput, true);
+    }
+  };
+
+  // `isTrusted` is the discriminator: only the browser can set it, so a real
+  // touch is unambiguous even though the synthetic ones look identical.
+  function onUserInput(event: Event): void {
+    if (event.isTrusted) stop();
+  }
+  if (stopOnUserInput) {
+    for (const type of USER_INPUT_EVENTS) {
+      host.addEventListener(type, onUserInput, true);
+    }
+  }
+
+  const wait = (ms: number) =>
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, ms);
+    });
+
+  async function run(): Promise<void> {
+    await wait(startDelayMs);
+    do {
+      for (const step of steps) {
+        const iterations = Math.max(1, Math.trunc(step.iterations ?? 1));
+        for (let iteration = 0; iteration < iterations; iteration++) {
+          if (stopped) return;
+          await playStep(step);
+          if (stopped) return;
+          await wait(step.restMs ?? DEFAULT_REST_MS);
+        }
+      }
+    } while (loop && !stopped);
+    pointer?.remove();
+  }
+
+  async function playStep(step: GestureStep): Promise<void> {
+    const box = host.getBoundingClientRect();
+    if (box.width <= 0 || box.height <= 0) return;
+    const points = step.path.map((point) => ({
+      clientX: box.left + point.x * box.width,
+      clientY: box.top + point.y * box.height,
+    }));
+    if (points.length === 0) return;
+
+    const id = identifier++;
+    const target = deepestElementAt(host, points[0].clientX, points[0].clientY);
+    if (!target) return;
+
+    showPointerAt(pointer, host, points[0]);
+    activeContact = { target, identifier: id, point: points[0] };
+    dispatchContact(target, 'touchstart', id, points[0]);
+
+    const duration = step.durationMs ?? DEFAULT_DURATION_MS;
+    const frames = Math.max(1, Math.round(duration / FRAME_MS));
+    for (let frame = 1; frame <= frames; frame++) {
+      if (stopped) return;
+      // Ease the travel so it reads as a hand rather than a linear tween.
+      const progress = easeInOutQuad(frame / frames);
+      const point = interpolate(points, progress);
+      showPointerAt(pointer, host, point);
+      activeContact.point = point;
+      dispatchContact(target, 'touchmove', id, point);
+      await wait(FRAME_MS);
+    }
+
+    if (stopped) return;
+    activeContact.point = points[points.length - 1];
+    endActiveContact();
+  }
+
+  // A demonstration must never take the page down with it. Anything thrown
+  // mid-drag would otherwise surface as an unhandled rejection and leave the
+  // contact down, the circle drawn, and the example believing a finger is
+  // still on it.
+  void run().catch(() => stop());
+  return { stop };
+}
+
+function easeInOutQuad(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+}
+
+/** Walk `points` as one polyline and return the position at `progress`. */
+function interpolate(
+  points: readonly { clientX: number; clientY: number }[],
+  progress: number,
+): { clientX: number; clientY: number } {
+  if (points.length === 1) return points[0];
+  const span = 1 / (points.length - 1);
+  const index = Math.min(points.length - 2, Math.floor(progress / span));
+  const local = (progress - index * span) / span;
+  const from = points[index];
+  const to = points[index + 1];
+  return {
+    clientX: from.clientX + (to.clientX - from.clientX) * local,
+    clientY: from.clientY + (to.clientY - from.clientY) * local,
+  };
+}
+
+/**
+ * The element that would receive a real touch here.
+ *
+ * A Lynx page lives in a shadow root and a component's touch listener is on an
+ * element inside it, so the host itself is the wrong target — descend through
+ * every shadow root under the point.
+ */
+function deepestElementAt(
+  host: HTMLElement,
+  clientX: number,
+  clientY: number,
+): Element | null {
+  let found: Element | null =
+    host.shadowRoot?.elementFromPoint(clientX, clientY) ??
+    host.ownerDocument.elementFromPoint(clientX, clientY);
+  while (found?.shadowRoot) {
+    const next = found.shadowRoot.elementFromPoint(clientX, clientY);
+    if (!next || next === found) break;
+    found = next;
+  }
+  return found;
+}
+
+type TouchPoint = { clientX: number; clientY: number };
+type TouchType = 'touchstart' | 'touchmove' | 'touchend';
+type TouchEventFactory = (
+  target: Element,
+  type: TouchType,
+  identifier: number,
+  point: TouchPoint,
+) => TouchEvent;
+
+/** Safari's legacy touch factories, absent everywhere else. */
+type LegacyTouchDocument = Document & {
+  createTouch: (
+    view: Window,
+    target: EventTarget,
+    identifier: number,
+    pageX: number,
+    pageY: number,
+    screenX: number,
+    screenY: number,
+  ) => Touch;
+  createTouchList: (...touches: Touch[]) => TouchList;
+};
+
+const TOUCH_EVENT_INIT = {
+  bubbles: true,
+  cancelable: true,
+  composed: true,
+} as const;
+
+/** `new Touch()` plus plain arrays — every engine but Safari. */
+const standardTouchEvent: TouchEventFactory = (
+  target,
+  type,
+  identifier,
+  point,
+) => {
+  const touch = new Touch({
+    identifier,
+    target,
+    clientX: point.clientX,
+    clientY: point.clientY,
+    pageX: point.clientX + window.scrollX,
+    pageY: point.clientY + window.scrollY,
+    screenX: point.clientX,
+    screenY: point.clientY,
+  });
+  return new TouchEvent(type, {
+    ...TOUCH_EVENT_INIT,
+    touches: type === 'touchend' ? [] : [touch],
+    targetTouches: type === 'touchend' ? [] : [touch],
+    changedTouches: [touch],
+  });
+};
+
+/**
+ * Safari's path: `document.createTouch` for the contact, and `TouchList`s
+ * rather than arrays for the event.
+ *
+ * Both halves are load-bearing. Safari's `TouchEvent` constructor rejects a
+ * plain array with a bare "Type error", and `createTouch` takes *page*
+ * coordinates — it derives `clientX`/`clientY` by subtracting the scroll, so
+ * the scroll has to be added back, and a preview is usually well down the page
+ * by the time anyone sees it.
+ */
+const legacyTouchEvent: TouchEventFactory = (
+  target,
+  type,
+  identifier,
+  point,
+) => {
+  const legacy = document as LegacyTouchDocument;
+  const touch = legacy.createTouch(
+    window,
+    target,
+    identifier,
+    point.clientX + window.scrollX,
+    point.clientY + window.scrollY,
+    point.clientX,
+    point.clientY,
+  );
+  const touches =
+    type === 'touchend'
+      ? legacy.createTouchList()
+      : legacy.createTouchList(touch);
+  // The DOM lib types these as `Touch[]`, following the current spec. Safari
+  // implements the older IDL and rejects an array outright, so the `TouchList`s
+  // have to go through a cast rather than a wider parameter type.
+  return new TouchEvent(type, {
+    ...TOUCH_EVENT_INIT,
+    touches,
+    targetTouches: touches,
+    changedTouches: legacy.createTouchList(touch),
+  } as unknown as TouchEventInit);
+};
+
+let touchEventFactory: TouchEventFactory | null | undefined;
+
+/**
+ * How this browser lets a script build a `TouchEvent`, or `null` if it will not.
+ *
+ * `typeof` is not the question. Safari declares `Touch` and throws
+ * `Illegal constructor` when you call it, so an existence check passes and the
+ * constructor throws — which used to reject the playback loop and take the
+ * whole demonstration down with it. What it accepts instead is not derivable
+ * from what it declares, so each strategy is probed by building one throwaway
+ * event. Probe once and cache: on Safari the first branch throws every time,
+ * and this runs per frame.
+ */
+function resolveTouchEventFactory(): TouchEventFactory | null {
+  if (touchEventFactory !== undefined) return touchEventFactory;
+  for (const factory of [standardTouchEvent, legacyTouchEvent]) {
+    try {
+      void factory(document.body, 'touchstart', 0, { clientX: 0, clientY: 0 });
+      touchEventFactory = factory;
+      return factory;
+    } catch {
+      // Try the next strategy.
+    }
+  }
+  touchEventFactory = null;
+  return null;
+}
+
+/**
+ * One contact, as the browser reports it.
+ *
+ * `@lynx-js/web-core` binds `touchstart` / `touchend` / `touchcancel` and no
+ * pointer events at all, so the touch half below is the one that actually
+ * drives the example — where it cannot be synthesized, the gesture does
+ * nothing. The pointer event is sent because real touch input produces both,
+ * in the order Chrome sends them, and an example may listen for either.
+ */
+function dispatchContact(
+  target: Element,
+  type: 'touchstart' | 'touchmove' | 'touchend',
+  identifier: number,
+  point: { clientX: number; clientY: number },
+): void {
+  target.dispatchEvent(
+    new PointerEvent(POINTER_TYPE[type], {
+      bubbles: true,
+      cancelable: type !== 'touchend',
+      composed: true,
+      pointerId: identifier,
+      pointerType: 'touch',
+      isPrimary: true,
+      clientX: point.clientX,
+      clientY: point.clientY,
+      screenX: point.clientX,
+      screenY: point.clientY,
+      button: type === 'touchmove' ? -1 : 0,
+      buttons: type === 'touchend' ? 0 : 1,
+      width: 24,
+      height: 24,
+      pressure: type === 'touchend' ? 0 : 0.5,
+    }),
+  );
+
+  const factory = resolveTouchEventFactory();
+  if (!factory) return;
+  target.dispatchEvent(factory(target, type, identifier, point));
+}
+
+/** The simulator-style contact circle. */
+function createPointer(host: HTMLElement): HTMLElement {
+  const dot = document.createElement('div');
+  dot.setAttribute('aria-hidden', 'true');
+  dot.style.cssText = [
+    'position:fixed',
+    'z-index:2',
+    `width:${POINTER_SIZE}px`,
+    `height:${POINTER_SIZE}px`,
+    'margin:0',
+    'border-radius:50%',
+    'background:rgba(255,255,255,0.28)',
+    'border:1.5px solid rgba(255,255,255,0.65)',
+    'box-shadow:0 0 12px rgba(255,255,255,0.25)',
+    'pointer-events:none',
+    'opacity:0',
+    'transition:opacity 0.18s ease',
+  ].join(';');
+  (host.parentElement ?? host).append(dot);
+  return dot;
+}
+
+function showPointerAt(
+  pointer: HTMLElement | undefined,
+  host: HTMLElement,
+  point: { clientX: number; clientY: number },
+): void {
+  if (!pointer) return;
+  // `position: fixed` with viewport coordinates, so the circle lands on the
+  // contact point whatever the preview is nested in or scrolled by.
+  pointer.style.left = `${point.clientX - POINTER_SIZE / 2}px`;
+  pointer.style.top = `${point.clientY - POINTER_SIZE / 2}px`;
+  pointer.style.opacity = '1';
+  // Hide it if the contact drifts outside the preview (a step whose path
+  // leaves the box) rather than drawing a circle over the page.
+  const box = host.getBoundingClientRect();
+  const inside =
+    point.clientX >= box.left &&
+    point.clientX <= box.right &&
+    point.clientY >= box.top &&
+    point.clientY <= box.bottom;
+  if (!inside) pointer.style.opacity = '0';
+}
+
+function hidePointer(pointer: HTMLElement | undefined): void {
+  if (pointer) pointer.style.opacity = '0';
+}

--- a/src/example-preview/components/index.tsx
+++ b/src/example-preview/components/index.tsx
@@ -62,6 +62,7 @@ enum PreviewType {
 }
 
 import type { ExamplePreviewMode } from '../index';
+import type { AutoGestureOptions } from '../../auto-gesture';
 
 interface ExampleContentProps {
   fileNames: string[];
@@ -87,6 +88,7 @@ interface ExampleContentProps {
   defaultTab?: PreviewTab;
   webLoadingScreen?: WebLoadingScreen;
   mode?: ExamplePreviewMode;
+  autoGesture?: AutoGestureOptions;
   webPreviewMode?: WebPreviewMode;
   designWidth?: number;
   designHeight?: number;
@@ -124,6 +126,7 @@ export function ExampleContent({
   defaultTab,
   webLoadingScreen,
   mode = 'linked',
+  autoGesture,
   webPreviewMode = 'responsive',
   designWidth = 375,
   designHeight = 812,
@@ -778,6 +781,7 @@ export function ExampleContent({
                   <WebIframe
                     show={webPanelActive}
                     src={defaultWebPreviewFile || ''}
+                    autoGesture={autoGesture}
                     webPreviewMode={webPreviewMode}
                     designWidth={designWidth}
                     designHeight={designHeight}

--- a/src/example-preview/components/ultra-lynx-view.tsx
+++ b/src/example-preview/components/ultra-lynx-view.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useEffect } from 'react';
+import type { AutoGestureOptions } from '../../auto-gesture';
 import type { WebPreviewMode } from '../utils/resolve-web-preview';
 import { DefaultNoSSR, useGoConfig } from '../../config';
 import s from './index.module.scss';
@@ -10,6 +11,8 @@ const WebIframe = React.lazy(() =>
 export type UltraLynxViewProps = {
   /** Absolute URL to the `.web.bundle` */
   src: string;
+  /** Simulated touches to replay once the example has painted. */
+  autoGesture?: AutoGestureOptions;
   webPreviewMode?: WebPreviewMode;
   designWidth?: number;
   designHeight?: number;
@@ -27,6 +30,7 @@ export type UltraLynxViewProps = {
  */
 export function UltraLynxView({
   src,
+  autoGesture,
   webPreviewMode = 'responsive',
   designWidth,
   designHeight,
@@ -58,6 +62,7 @@ export function UltraLynxView({
         <Suspense fallback={null}>
           <WebIframe
             show
+            autoGesture={autoGesture}
             src={src}
             webPreviewMode={webPreviewMode}
             designWidth={designWidth}

--- a/src/example-preview/components/web-iframe.tsx
+++ b/src/example-preview/components/web-iframe.tsx
@@ -15,6 +15,11 @@ import type {
   WebPreviewMode,
   ResolvedWebPreviewMode,
 } from '../utils/resolve-web-preview';
+import {
+  playAutoGesture,
+  type AutoGestureHandle,
+  type AutoGestureOptions,
+} from '../../auto-gesture';
 import { LoadingOverlay } from './loading-overlay';
 import type { WebPreviewLoadStage } from './loading-overlay';
 
@@ -43,6 +48,12 @@ type AutoFitBiases = {
 type WebIframeProps = {
   show: boolean;
   src: string;
+  /**
+   * Demonstrate the example with simulated touches once it has painted. A
+   * gesture-driven example shows nothing here otherwise: it binds touch events,
+   * so a desktop reader's mouse never reaches it.
+   */
+  autoGesture?: AutoGestureOptions;
   webPreviewMode?: WebPreviewMode;
   designWidth?: number;
   designHeight?: number;
@@ -652,6 +663,7 @@ function computeAutoFitBiases(args: {
 export const WebIframe = ({
   show,
   src,
+  autoGesture,
   webPreviewMode = 'responsive',
   designWidth = 375,
   designHeight = 812,
@@ -794,6 +806,44 @@ export const WebIframe = ({
   useEffect(() => {
     onLoadStateChangeRef.current?.({ ready, rendered, stage, error });
   }, [ready, rendered, stage, error]);
+
+  // A gesture-driven example is inert for a desktop reader: it binds touch
+  // events, and a mouse never produces them. Once the page has painted we can
+  // drive it ourselves, from the same synthetic-touch helper the standalone
+  // <lynx-view> mount uses. `rendered` drops on reload, so a refresh replays.
+  //
+  // Playback waits for the preview to be on screen. A tutorial page carries one
+  // preview per step, and the driver aims its contacts with
+  // `document.elementFromPoint` — viewport-relative, and empty for anything
+  // below the fold. Without this every preview on the page would start a
+  // playback that silently hits nothing, and a reader scrolling down would
+  // arrive to find it already finished and motionless.
+  const autoGestureRef = useRef(autoGesture);
+  autoGestureRef.current = autoGesture;
+  useEffect(() => {
+    const options = autoGestureRef.current;
+    if (!options || !rendered || !show || !lynxView) return;
+    let playback: AutoGestureHandle | null = null;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            playback ??= playAutoGesture(lynxView, options);
+          } else {
+            playback?.stop();
+            playback = null;
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(lynxView);
+    return () => {
+      observer.disconnect();
+      playback?.stop();
+      playback = null;
+    };
+  }, [rendered, show, lynxView, reloadKey]);
 
   // `webPreviewMode='responsive'` resolves to `usesFitPath === false`,
   // which skips all fit-only interpolation and auto-fit bias logic.

--- a/src/example-preview/index.tsx
+++ b/src/example-preview/index.tsx
@@ -8,6 +8,7 @@ import { ExampleContent } from './components';
 import { UltraLynxView } from './components/ultra-lynx-view';
 import type { SchemaOptionsData } from './hooks/use-switch-schema';
 import { isAssetFileType } from './utils/example-data';
+import type { AutoGestureOptions } from '../auto-gesture';
 import type { WebPreviewMode } from './utils/resolve-web-preview';
 
 const DefaultErrorWrap = ({
@@ -55,6 +56,13 @@ export interface ExamplePreviewProps {
   schemaOptions?: SchemaOptionsData;
   langAlias?: Record<string, string>;
   mode?: ExamplePreviewMode;
+  /**
+   * Demonstrate a gesture-driven example with simulated touches once the web
+   * preview has painted. A carousel that binds `touchstart`/`touchmove`/
+   * `touchend` shows nothing here otherwise, because a desktop reader's mouse
+   * never reaches it. See `@lynx-js/go-web/auto-gesture`.
+   */
+  autoGesture?: AutoGestureOptions;
   webPreviewMode?: WebPreviewMode;
   webPreview?: boolean;
   designWidth?: number;
@@ -153,6 +161,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     defaultTab: propsDefaultTab,
     webLoadingScreen: propsWebLoadingScreen,
     mode = 'linked',
+    autoGesture,
     webPreviewMode = 'responsive',
     webPreview = true,
     designWidth = 375,
@@ -315,6 +324,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
     return (
       <UltraLynxView
         src={defaultWebPreviewFile}
+        autoGesture={autoGesture}
         webPreviewMode={webPreviewMode}
         designWidth={designWidth}
         designHeight={designHeight}
@@ -355,6 +365,7 @@ export const ExamplePreview = (props: ExamplePreviewProps) => {
       defaultTab={resolvedDefaultTab}
       webLoadingScreen={webLoadingScreen}
       mode={mode}
+      autoGesture={autoGesture}
       webPreviewMode={webPreviewMode}
       designWidth={designWidth}
       designHeight={designHeight}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,3 +27,11 @@ export {
   UltraLynxView,
   type UltraLynxViewProps,
 } from './example-preview/components/ultra-lynx-view';
+
+export { playAutoGesture } from './auto-gesture';
+export type {
+  AutoGestureHandle,
+  AutoGestureOptions,
+  GesturePoint,
+  GestureStep,
+} from './auto-gesture';


### PR DESCRIPTION
## Summary

Adds `autoGesture` to `<Go>`, and ships the driver behind it as `@lynx-js/go-web/auto-gesture`.

A gesture-driven example cannot demonstrate itself in an embedded preview. The Lynx [Product Detail](https://lynxjs.org/learn/product-detail) tutorial is a carousel whose whole point is that the drag, the release and the snap all run on the main thread — but it binds `touchstart`/`touchmove`/`touchend`, so a desktop reader's mouse never reaches it. Every preview on that page, the finished carousel included, reads as a still image unless you scan the QR code.

```tsx
<Go example="swiper" autoGesture={{ loop: true, steps }} />
```

The driver takes a host element and fractional coordinates and knows nothing about Lynx, React or any framework, so it is also exported on its own for sites that render `<lynx-view>` themselves.

## Four things it gets right

Each was found by embedding real tutorial examples, not by reading specs.

**Both event families per contact.** Real touch input produces a pointer event *and* a touch event. The touch half is the one that does the work — web-core binds `touchstart`/`touchend`/`touchcancel` and no pointer events at all.

**Safari needs a different code path and does not advertise it.** Measured in headless WebKit:

| | Chromium | WebKit |
| --- | --- | --- |
| `new Touch()` | ok | **throws `Illegal constructor`** |
| `new TouchEvent()` | ok | ok |
| `document.createTouch()` | absent | ok |
| `TouchEvent` with a `Touch[]` | ok | **throws `Type error`** |
| `TouchEvent` with a `TouchList` | absent | ok |

Nothing there is derivable from a `typeof` check, so each strategy is probed by building one throwaway event and the winner is cached for the page. A `typeof` guard passes on Safari and then the constructor throws, which rejects the playback loop and takes the whole demonstration with it.

**Playback runs only while the preview is on screen.** Contacts are aimed with `document.elementFromPoint`, which is viewport-relative and returns nothing below the fold. On the Product Detail page — eleven previews — an ungated build produced ten contact circles and **zero** touch events.

**The reader always wins.** The first `isTrusted` event stops playback, and stopping mid-drag lifts the contact so the example runs its release handler instead of being left believing a finger is still down.

## Scope

This replaces #79, which also carried a framework-neutral `mountLynxView`. That had no consumers: the Octane site vendored its own port rather than depending on go-web, and both tutorial sites go through `<Go>`. Rather than ship speculative API, this PR is only the part with real consumers. #79's other claims about `WebIframe` defects were not reproduced in `<Go>` and are not repeated here.

## Validation

- [x] `tsc --noEmit`
- [x] `prettier --check .`
- [x] End-to-end in headless **Chromium** and **WebKit** against both tutorials: `lynx-website` Product Detail travels **1866px**, `vue-lynx` swiper travels **1390px**, from ~9 `touchstart`s and ~300 `touchmove`s. Identical in both engines, console clean.
- [x] The Safari path is covered by a regression test in the Octane port of this module (octanejs/octane#620, merged), which fails against the `typeof` guard.

## Follow-ups

lynx-family/lynx-website#1282 and Huxpro/vue-lynx#361 currently vendor this file; both switch to the published package once this releases.
