### PR TITLE
fix(auto-gesture): return instead of hanging on an empty step list

### DIFF
--- a/.changeset/empty-steps.md
+++ b/.changeset/empty-steps.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/go-web': patch
+---
+
+Return instead of hanging when `autoGesture` is given no steps.
+
+`steps: []` type-checks, and with `loop: true` the playback loop never reached an `await` — so it spun synchronously and neither a timer nor an event could set the stop flag. An empty sequence now ends the way it reads: by doing nothing.

--- a/src/auto-gesture.ts
+++ b/src/auto-gesture.ts
@@ -155,6 +155,10 @@ export function playAutoGesture(
     });
 
   async function run(): Promise<void> {
+    // Nothing to play. Without this the `do`/`while` below never reaches an
+    // `await`, so it spins synchronously and no timer or event can ever set
+    // `stopped` — the tab hangs rather than doing nothing.
+    if (steps.length === 0) return;
     await wait(startDelayMs);
     do {
       for (const step of steps) {


### PR DESCRIPTION
## Summary

`steps: []` satisfies `AutoGestureOptions`, and with `loop: true` it hangs the tab.

The `for` body never runs, so the `do`/`while` never reaches an `await`. It spins synchronously, which means neither a timer nor an event can set `stopped` — the loop cannot be broken from outside, and `stop()` has nothing to interrupt. An empty sequence now ends the way it reads: by doing nothing.

```ts
if (steps.length === 0) return;
```

## Credit

Caught by CodeRabbit reviewing the vendored copy in lynx-family/lynx-website#1282, before that site switched to the published package. Shipping it here so 0.9.0's consumers get it.

## Validation

- [x] `tsc --noEmit`
- [x] `prettier --check`